### PR TITLE
Update pyvista_utils version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "numpy<2",
   "pre-commit",
   "pyvista",
-  "pyvista_utils@git+https://github.com/isteinbrecher/pyvista_utils.git@86210ab",
+  "pyvista_utils@git+https://github.com/isteinbrecher/pyvista_utils.git@3aeb8329bd28b55c01977a10c8eae3a9b2f67442",
   "scipy",
   "splinepy",
   "vtk"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,7 +41,7 @@ import warnings
 import xml.etree.ElementTree as ET
 import vtk
 from vtk.util import numpy_support as vtk_numpy
-from pyvista_utils.compare_grids import compare_grids
+from vtk_utils.compare_grids import compare_grids
 
 
 # MeshPy imports


### PR DESCRIPTION
Update the `pyvista_utils` version.

@all if you are running the MeshPy tests locally you might have to reinstall MeshPy inside `pip` for the testing to work.