### PR TITLE
Move coupling node replacement functionality out of Abaqus module

### DIFF
--- a/meshpy/inputfile_utils.py
+++ b/meshpy/inputfile_utils.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# MeshPy: A beam finite element input generator
+#
+# MIT License
+#
+# Copyright (c) 2018-2024
+#     Ivo Steinbrecher
+#     Institute for Mathematics and Computer-Based Simulation
+#     Universitaet der Bundeswehr Muenchen
+#     https://www.unibw.de/imcs-en
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# -----------------------------------------------------------------------------
+"""This module defines utility functions for creating input files from MeshPy
+meshes."""
+
+from typing import Dict, List, Tuple
+
+from .conf import mpy
+from .mesh import Mesh
+from .node import Node
+
+
+def get_coupled_nodes_to_master_map(
+    mesh: Mesh, *, assign_n_global: bool = False
+) -> Tuple[Dict[Node, Node], List[Node]]:
+    """Get a mapping of nodes in a mesh that should be "replaced" because they
+    are coupled via a joint.
+
+    In some finite element (FE) solvers, nodes coupled via joints are resolved
+    by assigning a "master" node to represent the joint. This function identifies
+    such nodes and creates a mapping where each coupled node is mapped to its
+    master node.
+
+    Args
+    ----
+    mesh:
+        Input mesh
+    assign_n_global:
+        If this flag is set, the global indices are set in the node objects.
+
+    Return
+    ----
+    replaced_node_to_master_map:
+        A dictionary mapping each "replaced" node to its "master" node.
+    unique_nodes:
+        A list containing all unique nodes in the mesh, i.e., all nodes which
+        are not coupled and the master nodes.
+    """
+
+    # Get a dictionary that maps the "replaced" nodes to the "master" ones
+    replaced_node_to_master_map = {}
+    for coupling in mesh.boundary_conditions[mpy.bc.point_coupling, mpy.geo.point]:
+        if coupling.coupling_dof_type is not mpy.coupling_dof.fix:
+            raise ValueError(
+                "This function is only implemented for rigid joints at the DOFs"
+            )
+        coupling_nodes = coupling.geometry_set.get_points()
+        for node in coupling_nodes[1:]:
+            replaced_node_to_master_map[node] = coupling_nodes[0]
+
+    # Check that no "replaced" node is a "master" node
+    master_nodes = set(replaced_node_to_master_map.values())
+    for replaced_node in replaced_node_to_master_map.keys():
+        if replaced_node in master_nodes:
+            raise ValueError(
+                "A replaced node is also a master nodes. This is not supported"
+            )
+
+    # Get all unique nodes
+    unique_nodes = [
+        node for node in mesh.nodes if node not in replaced_node_to_master_map
+    ]
+
+    # Optionally number the nodes
+    if assign_n_global:
+        for i_node, node in enumerate(unique_nodes):
+            node.n_global = i_node
+        for replaced_node, master_node in replaced_node_to_master_map.items():
+            replaced_node.n_global = master_node.n_global
+
+    # Return the mapping
+    return replaced_node_to_master_map, unique_nodes

--- a/tests/test_input_file_utils.py
+++ b/tests/test_input_file_utils.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# MeshPy: A beam finite element input generator
+#
+# MIT License
+#
+# Copyright (c) 2018-2024
+#     Ivo Steinbrecher
+#     Institute for Mathematics and Computer-Based Simulation
+#     Universitaet der Bundeswehr Muenchen
+#     https://www.unibw.de/imcs-en
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# -----------------------------------------------------------------------------
+"""This script is used to test the functionality of the input file utils."""
+
+from meshpy import Beam3rLine2Line2, MaterialReissner, Mesh
+from meshpy.inputfile_utils import get_coupled_nodes_to_master_map
+from meshpy.mesh_creation_functions.beam_basic_geometry import create_beam_mesh_line
+
+
+def test_input_file_utils_get_coupled_nodes_to_master_map():
+    """Test the get_coupled_nodes_to_master_map function."""
+
+    beam_object = Beam3rLine2Line2
+    mat = MaterialReissner(radius=0.1)
+    mesh = Mesh()
+    create_beam_mesh_line(mesh, beam_object, mat, [0, 0, 0], [1, 0, 0])
+    create_beam_mesh_line(mesh, beam_object, mat, [1, 0, 0], [1, 1, 0])
+    create_beam_mesh_line(mesh, beam_object, mat, [1, 1, 0], [2, 0, 0])
+    create_beam_mesh_line(mesh, beam_object, mat, [1, 0, 0], [2, 0, 0])
+
+    mesh.couple_nodes()
+
+    replaced_node_to_master_map, unique_nodes = get_coupled_nodes_to_master_map(
+        mesh, assign_n_global=True
+    )
+
+    assert len(unique_nodes) == 4
+    assert unique_nodes == [mesh.nodes[i_node] for i_node in [0, 1, 3, 5]]
+
+    assert len(replaced_node_to_master_map) == 4
+    assert replaced_node_to_master_map[mesh.nodes[2]] == mesh.nodes[1]
+    assert replaced_node_to_master_map[mesh.nodes[4]] == mesh.nodes[3]
+    assert replaced_node_to_master_map[mesh.nodes[7]] == mesh.nodes[5]
+    assert replaced_node_to_master_map[mesh.nodes[6]] == mesh.nodes[1]
+
+    expected_n_global = [0, 1, 1, 2, 2, 3, 1, 3]
+    for i_node, expected_index in enumerate(expected_n_global):
+        assert mesh.nodes[i_node].n_global == expected_index


### PR DESCRIPTION
In some finite element (FE) solvers, nodes coupled via joints are resolved by assigning a "master" node to represent the joint. This PR introduces a general function that identifies such nodes and creates a mapping to identify the "replaced" and "remaining" nodes.