### PR TITLE
Extend 4C beam potential runtime output

### DIFF
--- a/meshpy/four_c/beam_potential.py
+++ b/meshpy/four_c/beam_potential.py
@@ -189,6 +189,7 @@ class BeamPotential:
         every_iteration=False,
         forces=True,
         moments=True,
+        uids=True,
         per_ele_pair=True,
         option_overwrite=False,
     ):
@@ -207,6 +208,8 @@ class BeamPotential:
             If the forces should be written.
         moments: bool
             If the moments should be written.
+        uids: bool
+            If the unique ids should be written.
         per_ele_pair: bool
             If the forces/moments should be written per element pair.
         option_overwrite: bool
@@ -223,6 +226,7 @@ class BeamPotential:
             EVERY_ITERATION                     {get_yes_no(every_iteration)}
             FORCES                              {get_yes_no(forces)}
             MOMENTS                             {get_yes_no(moments)}
+            WRITE_UIDS                          {get_yes_no(uids)}
             WRITE_FORCE_MOMENT_PER_ELEMENTPAIR  {get_yes_no(per_ele_pair)}""",
                 option_overwrite=option_overwrite,
             )

--- a/tests/reference-files/test_four_c_simulation_beam_potential_helix_reference.dat
+++ b/tests/reference-files/test_four_c_simulation_beam_potential_helix_reference.dat
@@ -25,6 +25,7 @@ INTERVAL_STEPS                        1
 EVERY_ITERATION                       yes
 FORCES                                yes
 MOMENTS                               yes
+WRITE_UIDS                            yes
 WRITE_FORCE_MOMENT_PER_ELEMENTPAIR    yes
 -----------------------------------------------------------------------MATERIALS
 MAT 1 MAT_BeamReissnerElastHyper YOUNG 1000 POISSONRATIO 0.0 DENS 0.0 CROSSAREA 0.7853981633974483 SHEARCORR 1.0 MOMINPOL 0.09817477042468103 MOMIN2 0.04908738521234052 MOMIN3 0.04908738521234052


### PR DESCRIPTION
Extend the 4C beam potential runtime output with new WRITE_UIDs option