### PR TITLE
Use 4C docker image for testing

### DIFF
--- a/.github/actions/build_arbrox_geometric_search/action.yml
+++ b/.github/actions/build_arbrox_geometric_search/action.yml
@@ -1,0 +1,15 @@
+name: build_arborx_geometric_search
+description: Build the geometric search functionality with ArborX
+runs:
+  using: composite
+  steps:
+    - name: Build ArborX
+      shell: bash
+      env:
+        kokkos_dir: /opt/4C-dependencies/lib/cmake/Kokkos
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        mkdir -p build/arborx
+        cd build/arborx
+        cmake -DKokkos_DIR=${{ env.kokkos_dir }} ../../meshpy/geometric_search/src -G Ninja
+        ninja

--- a/.github/actions/code_check/action.yml
+++ b/.github/actions/code_check/action.yml
@@ -1,0 +1,13 @@
+name: code_check
+description: Perform MeshPy code checks
+runs:
+  using: composite
+  steps:
+    - name: Code Checks
+      shell: bash
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        source python-testing-environment/bin/activate
+        pip install -e .[CI-CD]
+        black . --check --exclude=python-testing-environment && exit 0
+        exit 1

--- a/.github/actions/run_performance_tests/action.yml
+++ b/.github/actions/run_performance_tests/action.yml
@@ -1,0 +1,18 @@
+name: run_performance_tests
+description: MeshPy performance test suite
+runs:
+  using: composite
+  steps:
+    - name: MeshPy testing
+      shell: bash
+      env:
+        CUBIT_ROOT: /imcs/public/compsim/opt/cubit-15.2
+        PERFORMANCE_TESTING_HOST: github-sisyphos-docker
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        source python-testing-environment/bin/activate
+        pip install .[CI-CD]
+        python --version
+        pip list
+        cd tests
+        python performance_testing.py

--- a/.github/actions/run_tests/action.yml
+++ b/.github/actions/run_tests/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: Fail if the CubitPy tests can not be performed
     required: false
     default: 1
+  coverage_config:
+    description: Config file to use for coverage analysis
+    required: false
+    default: "coverage.config"
 runs:
   using: composite
   steps:
@@ -37,7 +41,7 @@ runs:
         python --version
         pip list
         cd tests
-        coverage run --rcfile=coverage.config testing_main.py
+        coverage run --rcfile=${{ inputs.coverage_config }} testing_main.py
         coverage html
         coverage report
         coverage-badge -o htmlcov/coverage.svg

--- a/.github/actions/run_tests/action.yml
+++ b/.github/actions/run_tests/action.yml
@@ -1,0 +1,43 @@
+name: run_tests
+description: Perform MeshPy test suite
+inputs:
+  install-command:
+    description: Command to install MeshPy with pip
+    required: false
+    default: ".[CI-CD]"
+  require_four_c:
+    description: Fail if the 4C tests can not be performed
+    required: false
+    default: 1
+  require_arborx:
+    description: Fail if the ArborX tests can not be performed
+    required: false
+    default: 1
+  require_cubitpy:
+    description: Fail if the CubitPy tests can not be performed
+    required: false
+    default: 1
+runs:
+  using: composite
+  steps:
+    - name: MeshPy testing
+      shell: bash
+      env:
+        MESHPY_FOUR_C_EXE: /home/user/4C/build/4C
+        TESTING_GITHUB: 1
+        TESTING_GITHUB_4C: ${{ inputs.require_four_c }}
+        TESTING_GITHUB_ARBORX: ${{ inputs.require_arborx }}
+        TESTING_GITHUB_CUBITPY: ${{ inputs.require_cubitpy }}
+        CUBIT_ROOT: /imcs/public/compsim/opt/cubit-15.2
+        OMPI_MCA_rmaps_base_oversubscribe: 1
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        source python-testing-environment/bin/activate
+        pip install ${{ inputs.install-command }}
+        python --version
+        pip list
+        cd tests
+        coverage run --rcfile=coverage.config testing_main.py
+        coverage html
+        coverage report
+        coverage-badge -o htmlcov/coverage.svg

--- a/.github/actions/setup_virtual_python_environment/action.yml
+++ b/.github/actions/setup_virtual_python_environment/action.yml
@@ -1,0 +1,17 @@
+name: setup_virtual_python_environment
+description: Configure the python virtual environment
+inputs:
+  python-exe:
+    description: Command for python executable
+    required: false
+    default: "python"
+runs:
+  using: composite
+  steps:
+    - name: Setup virtual environment
+      shell: bash
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        ${{ inputs.python-exe }} -m venv python-testing-environment
+        source python-testing-environment/bin/activate
+        pip install --upgrade pip

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Build with Jekyll
         run: |
           . ${SPACK_ACTIVATION_SCRIPT}
@@ -46,7 +46,7 @@ jobs:
         env:
           JEKYLL_ENV: production
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: public
 
@@ -60,4 +60,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,5 +1,5 @@
-# Workflow for testing meshpy
-name: Test meshpy
+
+name: Test MeshPy during pull requests
 
 on:
   push:
@@ -13,139 +13,90 @@ on:
   workflow_dispatch:
     type: choice
 
-env:
-  # Indicated the testing script, that it is performed on GitHub. In this
-  # case all test have to pass.
-  TESTING_GITHUB: 1
-  # Some tests require the 4C executable to check if the created input file
-  # works with 4C.
-  MESHPY_FOUR_C_EXE: /home_local/github-runner/testing_lib/four_c_master/release/4C
-  # Python executable and virtual environment name
-  PYTHON_EXE: python
-  PYTHON_VENV: python-testing-environment
-  # Meshpy can interact with cubitpy, to perform the corresponding tests,
-  # the following path has to be set
-  CUBIT_ROOT: /imcs/public/compsim/opt/cubit-15.2
-  # Meshpy allows to perform geometric search functions with ArborX,
-  # for this functionality we need Kokkos. On IMCS Ares this is provided
-  # with the spack installation under the following path.
-  SPACK_ACTIVATION_SCRIPT: /home_local/github-runner/testing_lib/spack/share/spack/setup-env.sh
-
 jobs:
-  meshpy-testing:
-    name: meshpy-testing
-    runs-on: self-hosted
+  meshpy-code-check:
+    name: Code check
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ppraegla/4c:latest
+    defaults:
+      run:
+        shell: bash
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup virtual python environment
+        uses: ./.github/actions/setup_virtual_python_environment
+      - name: Code checks
+        uses: ./.github/actions/code_check
+
+  meshpy-testing:
+    name: Run MeshPy test suite
+    runs-on: self-hosted
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup virtual python environment
+        uses: ./.github/actions/setup_virtual_python_environment
         with:
-          submodules: true
-      - name: Test meshpy
-        run: |
-          whoami
-          pwd
-          MESHPY_PATH=$(pwd)
-          echo "Value of MESHPY_FOUR_C_EXE: \"${MESHPY_FOUR_C_EXE}\""
-          # Load the python interpreter
-          . ${SPACK_ACTIVATION_SCRIPT}
-          spack load python@3.12.1
-          # Create the virtual environment
-          ${PYTHON_EXE} -m venv ${PYTHON_VENV}
-          source ${PYTHON_VENV}/bin/activate
-          # We have to update pip, otherwise there is a bug in the compilation of the cython code
-          pip install --upgrade pip
-          # Install meshpy
-          pip install .[CI-CD]
-          # Check git configuration
-          git config --list
-          # Print information on the python environment
-          python --version
-          pip list
-          # Run tests
-          cd tests
-          coverage run --rcfile=coverage.config testing_main.py
-          coverage html
-          coverage report
-          coverage-badge -o htmlcov/coverage.svg
-          # Check codestyle
-          cd $MESHPY_PATH
-          black . --check --exclude="${PYTHON_VENV}" && exit 0
-          # If we did not exit earlier, raise an error here
-          exit 1
-          ls
-      - name: Upload Test Results
+          python-exe: /home_local/github-runner/testing_lib/spack/opt/spack/linux-ubuntu20.04-icelake/gcc-9.4.0/python-3.12.1-qnjucxirxh534suwewl6drfa237u6t7w/bin/python
+      - name: Run the test suite
+        uses: ./.github/actions/run_tests
+        with:
+          require_four_c: 0
+          require_arborx: 0
+      - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{github.job}}-${{github.run_number}}
           path: ${{github.workspace}}/tests/testing-tmp/
 
-  geometric-search-testing:
-    name: geometric-search-testing
-    runs-on: self-hosted
+  meshpy-testing-arborx:
+    name: Run MeshPy test suite with ArborX
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ppraegla/4c:latest
+    defaults:
+      run:
+        shell: bash
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Additionally test the geometric search module with ArborX
-        run: |
-          whoami
-          pwd
-          MESHPY_PATH=$(pwd)
-          # Load the external modules
-          git submodule update --init
-          # Load the required packages via spack
-          . ${SPACK_ACTIVATION_SCRIPT}
-          spack load python@3.12.1
-          spack load ninja@1.11.1
-          spack load cmake@3.25.2
-          spack load kokkos@4.1.00
-          # Build the binaries
-          mkdir -p build/arborx
-          cd build/arborx
-          cmake ../../meshpy/geometric_search/src -G Ninja
-          ninja
-          cd $MESHPY_PATH
-          # Create the virtual environment
-          ${PYTHON_EXE} -m venv ${PYTHON_VENV}
-          source ${PYTHON_VENV}/bin/activate
-          # We have to update pip, otherwise there is a bug in the compilation of the cython code
-          pip install --upgrade pip
-          # Install meshpy, it is not yet possible to globally install the ArborX binaries, so we
-          # use the developement mode here.
-          pip install -e .[CI-CD]
-          # Print information on the python environment
-          python --version
-          pip list
-          # Run tests
-          cd tests
-          python testing_geometric_search.py
+      - name: Setup virtual python environment
+        uses: ./.github/actions/setup_virtual_python_environment
+      - name: Build ArborX geometric search
+        uses: ./.github/actions/build_arbrox_geometric_search
+      - name: Run the test suite
+        uses: ./.github/actions/run_tests
+        with:
+          install-command: "-e .[CI-CD]"
+          require_cubitpy: 0
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{github.job}}-${{github.run_number}}
+          path: ${{github.workspace}}/tests/testing-tmp/
 
-  performance-test:
-    name: meshpy-performance-testing
+  meshpy-performance-testing:
+    name: Run MeshPy performance test suite
     runs-on: self-hosted
     continue-on-error: true
+    defaults:
+      run:
+        shell: bash
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup virtual python environment
+        uses: ./.github/actions/setup_virtual_python_environment
         with:
-          submodules: true
-      - name: Performace test
-        run: |
-          whoami
-          pwd
-          MESHPY_PATH=$(pwd)
-          # Load the python interpreter
-          . ${SPACK_ACTIVATION_SCRIPT}
-          spack load python@3.12.1
-          # Create the virtual environment
-          ${PYTHON_EXE} -m venv ${PYTHON_VENV}
-          source ${PYTHON_VENV}/bin/activate
-          # We have to update pip, otherwise there is a bug in the compilation of the cython code
-          pip install --upgrade pip
-          # Install meshpy
-          pip install .[CI-CD]
-          # Print information on the python environment
-          python --version
-          pip list
-          # Run performance tests
-          cd tests
-          python performance_testing.py
+          python-exe: /home_local/github-runner/testing_lib/spack/opt/spack/linux-ubuntu20.04-icelake/gcc-9.4.0/python-3.12.1-qnjucxirxh534suwewl6drfa237u6t7w/bin/python
+      - name: Run the performance test suite
+        uses: ./.github/actions/run_performance_tests

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,6 +2,8 @@
 name: Test MeshPy during pull requests
 
 on:
+  schedule:
+    - cron: '0 22 * * *'
   push:
     branches:
       - main
@@ -18,7 +20,7 @@ jobs:
     name: Code check
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ppraegla/4c:latest
+      image: ghcr.io/4c-multiphysics/4c:latest
     defaults:
       run:
         shell: bash
@@ -59,7 +61,7 @@ jobs:
     name: Run MeshPy test suite with ArborX
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ppraegla/4c:latest
+      image: ghcr.io/4c-multiphysics/4c:latest
     defaults:
       run:
         shell: bash

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           install-command: "-e .[CI-CD]"
           require_cubitpy: 0
+          coverage_config: "coverage_local.config"
       - name: Upload test results on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/tests/coverage.config
+++ b/tests/coverage.config
@@ -1,4 +1,4 @@
-# Only analyze files from the repository.
+# Only analyze files from the repository, if MeshPy is installed in standard mode
 [run]
 include =
   */site-packages/meshpy/*

--- a/tests/coverage_local.config
+++ b/tests/coverage_local.config
@@ -1,4 +1,4 @@
-# Only analyze files from the repository.
+# Only analyze files from the repository, if MeshPy is installed in editable mode
 [run]
 include =
   ../meshpy/*

--- a/tests/performance_testing.py
+++ b/tests/performance_testing.py
@@ -50,7 +50,7 @@ from meshpy import (
     Beam3rHerm2Line3,
     Rotation,
 )
-from meshpy.utility import find_close_nodes
+from meshpy.utility import find_close_nodes, get_env_variable
 from meshpy.geometric_search import FindClosePointAlgorithm, find_close_points
 from meshpy.mesh_creation_functions.beam_basic_geometry import create_beam_mesh_line
 
@@ -178,7 +178,7 @@ class TestPerformance(object):
 
     # Set expected test times.
     expected_times = {}
-    expected_times["sisyphos2.bauv.unibw-muenchen.de"] = {
+    expected_times["github-sisyphos-docker"] = {
         "cubitpy_create_solid": 8.0,
         "meshpy_load_solid": 0.9,
         "meshpy_load_solid_full": 4.5,
@@ -214,7 +214,9 @@ class TestPerformance(object):
             kwargs = {}
 
         # Get the expected time for this function.
-        host = socket.gethostname()
+        host = get_env_variable(
+            "PERFORMANCE_TESTING_HOST", default=socket.gethostname()
+        )
         if host in self.expected_times.keys():
             if name in self.expected_times[host].keys():
                 expected_time = self.expected_times[host][name]

--- a/tests/testing_four_c_simulation.py
+++ b/tests/testing_four_c_simulation.py
@@ -41,6 +41,7 @@ import shutil
 # Testing imports.
 from utils import (
     compare_test_result,
+    skip_fail_four_c,
     testing_temp,
     testing_input,
 )
@@ -85,11 +86,7 @@ class TestFullFourC(unittest.TestCase):
             If the simulation should be a restart
         """
 
-        # Only run the test if an executable can be found
-        if "MESHPY_FOUR_C_EXE" not in os.environ.keys():
-            self.skipTest("4C path was not found!")
-        if shutil.which("mpirun") is None:
-            self.skipTest("mpirun was not found!")
+        skip_fail_four_c(self)
 
         # Check if temp directory exists.
         testing_dir = os.path.join(testing_temp, name)

--- a/tests/testing_geometric_search.py
+++ b/tests/testing_geometric_search.py
@@ -50,8 +50,7 @@ from meshpy.geometric_search import (
     point_partners_to_unique_indices,
 )
 from meshpy.utility import get_nodal_coordinates, filter_nodes
-from meshpy.geometric_search.geometric_search_arborx import arborx_available
-from meshpy.geometric_search.geometric_search_cython import cython_available
+from utils import skip_fail_arborx
 
 
 class TestGeometricSearch(unittest.TestCase):
@@ -98,20 +97,15 @@ class TestGeometricSearch(unittest.TestCase):
         self.xtest_find_close_points_between_bins(FindClosePointAlgorithm.kd_tree_scipy)
 
     def test_find_close_points_between_bins_brute_force_cython(self):
-        if cython_available:
-            self.xtest_find_close_points_between_bins(
-                FindClosePointAlgorithm.brute_force_cython
-            )
-        else:
-            self.skipTest("Cython not available")
+        self.xtest_find_close_points_between_bins(
+            FindClosePointAlgorithm.brute_force_cython
+        )
 
     def test_find_close_points_between_bins_boundary_volume_hierarchy_arborx(self):
-        if arborx_available:
-            self.xtest_find_close_points_between_bins(
-                FindClosePointAlgorithm.boundary_volume_hierarchy_arborx
-            )
-        else:
-            self.skipTest("ArborX not available")
+        skip_fail_arborx(self)
+        self.xtest_find_close_points_between_bins(
+            FindClosePointAlgorithm.boundary_volume_hierarchy_arborx
+        )
 
     def xtest_find_close_points_between_bins(self, algorithm, **kwargs):
         """
@@ -370,20 +364,15 @@ class TestGeometricSearch(unittest.TestCase):
         self.xtest_find_close_points_binning_flat(FindClosePointAlgorithm.kd_tree_scipy)
 
     def test_find_close_points_flat_brute_force_cython(self):
-        if cython_available:
-            self.xtest_find_close_points_binning_flat(
-                FindClosePointAlgorithm.brute_force_cython
-            )
-        else:
-            self.skipTest("Cython not available")
+        self.xtest_find_close_points_binning_flat(
+            FindClosePointAlgorithm.brute_force_cython
+        )
 
     def test_find_close_points_flat_boundary_volume_hierarchy_arborx(self):
-        if arborx_available:
-            self.xtest_find_close_points_binning_flat(
-                FindClosePointAlgorithm.boundary_volume_hierarchy_arborx
-            )
-        else:
-            self.skipTest("ArborX not available")
+        skip_fail_arborx(self)
+        self.xtest_find_close_points_binning_flat(
+            FindClosePointAlgorithm.boundary_volume_hierarchy_arborx
+        )
 
     def xtest_find_close_points_binning_flat(self, algorithm, **kwargs):
         """
@@ -491,20 +480,15 @@ class TestGeometricSearch(unittest.TestCase):
         self.xtest_find_close_points_dimension(FindClosePointAlgorithm.kd_tree_scipy)
 
     def test_find_close_points_dimension_brute_force_cython(self):
-        if cython_available:
-            self.xtest_find_close_points_dimension(
-                FindClosePointAlgorithm.brute_force_cython
-            )
-        else:
-            self.skipTest("Cython not available")
+        self.xtest_find_close_points_dimension(
+            FindClosePointAlgorithm.brute_force_cython
+        )
 
     def test_find_close_points_dimension_boundary_volume_hierarchy_arborx(self):
-        if arborx_available:
-            self.xtest_find_close_points_dimension(
-                FindClosePointAlgorithm.boundary_volume_hierarchy_arborx
-            )
-        else:
-            self.skipTest("ArborX not available")
+        skip_fail_arborx(self)
+        self.xtest_find_close_points_dimension(
+            FindClosePointAlgorithm.boundary_volume_hierarchy_arborx
+        )
 
     def xtest_find_close_points_dimension(self, algorithm, **kwargs):
         """
@@ -574,22 +558,17 @@ class TestGeometricSearch(unittest.TestCase):
         )
 
     def test_find_close_points_tolerance_precision_brute_force_cython(self):
-        if cython_available:
-            self.xtest_find_close_points_tolerance_precision(
-                FindClosePointAlgorithm.brute_force_cython
-            )
-        else:
-            self.skipTest("Cython not available")
+        self.xtest_find_close_points_tolerance_precision(
+            FindClosePointAlgorithm.brute_force_cython
+        )
 
     def test_find_close_points_tolerance_precision_boundary_volume_hierarchy_arborx(
         self,
     ):
-        if arborx_available:
-            self.xtest_find_close_points_tolerance_precision(
-                FindClosePointAlgorithm.boundary_volume_hierarchy_arborx
-            )
-        else:
-            self.skipTest("ArborX not available")
+        skip_fail_arborx(self)
+        self.xtest_find_close_points_tolerance_precision(
+            FindClosePointAlgorithm.boundary_volume_hierarchy_arborx
+        )
 
     def xtest_find_close_points_tolerance_precision(self, algorithm, **kwargs):
         """

--- a/tests/testing_meshpy.py
+++ b/tests/testing_meshpy.py
@@ -85,7 +85,7 @@ from meshpy.mesh_creation_functions.beam_curve import create_beam_mesh_curve
 
 # Testing imports.
 from utils import (
-    skip_fail_test,
+    skip_fail_cubitpy,
     testing_temp,
     testing_input,
     compare_strings,
@@ -1668,15 +1668,9 @@ class TestMeshpy(unittest.TestCase):
         dat file.
         """
 
-        # Check if cubitpy can be loaded.
-        import importlib
+        skip_fail_cubitpy(self)
 
-        found = importlib.util.find_spec("cubitpy") is not None
-        if not found:
-            # In this case skip the test.
-            skip_fail_test(self, "CubitPy could not be loaded!")
-
-        # Load the mesh creation functions.
+        # Load the mesh creation functions
         from meshpy_testing.create_cubit_input import create_tube, create_tube_cubit
 
         # Create the input file and read the file.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -48,14 +48,52 @@ from vtk_utils.compare_grids import compare_grids
 from meshpy.utility import get_env_variable
 
 
-def skip_fail_test(self, message):
-    """
-    Skip or fail the test depending if the test are run in GitHub or not.
-    """
-    if get_env_variable("TESTING_GITHUB", default="0") == "1":
-        self.skipTest(message)
-    else:
-        self.skipTest(message)
+def skip_fail_four_c(self):
+    """Check if a 4C executable can be found
+
+    If TESTING_GITHUB_4C==1 then we raise an error if we cant find
+    the 4C executable, otherwise the test is skipped"""
+
+    message = "Can not find 4C executable"
+    four_c_path = get_env_variable("MESHPY_FOUR_C_EXE", default="")
+    if not os.path.isfile(four_c_path):
+        if get_env_variable("TESTING_GITHUB_4C", default="0") == "1":
+            raise ImportError(message)
+        else:
+            self.skipTest(message)
+
+
+def skip_fail_arborx(self):
+    """Check if ArborX geometric search can be loaded
+
+    If TESTING_GITHUB_ARBORX==1 then we raise an error if we cant load
+    ArborX, otherwise the test is skipped"""
+
+    from meshpy.geometric_search.geometric_search_arborx import arborx_available
+
+    message = "Can not import ArborX geometric search"
+    if not arborx_available:
+        if get_env_variable("TESTING_GITHUB_ARBORX", default="0") == "1":
+            raise ImportError(message)
+        else:
+            self.skipTest(message)
+
+
+def skip_fail_cubitpy(self):
+    """Check if CubitPy can be loaded
+
+    If TESTING_GITHUB_CUBITPY==1 then we raise an error if we cant load
+    CubitPy, otherwise the test is skipped"""
+    message = "Can not import and initialize CubitPy"
+    try:
+        from cubitpy import CubitPy
+
+        cubit = CubitPy()
+    except Exception as e:
+        if get_env_variable("TESTING_GITHUB_CUBITPY", default="0") == "1":
+            raise ImportError(message)
+        else:
+            self.skipTest(message)
 
 
 # Define the testing paths


### PR DESCRIPTION
This PR updates the CI of MeshPy. The main testing focus is switched to GitHub hosted runners. As default docker image we take an image with a pre-build 4C version. This allows to do all testing that does not require Cubit on GitHub hosted runners.