### PR TITLE
Draft: Add custom postcommand to the simulation manager

### DIFF
--- a/meshpy/simulation_manager/simulation_manager.py
+++ b/meshpy/simulation_manager/simulation_manager.py
@@ -38,6 +38,7 @@ import os
 import subprocess
 import time
 import builtins
+import warnings
 from meshpy.utility import clean_simulation_directory
 
 
@@ -155,7 +156,8 @@ class Simulation:
             If the job can only be run on certain nodes, configured via a slurm
             feature.
         custom_post_simulation_command: str
-            Adds a custom bash execution to the end of the batch template
+            Adds a custom bash execution to the end of the batch template,
+            therefore this command will only be executed by a job submitted with the generated slurm scripts.
         """
 
         # Class variables
@@ -387,6 +389,10 @@ class SimulationManager:
                 run_script += 'echo "done" >> run_status.log\n'
             if status:
                 run_script += 'echo "done"\n'
+            if simulation.custom_post_simulation_command is not None:
+                warnings.warn(
+                    "You have specified a custom post simulation command for a batch script, which will not be executed. "
+                )
 
         run_script_path = os.path.join(self.path, script_name)
         with open(run_script_path, "w") as file:

--- a/meshpy/simulation_manager/simulation_manager.py
+++ b/meshpy/simulation_manager/simulation_manager.py
@@ -122,6 +122,7 @@ class Simulation:
         restart_from_prefix="",
         job_name=None,
         feature=None,
+        custom_post_simulation_command=None,
     ):
         """
         Initialize the simulation object. The input file will be written to
@@ -153,6 +154,8 @@ class Simulation:
         feature: str
             If the job can only be run on certain nodes, configured via a slurm
             feature.
+        custom_post_simulation_command: str
+            Adds a custom bash execution to the end of the batch template
         """
 
         # Class variables
@@ -165,6 +168,7 @@ class Simulation:
         self.wall_time = wall_time
         self.job_name = job_name
         self.feature = feature
+        self.custom_post_simulation_command = custom_post_simulation_command
 
         # Consistency check
         if self.n_proc is not None and (
@@ -272,6 +276,10 @@ class Simulation:
             is_not_node=is_true_batch(self.n_nodes is None),
         )
         batch_script_path = os.path.join(os.path.dirname(self.file_path), batch_name)
+
+        if self.custom_post_simulation_command is not None:
+            batch_string += self.custom_post_simulation_command
+
         with open(batch_script_path, "w") as file:
             file.write(batch_string)
 

--- a/tests/reference-files/test_simulation_manager_batch_file_1_reference
+++ b/tests/reference-files/test_simulation_manager_batch_file_1_reference
@@ -106,3 +106,4 @@ StageOut
 # END ################## DO NOT TOUCH ME #########################
 echo
 echo "Job finished with exit code $? at: `date`"
+echo "performing post processing command:"

--- a/tests/testing_simulation_manager.py
+++ b/tests/testing_simulation_manager.py
@@ -230,6 +230,7 @@ class TestSimulationManager(unittest.TestCase):
             restart_from_prefix="xxx_old",
             job_name="awesome_job",
             feature="skylake",
+            custom_post_simulation_command='echo "performing post processing command:" ',
         )
         sim.create_batch_file(testing_temp, "batch_name")
         compare_test_result(


### PR DESCRIPTION
Enables the user to add a custom bash command at the end of the `batch_template`

@isteinbrecher : not quite sure if this is a good idea, but for me, it would provide a little bit more flexibility .

Examples: 
- paraview 
- submit automatically next simulation