### PR TITLE
Create clean up function for simulation manager

### DIFF
--- a/meshpy/simulation_manager/simulation_manager.py
+++ b/meshpy/simulation_manager/simulation_manager.py
@@ -40,6 +40,7 @@ import time
 import builtins
 from meshpy.utility import clean_simulation_directory
 
+
 def is_true_batch(value):
     """Return a batch comment if value is False."""
     if value:
@@ -306,8 +307,7 @@ class SimulationManager:
         """
         Deletes all files in the path of the simulation manager.
         """
-        clean_simulation_directory(self.path,True)
-
+        clean_simulation_directory(self.path, True)
 
     def add(self, other):
         """

--- a/meshpy/simulation_manager/simulation_manager.py
+++ b/meshpy/simulation_manager/simulation_manager.py
@@ -35,11 +35,10 @@ A class that creates scripts to run multiple simulations.
 
 # Import python modules.
 import os
-import shutil
 import subprocess
 import time
 import builtins
-
+from meshpy.utility import clean_simulation_directory
 
 def is_true_batch(value):
     """Return a batch comment if value is False."""
@@ -303,20 +302,12 @@ class SimulationManager:
         self.path = path
         self.simulations = []
 
-    def clean_up(self):
+    def ensure_clean_simulation_directory(self):
         """
         Deletes all files in the path of the simulation manager.
         """
-        if os.path.isdir(self.path):
-            for filename in os.listdir(self.path):
-                file_path = os.path.join(self.path, filename)
-                try:
-                    if os.path.isfile(file_path) or os.path.islink(file_path):
-                        os.unlink(file_path)
-                    elif os.path.isdir(file_path):
-                        shutil.rmtree(file_path)
-                except Exception as e:
-                    print("Failed to delete %s. Reason: %s" % (file_path, e))
+        clean_simulation_directory(self.path,True)
+
 
     def add(self, other):
         """

--- a/meshpy/simulation_manager/simulation_manager.py
+++ b/meshpy/simulation_manager/simulation_manager.py
@@ -307,7 +307,7 @@ class SimulationManager:
         """
         Deletes all files in the path of the simulation manager.
         """
-        clean_simulation_directory(self.path, ask_before_clean=True)
+        clean_simulation_directory(self.path, ask_before_clean=False)
 
     def add(self, other):
         """

--- a/meshpy/simulation_manager/simulation_manager.py
+++ b/meshpy/simulation_manager/simulation_manager.py
@@ -35,6 +35,7 @@ A class that creates scripts to run multiple simulations.
 
 # Import python modules.
 import os
+import shutil
 import subprocess
 import time
 import builtins
@@ -301,6 +302,21 @@ class SimulationManager:
         # Class variables.
         self.path = path
         self.simulations = []
+
+    def clean_up(self):
+        """
+        Deletes all files in the path of the simulation manager.
+        """
+        if os.path.isdir(self.path):
+            for filename in os.listdir(self.path):
+                file_path = os.path.join(self.path, filename)
+                try:
+                    if os.path.isfile(file_path) or os.path.islink(file_path):
+                        os.unlink(file_path)
+                    elif os.path.isdir(file_path):
+                        shutil.rmtree(file_path)
+                except Exception as e:
+                    print("Failed to delete %s. Reason: %s" % (file_path, e))
 
     def add(self, other):
         """

--- a/meshpy/simulation_manager/simulation_manager.py
+++ b/meshpy/simulation_manager/simulation_manager.py
@@ -307,7 +307,7 @@ class SimulationManager:
         """
         Deletes all files in the path of the simulation manager.
         """
-        clean_simulation_directory(self.path, True)
+        clean_simulation_directory(self.path, ask_before_clean=True)
 
     def add(self, other):
         """

--- a/meshpy/utility.py
+++ b/meshpy/utility.py
@@ -143,21 +143,22 @@ def get_min_max_coordinates(nodes):
     return min_max
 
 
-def clean_simulation_directory(sim_dir, ask_before_clean=False):
+def clean_simulation_directory(sim_dir, *, ask_before_clean=False):
     """
-    If the simulation directory exists, the user is asked if the contents
-    should be removed. If it does not exist, it is created.
+    Clear the simulation directory. If it does not exist, it is created.
+    Optionally the user can be asked before a deletion of files.
     Args
     ----
     sim_dir:
-        Path to a directory .
+        Path to a directory
     ask_before_clean: bool
-        flag which indicates whether the user must confirm the removal.
+        Flag which indicates whether the user must confirm removal of files and directories
     """
 
     # Check if simulation directory exists.
     if os.path.exists(sim_dir):
-        print(f'Path "{sim_dir}" already exists')
+        if not ask_before_clean:
+            print(f'Path "{sim_dir}" already exists')
         while True:
             if not ask_before_clean:
                 answer = input("DELETE all contents? (y/n): ")

--- a/meshpy/utility.py
+++ b/meshpy/utility.py
@@ -143,17 +143,26 @@ def get_min_max_coordinates(nodes):
     return min_max
 
 
-def clean_simulation_directory(sim_dir):
+def clean_simulation_directory(sim_dir, ask_before_clean=False):
     """
     If the simulation directory exists, the user is asked if the contents
     should be removed. If it does not exist, it is created.
+    Args
+    ----
+    sim_dir:
+        Path to a directory .
+    ask_before_clean: bool
+        flag which indicates whether the user must confirm the removal.
     """
 
     # Check if simulation directory exists.
     if os.path.exists(sim_dir):
         print(f'Path "{sim_dir}" already exists')
         while True:
-            answer = input("DELETE all contents? (y/n): ")
+            if not ask_before_clean:
+                answer = input("DELETE all contents? (y/n): ")
+            else:
+                answer = "y"
             if answer.lower() == "y":
                 for filename in os.listdir(sim_dir):
                     file_path = os.path.join(sim_dir, filename)

--- a/meshpy/utility.py
+++ b/meshpy/utility.py
@@ -157,10 +157,10 @@ def clean_simulation_directory(sim_dir, *, ask_before_clean=False):
 
     # Check if simulation directory exists.
     if os.path.exists(sim_dir):
-        if not ask_before_clean:
+        if ask_before_clean:
             print(f'Path "{sim_dir}" already exists')
         while True:
-            if not ask_before_clean:
+            if ask_before_clean:
                 answer = input("DELETE all contents? (y/n): ")
             else:
                 answer = "y"

--- a/tests/testing_simulation_manager.py
+++ b/tests/testing_simulation_manager.py
@@ -257,6 +257,9 @@ class TestSimulationManager(unittest.TestCase):
         )
 
     def test_simulation_manager_cleaned_start_directory(self):
+        """
+        Creates some simulation files in a directory and tests the removal of all files within the directory.
+        """
 
         # Create some simulations in a folder.
         convergence_base_dir = os.path.join(
@@ -272,7 +275,7 @@ class TestSimulationManager(unittest.TestCase):
         self.assertTrue(os.path.isdir(manager.path))
 
         # check if folder is empty
-        self.assertFalse(len(os.listdir(manager.path)))
+        self.assertTrue(len(os.listdir(manager.path)) == 0)
 
 
 if __name__ == "__main__":

--- a/tests/testing_simulation_manager.py
+++ b/tests/testing_simulation_manager.py
@@ -256,6 +256,22 @@ class TestSimulationManager(unittest.TestCase):
             additional_identifier=2,
         )
 
+    def test_simulation_manager_clean_up(self):
+        # Create some simulations in a folder.
+        convergence_base_dir = os.path.join(
+            testing_temp, "simulation_manager_test_folder"
+        )
+        manager = self.create_simulations(convergence_base_dir)
+
+        # Perform clean up
+        manager.clean_up()
+
+        # check if the folder still exists
+        self.assertTrue(os.path.isdir(manager.path))
+
+        # check if folder is empty
+        self.assertFalse(len(os.listdir(manager.path)))
+
 
 if __name__ == "__main__":
     # Execution part of script.

--- a/tests/testing_simulation_manager.py
+++ b/tests/testing_simulation_manager.py
@@ -256,15 +256,17 @@ class TestSimulationManager(unittest.TestCase):
             additional_identifier=2,
         )
 
-    def test_simulation_manager_clean_up(self):
+    def test_simulation_manager_cleaned_start_directory(self):
+
         # Create some simulations in a folder.
         convergence_base_dir = os.path.join(
             testing_temp, "simulation_manager_test_folder"
         )
+
         manager = self.create_simulations(convergence_base_dir)
 
-        # Perform clean up
-        manager.clean_up()
+        # Ensure clean state before adding next simulation
+        manager.ensure_clean_simulation_directory()
 
         # check if the folder still exists
         self.assertTrue(os.path.isdir(manager.path))


### PR DESCRIPTION
Add a simple clean up function for the simulation manager, which simply deletes all folders and files within the main folder (Place where the simulation is performed/written) - Has not been tested so far for the cluster.