### PR TITLE
Proof of concept for yaml output

### DIFF
--- a/meshpy/conf.py
+++ b/meshpy/conf.py
@@ -177,9 +177,6 @@ class MeshPy(object):
         self.geometric_search_max_nodes_brute_force = 1000
         self.geometric_search_binning_n_bin = 10
 
-        # Values for the formating of the input file.
-        self.dat_len_section = 80
-
         # Import meshes as pure dat or import the geometry.
         self.import_mesh_full = False
 


### PR DESCRIPTION
This is just a pretty rough and quick draft to convert MeshPy output from .dat to .yaml.

There are several things which need to be reworked for a final version. This should demonstrate an overall working versions to get a feeling for the necessary changes - and also to look at a .yaml file.

This MR produced the following exemplary .yaml file (saved as .txt due to Github not supporting the upload of .yaml files):

[test_input.4C.txt](https://github.com/user-attachments/files/17903787/test_input.4C.txt)

As a direct comparison, this would be the regular 4C .dat input file (again formatted as .txt to enable the upload to Github)

[test_input.txt](https://github.com/user-attachments/files/17903794/test_input.txt)


I quite like the look and feel of the .yaml file, and especially the syntax highlighting in VSCode. Try it for youself!

@isteinbrecher I would be interested in you opinion
