### PR TITLE
Rework geometry set

### DIFF
--- a/meshpy/geometry_set.py
+++ b/meshpy/geometry_set.py
@@ -82,9 +82,7 @@ class GeometrySetBase(BaseMeshItemFull):
                 output so we can color the nodes which are part of element sets.
         """
         if link_to_nodes == "explicitly_contained_nodes":
-            node_list = self.get_nodes_explicitly_contained_in_set(
-                fail_if_not_point_set=False
-            )
+            node_list = self.get_node_dict().keys()
         elif link_to_nodes == "all_nodes":
             node_list = self.get_all_nodes()
         else:
@@ -96,32 +94,23 @@ class GeometrySetBase(BaseMeshItemFull):
         """Check if nodes in this set have to be replaced.
         We need to do this for explicitly contained nodes in this set.
         """
-        for node in self.get_nodes_explicitly_contained_in_set(
-            fail_if_not_point_set=False
-        ):
+        # Don't iterate directly over the keys as the dict changes during this iteration
+        for node in list(self.get_node_dict().keys()):
             if node.master_node is not None:
                 self.replace_node(node, node.get_master_node())
 
     def replace_node(self, old_node, new_node):
-        """Replace old_node with new_node. This is only done for point sets."""
+        """Replace old_node with new_node."""
 
-        # Check if the new node is in the set.
-        my_nodes = self.get_nodes_explicitly_contained_in_set(
-            fail_if_not_point_set=False
+        explicit_nodes_in_this_set = self.get_node_dict()
+        explicit_nodes_in_this_set[new_node] = None
+        del explicit_nodes_in_this_set[old_node]
+
+    def get_node_dict(self):
+        """Return the dictionary containing the explicitly added nodes for this set"""
+        raise NotImplementedError(
+            'The "get_node_dict" method has to be overwritten in the derived class'
         )
-        has_new_node = new_node in my_nodes
-
-        for i, node in enumerate(my_nodes):
-            if node == old_node:
-                if has_new_node:
-                    del my_nodes[i]
-                else:
-                    my_nodes[i] = new_node
-                break
-        else:
-            raise ValueError(
-                "The node that should be replaced is not in the current node set"
-            )
 
     def get_points(self):
         """Return nodes explicitly associated with this set."""
@@ -179,7 +168,7 @@ class GeometrySet(GeometrySetBase):
 
         self.geometry_objects = {}
         for geo in mpy.geo:
-            self.geometry_objects[geo] = []
+            self.geometry_objects[geo] = {}
         self.add(geometry)
 
     @staticmethod
@@ -212,10 +201,17 @@ class GeometrySet(GeometrySetBase):
                     "This is not possible"
                 )
         elif self._get_geometry_type(item) is self.geometry_type:
-            if item not in self.geometry_objects[self.geometry_type]:
-                self.geometry_objects[self.geometry_type].append(item)
+            self.geometry_objects[self.geometry_type][item] = None
         else:
             raise TypeError(f"Got unexpected geometry type {type(item)}")
+
+    def get_node_dict(self):
+        """Return the dictionary containing the explicitly added nodes for this set.
+        For non-point sets an empty dict is returned."""
+        if self.geometry_type is mpy.geo.point:
+            return self.geometry_objects[mpy.geo.point]
+        else:
+            return {}
 
     def get_points(self):
         """
@@ -223,7 +219,7 @@ class GeometrySet(GeometrySetBase):
         point set something is returned here.
         """
         if self.geometry_type is mpy.geo.point:
-            return self.geometry_objects[mpy.geo.point]
+            return list(self.geometry_objects[mpy.geo.point].keys())
         else:
             raise TypeError(
                 "The function get_points can only be called for point sets."
@@ -237,10 +233,10 @@ class GeometrySet(GeometrySetBase):
         """
 
         if self.geometry_type is mpy.geo.point:
-            return self.geometry_objects[mpy.geo.point]
+            return list(self.geometry_objects[mpy.geo.point].keys())
         elif self.geometry_type is mpy.geo.line:
             nodes = []
-            for element in self.geometry_objects[mpy.geo.line]:
+            for element in self.geometry_objects[mpy.geo.line].keys():
                 nodes.extend(element.nodes)
             # Remove duplicates while preserving order
             return list(dict.fromkeys(nodes))
@@ -267,7 +263,7 @@ class GeometrySetNodes(GeometrySetBase):
         """
 
         super().__init__(geometry_type, **kwargs)
-        self.nodes = []
+        self.nodes = {}
         if nodes is not None:
             self.add(nodes)
 
@@ -286,8 +282,10 @@ class GeometrySetNodes(GeometrySetBase):
     def replace_indices_with_nodes(self, nodes):
         """After the set is imported from a dat file, replace the node indices
         with the corresponding nodes objects."""
-        for i, node in enumerate(self.nodes):
-            self.nodes[i] = nodes[node]
+        node_dict = {}
+        for node_id in self.nodes.keys():
+            node_dict[nodes[node_id]] = None
+        self.nodes = node_dict
 
     def add(self, value):
         """
@@ -306,8 +304,7 @@ class GeometrySetNodes(GeometrySetBase):
             for item in value:
                 self.add(item)
         elif isinstance(value, (int, Node)):
-            if value not in self.nodes:
-                self.nodes.append(value)
+            self.nodes[value] = None
         elif isinstance(value, GeometrySetNodes):
             # Add all nodes from this geometry set.
             if self.geometry_type == value.geometry_type:
@@ -321,10 +318,14 @@ class GeometrySetNodes(GeometrySetBase):
         else:
             raise TypeError(f"Expected Node or list, but got {type(value)}")
 
+    def get_node_dict(self):
+        """Return the dictionary containing the explicitly added nodes for this set."""
+        return self.nodes
+
     def get_points(self):
         """Return nodes explicitly associated with this set."""
         if self.geometry_type is mpy.geo.point:
-            return self.nodes
+            return self.get_all_nodes()
         else:
             raise TypeError(
                 "The function get_points can only be called for point sets."
@@ -333,4 +334,4 @@ class GeometrySetNodes(GeometrySetBase):
 
     def get_all_nodes(self):
         """Return all nodes associated with this set."""
-        return self.nodes
+        return list(self.nodes.keys())

--- a/tests/performance_testing.py
+++ b/tests/performance_testing.py
@@ -188,8 +188,8 @@ class TestPerformance(object):
     expected_times = {}
     expected_times["sisyphos2.bauv.unibw-muenchen.de"] = {
         "cubitpy_create_solid": 8.0,
-        "meshpy_load_solid": 0.9,
-        "meshpy_load_solid_full": 4.5,
+        "meshpy_load_solid": 1.5,
+        "meshpy_load_solid_full": 3.5,
         "meshpy_create_beams": 9.0,
         "meshpy_rotate": 0.6,
         "meshpy_translate": 0.5,

--- a/tests/performance_testing.py
+++ b/tests/performance_testing.py
@@ -114,6 +114,14 @@ def create_solid_block(file_path, nx, ny, nz):
             bc_description="NUMDOF 6 ONOFF 1 1 1 0 0 0 VAL 3.0 3.0 0.0 0.0 0.0 0.0 FUNCT 1 2 0 0 0 0",
         )
         counter += 1
+    for item in brick.volumes():
+        cubit.add_node_set(
+            item,
+            name="node_set_" + str(counter),
+            bc_type=cupy.bc_type.neumann,
+            bc_description="NUMDOF 6 ONOFF 1 1 1 0 0 0 VAL 3.0 3.0 0.0 0.0 0.0 0.0 FUNCT 1 2 0 0 0 0",
+        )
+        counter += 1
 
     # Export mesh
     cubit.create_dat(file_path)

--- a/tests/testing_four_c_simulation.py
+++ b/tests/testing_four_c_simulation.py
@@ -317,7 +317,7 @@ class TestFullFourC(unittest.TestCase):
 
         # Call get_unique_geometry_sets to check that this does not affect the
         # mesh creation.
-        input_file.get_unique_geometry_sets(link_nodes="all_nodes")
+        input_file.get_unique_geometry_sets(link_to_nodes="all_nodes")
 
         # Check the created input file
         if compare_created_input_file:

--- a/tests/testing_meshpy.py
+++ b/tests/testing_meshpy.py
@@ -1010,10 +1010,14 @@ class TestMeshpy(unittest.TestCase):
         # Add a set with all nodes, to check that the nodes in the
         # boundary condition are replaced correctly.
         if use_nodal_geometry_sets:
+            mesh_ref.add(GeometrySetNodes(mpy.geo.line, ref_nodes))
             mesh_ref.add(GeometrySetNodes(mpy.geo.point, ref_nodes))
+            mesh_couple.add(GeometrySetNodes(mpy.geo.line, coupling_nodes))
             mesh_couple.add(GeometrySetNodes(mpy.geo.point, coupling_nodes))
         else:
+            mesh_ref.add(GeometrySet(mesh_ref.elements))
             mesh_ref.add(GeometrySet(ref_nodes))
+            mesh_couple.add(GeometrySet(mesh_couple.elements))
             mesh_couple.add(GeometrySet(coupling_nodes))
 
         # Add another set with all nodes, this time only the coupling node


### PR DESCRIPTION
This PR reworks the `GeometrySet` object (one of the more messier parts of MeshPy).

We used to store the geometry (nodes, elements) contained in a geometry set in a `list`. To ensure unique entries in this list we checked if the list contains a single item before adding it. This works as expected, however, for a large number of contained items, the check gets increasingly slow and this scales with approximately $\mathcal{O}(n^2)$. This was noticed when modifying the performance tests to also include a volume set with approximately 100,000 nodes. The runtime for the performance test `meshpy_load_solid_full` increased from 4sec to 40sec.

In this PR the internal storage is changed to a `dict` (with the keys being the geometry items and the values always being `None`). This mimics an ordered set using only types from the standard python library. This reduced the complexity to $\mathcal{O}(n)$. The previously mentioned tests runtime now actually decreased (with the additional volume set).