### PR TITLE
Add first badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,27 @@
-# MeshPy
+<h1 align="center">
+  MeshPy
+</h1>
+
+<div align="center">
+
+[![website](https://img.shields.io/badge/MeshPy-website?label=website&color=blue)](https://imcs-compsim.github.io/meshpy/)
+
+</div>
+
+<div align="center">
+
+[![Code quality](https://github.com/imcs-compsim/meshpy/actions/workflows/check_code.yml/badge.svg)](https://github.com/imcs-compsim/meshpy/actions/workflows/check_code.yml)
+[![Test suite](https://github.com/imcs-compsim/meshpy/actions/workflows/testing.yml/badge.svg)](https://github.com/imcs-compsim/meshpy/actions/workflows/testing.yml)
+
+</div>
+
+<div align="center">
+
+[![pre-commit](https://img.shields.io/badge/enabled-green?logo=pre-commit&label=pre-commit)](https://pre-commit.com/)
+[![ruff-formatter](https://img.shields.io/badge/code-ruff-green?logo=ruff&label=code-formatter)](https://docs.astral.sh/ruff/formatter)
+[![ruff-linter](https://img.shields.io/badge/code-ruff-green?logo=ruff&label=code-linter)](https://docs.astral.sh/ruff/linter)
+
+</div>
 
 MeshPy is a general purpose 3D beam finite element input generator written in `python`.
 It contains basic geometry creation and manipulation functions to create complex beam geometries, including rotational degrees of freedom for the beam nodes.


### PR DESCRIPTION
This PR adds the first set of badges to the readme

Open badges which we should/can add in a future PR but need more work

### Coverage

- [ ] coverage percentage
- [ ] link to coverage report => we have to decide if we want to host the coverage report on our own github repo or just use something like coveralls/codecov (would be a lot easier => we also get the coverage badge very easy vs if we have to do it ourself)

### Documentation

- [ ] link to documentation => needs to be hosted on the website => will come after the website is published

### Operating systems

=> we have to think about the systems => if we want to use the github provided badges we would need to further split each operating system into an individual workflow, we could also test something like this https://github.com/marketplace/actions/bring-your-own-badge
- [ ] linux passing
- [ ] windows passing
- [ ] macOS passing

### Final notes

During the badge addition to 4C we discussed that we need to save the svg's in our own repo to not send the users IP adress to the shields.io server (the badges are currently retrieved during each access of the repo)

in my opinion this is no problem due to shields.io privacy notice https://shields.io/privacy

(also all other repos use shields.io but if it would violate GDPR we should not do it)