### PR TITLE
Add upload folder on failure

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -72,6 +72,12 @@ jobs:
           # If we did not exit earlier, raise an error here
           exit 1
           ls
+      - name: Upload Test Results
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{github.job}}-${{github.run_number}}
+          path: ${{github.workspace}}/tests/testing-tmp/
 
   geometric-search-testing:
     name: geometric-search-testing


### PR DESCRIPTION
During #126 I encountered the problem that my changes work locally, but for some reason the pipeline fails.

I therefore added the automatic upload of the testing folder.
Additionally, I introduced the environment variable `MESHPY_TESTING_DIR`, with which allows to specify the location of the testing folder.

