### PR TITLE
Generalize nurbs

### DIFF
--- a/meshpy/__init__.py
+++ b/meshpy/__init__.py
@@ -50,6 +50,7 @@ from .material import (
     MaterialKirchhoff,
     MaterialReissner,
     MaterialReissnerElastoplastic,
+    MaterialString,
     MaterialStVenantKirchhoff,
 )
 from .element_beam import Beam3eb, Beam3k, Beam3rHerm2Line3, Beam3rLine2Line2
@@ -90,6 +91,7 @@ __all__ = [
     "BoundaryCondition",
     "Coupling",
     "MaterialEulerBernoulli",
+    "MaterialString",
     "MaterialStVenantKirchhoff",
     "Node",
     "NodeCosserat"

--- a/meshpy/material.py
+++ b/meshpy/material.py
@@ -264,6 +264,19 @@ class MaterialEulerBernoulli(MaterialBeam):
         )
 
 
+class MaterialString(Material):
+    """Holds material definition that is defined by a string."""
+
+    def __init__(self, material_string, **kwargs):
+        super().__init__(**kwargs)
+        self.material_string = material_string
+
+    def _get_dat(self):
+        """Return the line for this material."""
+        string = "MAT {} {}"
+        return string.format(self.n_global, self.material_string)
+
+
 class MaterialSolid(Material):
     """Base class for a material for solids"""
 

--- a/meshpy/mesh_creation_functions/nurbs_generic.py
+++ b/meshpy/mesh_creation_functions/nurbs_generic.py
@@ -48,6 +48,7 @@ def add_geomdl_nurbs_to_mesh(
     geomdl_obj,
     *,
     material=None,
+    element_string=None,
     element_description=None,
 ):
     """
@@ -119,6 +120,7 @@ def add_geomdl_nurbs_to_mesh(
         geomdl_obj.degree,
         nodes=control_points,
         material=material,
+        element_string=element_string,
         element_description=element_description,
     )
 

--- a/meshpy/nurbs_patch.py
+++ b/meshpy/nurbs_patch.py
@@ -39,9 +39,7 @@ import numpy as np
 from .conf import mpy
 from .element import Element
 
-from .material import (
-    MaterialStVenantKirchhoff,
-)
+from .material import MaterialString, MaterialStVenantKirchhoff
 
 
 class NURBSPatch(Element):
@@ -50,7 +48,7 @@ class NURBSPatch(Element):
     """
 
     # A list of valid material types for this element
-    valid_material = [MaterialStVenantKirchhoff]
+    valid_material = [MaterialString, MaterialStVenantKirchhoff]
 
     def __init__(
         self,

--- a/meshpy/nurbs_patch.py
+++ b/meshpy/nurbs_patch.py
@@ -54,6 +54,7 @@ class NURBSPatch(Element):
         self,
         knot_vectors,
         polynomial_orders,
+        element_string,
         material=None,
         nodes=None,
         element_description=None,
@@ -69,7 +70,8 @@ class NURBSPatch(Element):
         # Set numbers for elements
         self.n_nurbs_patch = None
 
-        # Set the element description
+        # Set the element definitions
+        self.element_string = element_string
         self.element_description = element_description
 
     def add_element_specific_section(self, sections):
@@ -156,6 +158,11 @@ class NURBSSurface(NURBSPatch):
     A patch of a NURBS surface
     """
 
+    def __init__(self, *args, element_string=None, **kwargs):
+        if element_string is None:
+            element_string = "WALLNURBS"
+        super().__init__(*args, element_string, **kwargs)
+
     def _get_dat(self):
         """Return the lines with elements for the input file"""
 
@@ -204,8 +211,9 @@ class NURBSSurface(NURBSPatch):
                     string_cps += "{} ".format(cp.n_global)
 
                 patch_elements.append(
-                    "{} WALLNURBS NURBS{} {} MAT {} {}".format(
+                    "{} {} NURBS{} {} MAT {} {}".format(
                         self.n_global + j,
+                        self.element_string,
                         (self.polynomial_orders[0] + 1)
                         * (self.polynomial_orders[1] + 1),
                         string_cps,
@@ -222,6 +230,11 @@ class NURBSVolume(NURBSPatch):
     """
     A patch of a NURBS volume
     """
+
+    def __init__(self, *args, element_string=None, **kwargs):
+        if element_string is not None:
+            raise ValueError("element_string is not yet implemented for NURBS volumes")
+        super().__init__(*args, element_string, **kwargs)
 
     def _get_dat(self):
         """Return the lines with elements for the input file"""

--- a/tests/reference-files/test_nurbs_string_types_reference.dat
+++ b/tests/reference-files/test_nurbs_string_types_reference.dat
@@ -9,6 +9,7 @@
 -----------------------------------------------------------------------MATERIALS
 MAT 1 STRING_MATERIAL
 -----------------------------------------------------------STRUCTURE KNOTVECTORS
+NURBS_DIMENSION                       2
 BEGIN                                 NURBSPATCH
 ID                                    1
 NUMKNOTS                              8

--- a/tests/reference-files/test_nurbs_string_types_reference.dat
+++ b/tests/reference-files/test_nurbs_string_types_reference.dat
@@ -1,0 +1,110 @@
+// -----------------------------------------------------------------------------
+// This input file was created with MeshPy.
+// Copyright (c) 2018-2024
+//     Ivo Steinbrecher
+//     Institute for Mathematics and Computer-Based Simulation
+//     Universitaet der Bundeswehr Muenchen
+//     https://www.unibw.de/imcs-en
+// -----------------------------------------------------------------------------
+-----------------------------------------------------------------------MATERIALS
+MAT 1 STRING_MATERIAL
+-----------------------------------------------------------STRUCTURE KNOTVECTORS
+BEGIN                                 NURBSPATCH
+ID                                    1
+NUMKNOTS                              8
+DEGREE                                2
+TYPE                                  Interpolated
+0.0
+0.0
+0.0
+0.3333333333333333
+0.6666666666666666
+1.0
+1.0
+1.0
+NUMKNOTS                              7
+DEGREE                                2
+TYPE                                  Interpolated
+0.0
+0.0
+0.0
+0.5
+1.0
+1.0
+1.0
+END                                   NURBSPATCH
+-------------------------------------------------------------DNODE-NODE TOPOLOGY
+NODE 1 DNODE 1
+NODE 5 DNODE 2
+NODE 16 DNODE 3
+NODE 20 DNODE 4
+-------------------------------------------------------------DLINE-NODE TOPOLOGY
+NODE 1 DLINE 1
+NODE 2 DLINE 1
+NODE 3 DLINE 1
+NODE 4 DLINE 1
+NODE 5 DLINE 1
+NODE 5 DLINE 2
+NODE 10 DLINE 2
+NODE 15 DLINE 2
+NODE 20 DLINE 2
+NODE 16 DLINE 3
+NODE 17 DLINE 3
+NODE 18 DLINE 3
+NODE 19 DLINE 3
+NODE 20 DLINE 3
+NODE 1 DLINE 4
+NODE 6 DLINE 4
+NODE 11 DLINE 4
+NODE 16 DLINE 4
+-------------------------------------------------------------DSURF-NODE TOPOLOGY
+NODE 1 DSURFACE 1
+NODE 2 DSURFACE 1
+NODE 3 DSURFACE 1
+NODE 4 DSURFACE 1
+NODE 5 DSURFACE 1
+NODE 6 DSURFACE 1
+NODE 7 DSURFACE 1
+NODE 8 DSURFACE 1
+NODE 9 DSURFACE 1
+NODE 10 DSURFACE 1
+NODE 11 DSURFACE 1
+NODE 12 DSURFACE 1
+NODE 13 DSURFACE 1
+NODE 14 DSURFACE 1
+NODE 15 DSURFACE 1
+NODE 16 DSURFACE 1
+NODE 17 DSURFACE 1
+NODE 18 DSURFACE 1
+NODE 19 DSURFACE 1
+NODE 20 DSURFACE 1
+---------------------------------------------------------------------NODE COORDS
+CP 1 COORD -0.5 -1.5 0 1.0
+CP 2 COORD -0.333333333333 -1.5 0 1.0
+CP 3 COORD 0 -1.5 0 1.0
+CP 4 COORD 0.333333333333 -1.5 0 1.0
+CP 5 COORD 0.5 -1.5 0 1.0
+CP 6 COORD -0.5 -0.75 0 1.0
+CP 7 COORD -0.333333333333 -0.75 0 1.0
+CP 8 COORD 0 -0.75 0 1.0
+CP 9 COORD 0.333333333333 -0.75 0 1.0
+CP 10 COORD 0.5 -0.75 0 1.0
+CP 11 COORD -0.5 0.75 0 1.0
+CP 12 COORD -0.333333333333 0.75 0 1.0
+CP 13 COORD 0 0.75 0 1.0
+CP 14 COORD 0.333333333333 0.75 0 1.0
+CP 15 COORD 0.5 0.75 0 1.0
+CP 16 COORD -0.5 1.5 0 1.0
+CP 17 COORD -0.333333333333 1.5 0 1.0
+CP 18 COORD 0 1.5 0 1.0
+CP 19 COORD 0.333333333333 1.5 0 1.0
+CP 20 COORD 0.5 1.5 0 1.0
+--------------------------------------------------------------STRUCTURE ELEMENTS
+1 STRING_TYPE NURBS9 1 2 3 6 7 8 11 12 13  MAT 1 STRING_DESCRIPTION
+2 STRING_TYPE NURBS9 2 3 4 7 8 9 12 13 14  MAT 1 STRING_DESCRIPTION
+3 STRING_TYPE NURBS9 3 4 5 8 9 10 13 14 15  MAT 1 STRING_DESCRIPTION
+4 STRING_TYPE NURBS9 6 7 8 11 12 13 16 17 18  MAT 1 STRING_DESCRIPTION
+5 STRING_TYPE NURBS9 7 8 9 12 13 14 17 18 19  MAT 1 STRING_DESCRIPTION
+6 STRING_TYPE NURBS9 8 9 10 13 14 15 18 19 20  MAT 1 STRING_DESCRIPTION
+------------------------------------------------------------------FLUID ELEMENTS
+-----------------------------------------------------------------------------END

--- a/tests/testing_nurbs.py
+++ b/tests/testing_nurbs.py
@@ -41,6 +41,7 @@ import os
 from meshpy import (
     InputFile,
     MaterialStVenantKirchhoff,
+    MaterialString,
     Rotation,
 )
 
@@ -280,6 +281,33 @@ class TestNurbsMeshCreationFunction(unittest.TestCase):
             surf_obj,
             material=mat,
             element_description=element_description,
+        )
+
+        input_file.add(patch_set)
+
+        # Compare with the reference file
+        compare_test_result(self, input_file.get_string(header=False))
+
+    def test_nurbs_string_types(self):
+        """Test the creating of a NURBS with strings for the element and material definition."""
+
+        # Create input file
+        input_file = InputFile()
+
+        # Create the base of a sphere
+        surf_obj = create_nurbs_flat_plate_2d(1, 3, n_ele_u=3, n_ele_v=2)
+
+        # Create first patch set
+        mat = MaterialString("STRING_MATERIAL")
+
+        element_description = ()
+
+        patch_set = add_geomdl_nurbs_to_mesh(
+            input_file,
+            surf_obj,
+            material=mat,
+            element_string="STRING_TYPE",
+            element_description="STRING_DESCRIPTION",
         )
 
         input_file.add(patch_set)


### PR DESCRIPTION
This merge allows to set the "element string" for a NURBS patch directly in the script, i.e., we don't have to implement all relevant cases.
Similarly, now there is a class `MaterialString` which allows to directly set a material from the calling script so we don't have to implement each material case in MeshPy.