### PR TITLE
Return geometry objects from geometry_set

### DIFF
--- a/meshpy/geometry_set.py
+++ b/meshpy/geometry_set.py
@@ -246,6 +246,10 @@ class GeometrySet(GeometrySetBase):
                 "Currently GeometrySet are only implemented for points and lines"
             )
 
+    def get_geometry_objects(self):
+        """Return a list of the objects with the specified geometry type."""
+        return list(self.geometry_objects[self.geometry_type].keys())
+
 
 class GeometrySetNodes(GeometrySetBase):
     """Geometry set which is defined by nodes and not explicit geometry."""

--- a/tests/testing_meshpy.py
+++ b/tests/testing_meshpy.py
@@ -966,6 +966,32 @@ class TestMeshpy(unittest.TestCase):
             additional_identifier=additional_identifier,
         )
 
+    def test_geometry_set_get_geometry_objects(self):
+        """Test if the geometry set returns the objects(elements) in the
+        correct order."""
+
+        # Initialize material and input file.
+        mat = MaterialReissner()
+        mesh = InputFile()
+
+        # number of elements
+        n_el = 5
+
+        # Create a simple beam.
+        geometry = create_beam_mesh_line(
+            mesh, Beam3rHerm2Line3, mat, [0, 0, 0], [2, 0, 0], n_el=n_el
+        )
+
+        # Get all elements from the geometry set.
+        elements_of_geometry = geometry["line"].get_geometry_objects()
+
+        # Check number of elements.
+        self.assertEqual(len(elements_of_geometry), n_el)
+
+        # Check if the order of the elements from the geometry set is the same as for the mesh.
+        for i_element, element in enumerate(elements_of_geometry):
+            self.assertEqual(element, mesh.elements[i_element])
+
     def test_meshpy_replace_nodes_geometry_set(self):
         """Test case for coupling of nodes, and reusing the identical nodes.
 


### PR DESCRIPTION
Adds a function to return the geometry object of the geometry set and adds an example how it can be used to add specific elements from a line to a condition. 