### PR TITLE
Fix import vtk_utils to pyvista_utils #122

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,7 +41,7 @@ import warnings
 import xml.etree.ElementTree as ET
 import vtk
 from vtk.util import numpy_support as vtk_numpy
-from vtk_utils.compare_grids import compare_grids
+from pyvista_utils.compare_grids import compare_grids
 
 
 # MeshPy imports


### PR DESCRIPTION
The project is named `pyvista_utils` here https://github.com/isteinbrecher/pyvista_utils/blob/3aeb8329bd28b55c01977a10c8eae3a9b2f67442/pyproject.toml#L6C1-L6C23

Therefore, this should be correct and works for my local machine.

I am wondering why it works within the pipeline with the "wrong" name?