### PR TITLE
Add beam contact boundary condition

### DIFF
--- a/meshpy/boundary_condition.py
+++ b/meshpy/boundary_condition.py
@@ -86,6 +86,7 @@ class BoundaryConditionBase(BaseMeshItem):
             or bc_key is mpy.bc.beam_to_solid_surface_meshtying
             or bc_key is mpy.bc.beam_to_solid_surface_contact
             or bc_key is mpy.bc.beam_to_solid_volume_meshtying
+            or bc_key is mpy.bc.beam_to_beam_contact
         ):
             # Normal boundary condition (including beam-to-solid conditions).
             return BoundaryCondition(

--- a/meshpy/conf.py
+++ b/meshpy/conf.py
@@ -55,6 +55,7 @@ class BoundaryCondition(Enum):
     beam_to_solid_volume_meshtying = auto()
     beam_to_solid_surface_meshtying = auto()
     beam_to_solid_surface_contact = auto()
+    beam_to_beam_contact = auto()
     point_coupling = auto()
     point_coupling_penalty = auto()
 

--- a/meshpy/inputfile.py
+++ b/meshpy/inputfile.py
@@ -288,6 +288,10 @@ class InputFile(Mesh):
             mpy.bc.beam_to_solid_surface_contact,
             mpy.geo.surface,
         ): "BEAM INTERACTION/BEAM TO SOLID SURFACE CONTACT SURFACE",
+        (
+            mpy.bc.beam_to_beam_contact,
+            mpy.geo.line,
+        ): "BEAM INTERACTION/BEAM TO BEAM CONTACT CONDITIONS",
         (mpy.bc.point_coupling, mpy.geo.point): "DESIGN POINT COUPLING CONDITIONS",
         (
             mpy.bc.point_coupling_penalty,


### PR DESCRIPTION
Adding boundary condition description and routine for beam to beam contact. This makes the creation of respective scenarios a little bit more convenient (hopefully).