### PR TITLE
Ensure unique ordering for function get_all_nodes

### DIFF
--- a/meshpy/geometry_set.py
+++ b/meshpy/geometry_set.py
@@ -219,7 +219,8 @@ class GeometrySet(GeometrySetBase):
             nodes = []
             for element in self.geometry_objects[mpy.geo.line]:
                 nodes.extend(element.nodes)
-            return list(set(nodes))
+            # Remove duplicates while preserving order
+            return list(dict.fromkeys(nodes))
         else:
             raise TypeError(
                 "Currently GeometrySet are only implemented for points and lines"

--- a/tests/reference-files/test_unique_ordering_of_line_condition_reference.dat
+++ b/tests/reference-files/test_unique_ordering_of_line_condition_reference.dat
@@ -1,0 +1,88 @@
+// -----------------------------------------------------------------------------
+// This input file was created with MeshPy.
+// Copyright (c) 2018-2024
+//     Ivo Steinbrecher
+//     Institute for Mathematics and Computer-Based Simulation
+//     Universitaet der Bundeswehr Muenchen
+//     https://www.unibw.de/imcs-en
+// -----------------------------------------------------------------------------
+-----------------------------------------------------------------------MATERIALS
+MAT 1 MAT_BeamReissnerElastHyper YOUNG -1.0 POISSONRATIO 0.0 DENS 0.0 CROSSAREA 3.141592653589793 SHEARCORR 1 MOMINPOL 1.5707963267948966 MOMIN2 0.7853981633974483 MOMIN3 0.7853981633974483
+--------------------------------------------------DESIGN POINT DIRICH CONDITIONS
+DPOINT 21
+E 1 - 0.0
+E 2 - 0.1
+E 3 - 0.2
+E 4 - 0.30000000000000004
+E 5 - 0.4
+E 6 - 0.5
+E 7 - 0.6
+E 8 - 0.7
+E 9 - 0.8
+E 10 - 0.9
+E 11 - 1.0
+E 12 - 1.1
+E 13 - 1.2
+E 14 - 1.2999999999999998
+E 15 - 1.4
+E 16 - 1.5
+E 17 - 1.6
+E 18 - 1.7000000000000002
+E 19 - 1.8
+E 20 - 1.9
+E 21 - 2.0
+-------------------------------------------------------------DNODE-NODE TOPOLOGY
+NODE 1 DNODE 1
+NODE 2 DNODE 2
+NODE 3 DNODE 3
+NODE 4 DNODE 4
+NODE 5 DNODE 5
+NODE 6 DNODE 6
+NODE 7 DNODE 7
+NODE 8 DNODE 8
+NODE 9 DNODE 9
+NODE 10 DNODE 10
+NODE 11 DNODE 11
+NODE 12 DNODE 12
+NODE 13 DNODE 13
+NODE 14 DNODE 14
+NODE 15 DNODE 15
+NODE 16 DNODE 16
+NODE 17 DNODE 17
+NODE 18 DNODE 18
+NODE 19 DNODE 19
+NODE 20 DNODE 20
+NODE 21 DNODE 21
+---------------------------------------------------------------------NODE COORDS
+NODE 1 COORD 0 0 0
+NODE 2 COORD 0.1 0 0
+NODE 3 COORD 0.2 0 0
+NODE 4 COORD 0.3 0 0
+NODE 5 COORD 0.4 0 0
+NODE 6 COORD 0.5 0 0
+NODE 7 COORD 0.6 0 0
+NODE 8 COORD 0.7 0 0
+NODE 9 COORD 0.8 0 0
+NODE 10 COORD 0.9 0 0
+NODE 11 COORD 1 0 0
+NODE 12 COORD 1.1 0 0
+NODE 13 COORD 1.2 0 0
+NODE 14 COORD 1.3 0 0
+NODE 15 COORD 1.4 0 0
+NODE 16 COORD 1.5 0 0
+NODE 17 COORD 1.6 0 0
+NODE 18 COORD 1.7 0 0
+NODE 19 COORD 1.8 0 0
+NODE 20 COORD 1.9 0 0
+NODE 21 COORD 2 0 0
+--------------------------------------------------------------STRUCTURE ELEMENTS
+1 BEAM3R HERM2LINE3 1 3 2 MAT 1 TRIADS 0 0 0 0 0 0 0 0 0
+2 BEAM3R HERM2LINE3 3 5 4 MAT 1 TRIADS 0 0 0 0 0 0 0 0 0
+3 BEAM3R HERM2LINE3 5 7 6 MAT 1 TRIADS 0 0 0 0 0 0 0 0 0
+4 BEAM3R HERM2LINE3 7 9 8 MAT 1 TRIADS 0 0 0 0 0 0 0 0 0
+5 BEAM3R HERM2LINE3 9 11 10 MAT 1 TRIADS 0 0 0 0 0 0 0 0 0
+6 BEAM3R HERM2LINE3 11 13 12 MAT 1 TRIADS 0 0 0 0 0 0 0 0 0
+7 BEAM3R HERM2LINE3 13 15 14 MAT 1 TRIADS 0 0 0 0 0 0 0 0 0
+8 BEAM3R HERM2LINE3 15 17 16 MAT 1 TRIADS 0 0 0 0 0 0 0 0 0
+9 BEAM3R HERM2LINE3 17 19 18 MAT 1 TRIADS 0 0 0 0 0 0 0 0 0
+10 BEAM3R HERM2LINE3 19 21 20 MAT 1 TRIADS 0 0 0 0 0 0 0 0 0

--- a/tests/testing_meshpy.py
+++ b/tests/testing_meshpy.py
@@ -541,6 +541,35 @@ class TestMeshpy(unittest.TestCase):
         # Check the output.
         compare_test_result(self, mesh.get_string(header=False))
 
+    def test_unique_ordering_of_line_condition(self):
+        """This test ensures that the ordering of the nodes returned from the
+        function get_all_nodes is unique for line sets."""
+
+        # set up a beam mesh with material
+        input_file = InputFile()
+        mat = MaterialReissner()
+        beam_set = create_beam_mesh_line(
+            input_file, Beam3rHerm2Line3, mat, [0, 0, 0], [2, 0, 0], n_el=10
+        )
+
+        # apply different Dirichlet conditions to all nodes within this condition
+        for i, node in enumerate(beam_set["line"].get_all_nodes()):
+
+            # add different condition value for each node
+            input_file.add(
+                BoundaryCondition(
+                    GeometrySet(node),
+                    node.coordinates[0],
+                    bc_type=mpy.bc.dirichlet,
+                )
+            )
+
+        # Check the input file
+        compare_test_result(
+            self,
+            input_file.get_string(check_nox=False, header=False),
+        )
+
     def test_meshpy_reissner_beam(self):
         """
         Test that the input file for all types of Reissner beams is generated


### PR DESCRIPTION
During #126 I encountered non-deterministic behavior for the function `get_all_nodes`, when they are used from a geometry based on a line set.

To ensure the same numbering of the nodes, some adjustments were made and a test case is added.