### PR TITLE
Add missing docstrings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
     hooks:
       - id: interrogate
         name: Run interrogate (linter for docstrings)
-        args: [--fail-under=95, --ignore-init-module, --style=google, -vv, meshpy/]
+        args: [--fail-under=100, --ignore-init-module, --style=google, -vv]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.13.0
     hooks:

--- a/meshpy/conf.py
+++ b/meshpy/conf.py
@@ -152,6 +152,7 @@ class MeshPy(object):
         self.vtk_type = VTKType
 
     def set_default_values(self):
+        """Set the configuration to the default values."""
         # Version information.
         self.git_sha = None
         self.git_date = None

--- a/meshpy/inputfile.py
+++ b/meshpy/inputfile.py
@@ -879,6 +879,7 @@ class InputFile(Mesh):
         # and elements, so the couplings can decide which DOFs they couple,
         # depending on the type of the connected beam element.
         def get_number_of_coupling_conditions(key):
+            """Return the number of coupling conditions in the mesh."""
             if (key, mpy.geo.point) in all_boundary_conditions.keys():
                 return len(all_boundary_conditions[key, mpy.geo.point])
             else:
@@ -935,10 +936,11 @@ class InputFile(Mesh):
         return lines
 
     def get_string(self, **kwargs):
-        """Return the lines of the input file as string."""
+        """Return the lines of the input file as a joined string."""
         return "\n".join(self.get_dat_lines(**kwargs))
 
     def __str__(self, **kwargs):
+        """Return the string representation of this input file."""
         return self.get_string(**kwargs)
 
     def _get_header(self, add_script):

--- a/meshpy/mesh_creation_functions/beam_basic_geometry.py
+++ b/meshpy/mesh_creation_functions/beam_basic_geometry.py
@@ -101,10 +101,11 @@ def create_beam_mesh_line(
     rotation = Rotation.from_basis(t1, t2)
 
     def get_beam_geometry(parameter_a, parameter_b):
-        """Return a function for the position and rotation along the beam
-        axis."""
+        """Return a function for the position along the beams axis."""
 
         def beam_function(xi):
+            """Return a point on the beams axis for a given parameter
+            coordinate xi."""
             point_a = start_point + parameter_a * direction
             point_b = start_point + parameter_b * direction
             return (0.5 * (1 - xi) * point_a + 0.5 * (1 + xi) * point_b, rotation)
@@ -259,6 +260,8 @@ def create_beam_mesh_arc_segment_via_axis(
         axis."""
 
         def beam_function(xi):
+            """Return a point and the triad on the beams axis for a given
+            parameter coordinate xi."""
             phi = 0.5 * (xi + 1) * (beta - alpha) + alpha
             arc_rotation = Rotation(axis, phi)
             rot = arc_rotation * start_rotation

--- a/meshpy/mesh_creation_functions/beam_curve.py
+++ b/meshpy/mesh_creation_functions/beam_curve.py
@@ -142,6 +142,7 @@ def create_beam_mesh_curve(
         rp_positive = rp
 
         def rp(t):
+            """Return the inverted tangent vector."""
             return -(rp_positive(t))
 
     def ds(t):

--- a/tests/pytest_testing_cosserat_curve.py
+++ b/tests/pytest_testing_cosserat_curve.py
@@ -183,6 +183,7 @@ def test_cosserat_mesh_transformation():
     #     json.dump(np_array.tolist(), f, indent=2)
 
     def load_result(name):
+        """Load the position and rotation results from the reference files."""
         with open(
             os.path.join(testing_input, f"{get_pytest_test_name()}_{name}.json"), "r"
         ) as f:

--- a/tests/testing_four_c.py
+++ b/tests/testing_four_c.py
@@ -221,6 +221,8 @@ class Test4C(unittest.TestCase):
 
         # Test that the direction function version works
         def director_function(cell_center):
+            """Return director that will be used to determine the solid
+            thickness direction."""
             return cell_center / np.linalg.norm(cell_center)
 
         mesh_dome = mesh_dome_original.copy()

--- a/tests/testing_geometric_search.py
+++ b/tests/testing_geometric_search.py
@@ -90,14 +90,17 @@ class TestGeometricSearch(unittest.TestCase):
         self.assertEqual(inverse_indices, inverse_indices_ref)
 
     def test_find_close_points_between_bins_scipy(self):
+        """TODO: Remove this once we can use pytest fixtures for this"""
         self.xtest_find_close_points_between_bins(FindClosePointAlgorithm.kd_tree_scipy)
 
     def test_find_close_points_between_bins_brute_force_cython(self):
+        """TODO: Remove this once we can use pytest fixtures for this"""
         self.xtest_find_close_points_between_bins(
             FindClosePointAlgorithm.brute_force_cython
         )
 
     def test_find_close_points_between_bins_boundary_volume_hierarchy_arborx(self):
+        """TODO: Remove this once we can use pytest fixtures for this"""
         skip_fail_arborx(self)
         self.xtest_find_close_points_between_bins(
             FindClosePointAlgorithm.boundary_volume_hierarchy_arborx
@@ -357,14 +360,17 @@ class TestGeometricSearch(unittest.TestCase):
         )
 
     def test_find_close_points_flat_brute_force_scipy(self):
+        """TODO: Remove this once we can use pytest fixtures for this"""
         self.xtest_find_close_points_binning_flat(FindClosePointAlgorithm.kd_tree_scipy)
 
     def test_find_close_points_flat_brute_force_cython(self):
+        """TODO: Remove this once we can use pytest fixtures for this"""
         self.xtest_find_close_points_binning_flat(
             FindClosePointAlgorithm.brute_force_cython
         )
 
     def test_find_close_points_flat_boundary_volume_hierarchy_arborx(self):
+        """TODO: Remove this once we can use pytest fixtures for this"""
         skip_fail_arborx(self)
         self.xtest_find_close_points_binning_flat(
             FindClosePointAlgorithm.boundary_volume_hierarchy_arborx
@@ -473,14 +479,17 @@ class TestGeometricSearch(unittest.TestCase):
             )
 
     def test_find_close_points_dimension_scipy(self):
+        """TODO: Remove this once we can use pytest fixtures for this"""
         self.xtest_find_close_points_dimension(FindClosePointAlgorithm.kd_tree_scipy)
 
     def test_find_close_points_dimension_brute_force_cython(self):
+        """TODO: Remove this once we can use pytest fixtures for this"""
         self.xtest_find_close_points_dimension(
             FindClosePointAlgorithm.brute_force_cython
         )
 
     def test_find_close_points_dimension_boundary_volume_hierarchy_arborx(self):
+        """TODO: Remove this once we can use pytest fixtures for this"""
         skip_fail_arborx(self)
         self.xtest_find_close_points_dimension(
             FindClosePointAlgorithm.boundary_volume_hierarchy_arborx
@@ -546,11 +555,13 @@ class TestGeometricSearch(unittest.TestCase):
         )
 
     def test_find_close_points_tolerance_precision_brute_force_scipy(self):
+        """TODO: Remove this once we can use pytest fixtures for this"""
         self.xtest_find_close_points_tolerance_precision(
             FindClosePointAlgorithm.kd_tree_scipy
         )
 
     def test_find_close_points_tolerance_precision_brute_force_cython(self):
+        """TODO: Remove this once we can use pytest fixtures for this"""
         self.xtest_find_close_points_tolerance_precision(
             FindClosePointAlgorithm.brute_force_cython
         )
@@ -558,6 +569,7 @@ class TestGeometricSearch(unittest.TestCase):
     def test_find_close_points_tolerance_precision_boundary_volume_hierarchy_arborx(
         self,
     ):
+        """TODO: Remove this once we can use pytest fixtures for this"""
         skip_fail_arborx(self)
         self.xtest_find_close_points_tolerance_precision(
             FindClosePointAlgorithm.boundary_volume_hierarchy_arborx

--- a/tests/testing_header_functions.py
+++ b/tests/testing_header_functions.py
@@ -92,9 +92,13 @@ class TestHeaderFunctions(unittest.TestCase):
         compare_test_result(self, input_file.get_string(header=False, check_nox=False))
 
     def test_header_functions_static_time(self):
-        """Test the time setting options in the static header functions."""
+        """Test the time setting options in the static header functions.
+
+        TODO: Replace this with pytest fixtures
+        """
 
         def test_time_values(additional_identifier, kwargs):
+            """Test the time setting options in the static header functions."""
             mpy.set_default_values()
             input_file = InputFile()
             set_header_static(input_file, **kwargs)

--- a/tests/testing_mesh_creation_functions.py
+++ b/tests/testing_mesh_creation_functions.py
@@ -93,13 +93,16 @@ def create_helix_function(
     """
 
     if transformation_factor is None and number_of_turns is None:
-        # Identity transformation
+
         def transformation(t):
+            """Return identity transformation."""
             return 1.0
 
     elif transformation_factor is not None and number_of_turns is not None:
-        # Transform the parameter coordinate to make the function more complex
+
         def transformation(t):
+            """Transform the parameter coordinate to make the function more
+            complex."""
             return (
                 npAD.exp(transformation_factor * t / (2.0 * np.pi * number_of_turns))
                 * t
@@ -113,6 +116,7 @@ def create_helix_function(
         )
 
     def helix(t):
+        """Parametric function to describe a helix."""
         return npAD.array(
             [
                 radius * npAD.cos(transformation(t)),
@@ -661,8 +665,8 @@ class TestMeshCreationFunctions(unittest.TestCase):
         # Set parameters for the sin.
         n_el = 8
 
-        # Create a helix with a parametric curve.
         def sin(t):
+            """Parametric curve as a sin."""
             return npAD.array([t, npAD.sin(t)])
 
         sin_set = create_beam_mesh_curve(
@@ -705,9 +709,11 @@ class TestMeshCreationFunctions(unittest.TestCase):
         n_el = 4
 
         def curve(t):
+            """Parametric representation of the centerline curve."""
             return npAD.array([L * t, t * t * L * L, 0.0])
 
         def rotation(t):
+            """Function that defines the triad along the centerline curve."""
             rp2 = jacobian(curve)(t)
             rp = [rp2[0], rp2[1], 0]
             R1 = Rotation([1, 0, 0], t * 2 * np.pi)
@@ -742,8 +748,9 @@ class TestMeshCreationFunctions(unittest.TestCase):
         # Add material and function.
         mat = MaterialReissner(youngs_modulus=2.07e2, radius=0.1, shear_correction=1.1)
 
-        # Create a line with a parametric curve (and a transformed parameter).
         def line(t):
+            """Create a line with a parametric curve (and a transformed
+            parameter)."""
             factor = 2
             t_trans = npAD.exp(factor * t / (2.0 * np.pi)) * t / npAD.exp(factor)
             return npAD.array([t_trans, 0, 0])

--- a/tests/testing_meshpy.py
+++ b/tests/testing_meshpy.py
@@ -655,6 +655,7 @@ class TestMeshpy(unittest.TestCase):
         """Test the Kirchhoff Love beam material."""
 
         def set_stiff(material):
+            """Set the material properties for the beam material."""
             material.area = 2.0
             material.mom2 = 3.0
             material.mom3 = 4.0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -126,14 +126,8 @@ def compare_string_tolerance(
     """Compare two strings, all floating point values will be compared with a
     tolerance."""
 
-    def set_tol(tol):
-        if tol is None:
-            return 0.0
-        else:
-            return tol
-
-    rtol = set_tol(rtol)
-    atol = set_tol(atol)
+    rtol = 0.0 if rtol is None else rtol
+    atol = 0.0 if atol is None else atol
 
     lines_reference = reference.strip().split("\n")
     lines_compare = compare.strip().split("\n")

--- a/tutorial/__init__.py
+++ b/tutorial/__init__.py
@@ -28,5 +28,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # -----------------------------------------------------------------------------
+"""This module contains the MeshPy tutorials."""
 
 from .tutorial import meshpy_tutorial


### PR DESCRIPTION
This PR adds all missing dock strings and sets the required doctoring coverage to 100%.

@davidrudlstorfer I added temporary "TODO" dock strings to a lot of different testing functions that will likely be replaced with `pytest` fixtures in the near future.