### PR TITLE
Allow `parametrize` tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,12 @@ def pytest_collection_modifyitems(config: Config, items: list) -> None:
     # loop over all collected tests
     for item in items:
         # Get all set markers for current test (e.g. `fourc_arborx`, `cubitpy`, `performance`, ...)
-        markers = [marker.name for marker in item.iter_markers()]
+        # We don't care about the "parametrize" marker here
+        markers = [
+            marker.name
+            for marker in item.iter_markers()
+            if not marker.name == "parametrize"
+        ]
 
         for flag, marker in zip(
             ["--4C", "--ArborX", "--CubitPy", "--performance-tests"],

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -105,3 +105,10 @@ def test_performance() -> None:
     """Performance test."""
 
     assert True
+
+
+@pytest.mark.parametrize("argument", [1, 2, pytest.param(3, marks=pytest.mark.arborx)])
+def test_parametrize(argument) -> None:
+    """Parametrize test, one parameter is tagged with an additional mark."""
+
+    assert True


### PR DESCRIPTION
While working on porting the geometric search tests, I saw that we have a small bug in the testing framework that messes up our test selection process when using `@pytest.mark.parametrize`. This should fix it.