### PR TITLE
Update 4C docker image to main

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -71,7 +71,7 @@ jobs:
     name: ubuntu-latest with 4C and ArborX
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c:latest
+      image: ghcr.io/4c-multiphysics/4c:main
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
To use the latest 4C docker image we have to now use the tag `main` instead of latest

https://github.com/4C-multiphysics/4C/pull/247