### PR TITLE
Add examples in .ipynb notebooks

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -1,0 +1,45 @@
+# MeshPy: A beam finite element input generator
+#
+# MIT License
+#
+# Copyright (c) 2018-2025
+#     Ivo Steinbrecher
+#     Institute for Mathematics and Computer-Based Simulation
+#     Universitaet der Bundeswehr Muenchen
+#     https://www.unibw.de/imcs-en
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+ARG BASE_IMAGE_TAG=latest
+FROM ghcr.io/pyvista/pyvista:$BASE_IMAGE_TAG
+
+USER root
+RUN apt-get upgrade
+RUN apt-get update
+RUN apt-get install -y git
+RUN apt-get install -y build-essential
+RUN apt-get install -y ffmpeg libsm6 libxext6
+RUN apt-get install -y libgl1-mesa-glx xvfb
+
+COPY . ${HOME}
+USER root
+RUN chown -R 1000 ${HOME}
+RUN chown -R 1000 ${HOME}/.*
+USER jovyan
+WORKDIR ${HOME}
+RUN pip install -e .

--- a/.binder/start
+++ b/.binder/start
@@ -1,0 +1,32 @@
+#!/bin/bash
+# MeshPy: A beam finite element input generator
+#
+# MIT License
+#
+# Copyright (c) 2018-2025
+#     Ivo Steinbrecher
+#     Institute for Mathematics and Computer-Based Simulation
+#     Universitaet der Bundeswehr Muenchen
+#     https://www.unibw.de/imcs-en
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Copied from https://mybinder.org/v2/gh/pyvista/pyvista-examples/master
+export PYVISTA_TRAME_SERVER_PROXY_PREFIX="$JUPYTERHUB_SERVICE_PREFIX/proxy/"
+exec "$@"

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ website/public/
 # Don't ignore directory of Github workflows
 !.github
 !.pre-commit-config.yaml
+!.binder

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,7 @@ repos:
     hooks:
       - id: clang-format
         name: Run clang-format (C/C++ formatter)
+        types: [c, c++]
   - repo: https://github.com/PyCQA/docformatter
     rev: "eb1df347edd128b30cd3368dddc3aa65edcfac38" # change back to version once bug is fixed in latest version to be compatible with pre-commit
     hooks:
@@ -68,6 +69,11 @@ repos:
         name: Run mypy (static type checker for python)
         args: ["--install-types", "--non-interactive", "--ignore-missing-imports", "--follow-imports=silent"]
         exclude: ^website/
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.8.1
+    hooks:
+      - id: nbstripout
+        name: Run nbstripout (strip output from Jupyter notebooks)
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.5
     hooks:
@@ -107,7 +113,7 @@ repos:
     rev: v1.28.4
     hooks:
       - id: typos
-        name: Check for typos
+        name: Run typo checker
         exclude: ".*\\.(nb|wls)$"
   - repo: https://github.com/pamoller/xmlformatter
     rev: v0.2.8

--- a/README.md
+++ b/README.md
@@ -67,7 +67,15 @@ MeshPy is developed at the [Institute for Mathematics and Computer-Based Simulat
 
 ## How to use MeshPy?
 
-Basic tutorials can be found in the directory `tutorial/`.
+MeshPy provides example notebooks to showcase its core features and functionality.
+The examples can be found in the `examples/` directory.
+They can be run locally or directly tested from your browser via the following links:
+
+- Example 1: **Finite rotation framework** [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/imcs-compsim/meshpy/add-examples?labpath=examples%2Fexample_1_finite_rotations.ipynb)
+- Example 2: **Core mesh generation functions** [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/imcs-compsim/meshpy/add-examples?labpath=examples%2Fexample_2_core_mesh_generation_functions.ipynb)
+
+You can also interactively test the entire MeshPy framework directly from your browser here [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/imcs-compsim/meshpy/add-examples)
+
 
 ## How to cite MeshPy?
 

--- a/examples/example_1_finite_rotations.ipynb
+++ b/examples/example_1_finite_rotations.ipynb
@@ -1,0 +1,454 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example 1: Introduction to finite rotations in MeshPy\n",
+    "$\n",
+    "% Define TeX macros for this document\n",
+    "\\def\\vv#1{\\boldsymbol{#1}}\n",
+    "\\def\\mm#1{\\boldsymbol{#1}}\n",
+    "\\def\\R#1{\\mathbb{R}^{#1}}\n",
+    "\\def\\SO{SO(3)}\n",
+    "\\def\\triad{\\mm{\\Lambda}}\n",
+    "$\n",
+    "When working with Cosserat continua in 3D, the mathematical treatment of finite rotations is required.\n",
+    "This example gives an overview of the finite rotation functionality in MeshPy.\n",
+    "For a more comprehensive and theoretical overview of finite rotations, the interested reader is referred to:\n",
+    "- Crisfield, M. A., 1997, Non-Linear Finite Element Analysis of Solids and Structures, Volume 2, Advanced Topics, Wiley & Sons.\n",
+    "- Krenk, S., 2009, Non-Linear Modeling and Analysis of Solids and Structures, Cambridge University Press.\n",
+    "\n",
+    "All finite rotation functionality within MeshPy can be accessed via the `Rotation` class.\n",
+    "Each instance of this class represents an element of the special orthogonal group $\\SO$.\n",
+    "\n",
+    "The rotation class can be imported with"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pyvista as pv\n",
+    "\n",
+    "# Import the MeshPy rotation class\n",
+    "from meshpy import Rotation\n",
+    "\n",
+    "# Utility functionality for this example\n",
+    "from meshpy.examples.example_1_utils import (\n",
+    "    PyVistaPlotter,\n",
+    "    add_cube_plot,\n",
+    "    print_matrix,\n",
+    "    print_rotation_matrix,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Different finite rotation representations\n",
+    "\n",
+    "Internally, MeshPy uses a unit-quaternion representation to store the $\\SO$ element which provides an efficient an singularity free representation.\n",
+    "However, the user can input and output all major representations of large rotations via the `Rotation` class.\n",
+    "Supported representations are:\n",
+    "- **Rotation axis and angle:** \n",
+    "  From an user input point of view, this is the most natural wat to create a large rotation object. This is the default initialization method via the constructor, i.e., `rotation = Rotation(axis, angle)`\n",
+    "- **Rotation (pseudo-) vector:** can be done with `rotation = Rotation.from_rotation_vector(psi)`\n",
+    "- **Unit-quaternion:** can be done with `rotation = Rotation.from_quaternion(q)`\n",
+    "- **Rotation matrix:** can be done with `rotation = Rotation.from_rotation_matrix(R)`\n",
+    "\n",
+    "\n",
+    "Lets start with the creation of a unit rotation from  all different representations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Unit rotation from the axis/angle constructor.\n",
+    "# Note: In this case the rotation axis does not matter, but it can not be a 0 vector\n",
+    "unit_rotation_from_axis_angle = Rotation([1, 1, 1], 0.0)\n",
+    "\n",
+    "# Unit rotation from a rotation vector\n",
+    "unit_rotation_from_rotation_vector = Rotation.from_rotation_vector([0, 0, 0])\n",
+    "\n",
+    "# Unit rotation from a quaternion\n",
+    "unit_rotation_from_quaternion = Rotation.from_quaternion([1, 0, 0, 0])\n",
+    "\n",
+    "# Unit rotation from a rotation matrix (in this case the identity matrix)\n",
+    "unit_rotation_from_rotation_matrix = Rotation.from_rotation_matrix(np.identity(3))\n",
+    "\n",
+    "# An empty constructor also creates a unit rotation\n",
+    "unit_rotation_constructor = Rotation()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now check that all created rotations are equal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert unit_rotation_constructor == unit_rotation_from_axis_angle\n",
+    "assert unit_rotation_constructor == unit_rotation_from_rotation_vector\n",
+    "assert unit_rotation_constructor == unit_rotation_from_quaternion\n",
+    "assert unit_rotation_constructor == unit_rotation_from_rotation_matrix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the next step, lets create rotations around the $x$-axis with an angle of $\\pi/3$.\n",
+    "\n",
+    "Note: The rotation matrix representing this rotation is\n",
+    "$$\n",
+    "\\mm{R}_x = \n",
+    "\\begin{bmatrix}\n",
+    "1 & 0 & 0 \\\\\n",
+    "0 & \\cos\\left(\\frac{\\pi}{3}\\right) & -\\sin\\left(\\frac{\\pi}{3}\\right) \\\\\n",
+    "0 & \\sin\\left(\\frac{\\pi}{3}\\right) & \\cos\\left(\\frac{\\pi}{3}\\right)\n",
+    "\\end{bmatrix}\n",
+    "$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Rotation from the axis/angle constructor\n",
+    "# We define the x-axis as rotation axis and the angle as the second argument\n",
+    "rotation_from_axis_angle = Rotation([1, 0, 0], np.pi / 3)\n",
+    "\n",
+    "# Rotation from a rotation vector\n",
+    "rotation_from_rotation_vector = Rotation.from_rotation_vector([np.pi / 3, 0, 0])\n",
+    "\n",
+    "# Rotation from a rotation matrix\n",
+    "rotation_from_rotation_matrix = Rotation.from_rotation_matrix(\n",
+    "    np.array(\n",
+    "        [\n",
+    "            [1, 0, 0],\n",
+    "            [0, np.cos(np.pi / 3), -np.sin(np.pi / 3)],\n",
+    "            [0, np.sin(np.pi / 3), np.cos(np.pi / 3)],\n",
+    "        ]\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again, we can check that all initializations result in the same rotation object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert rotation_from_axis_angle == rotation_from_rotation_vector\n",
+    "assert rotation_from_axis_angle == rotation_from_rotation_matrix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also extract the different representations from any `Rotation` object\n",
+    "\n",
+    "Note: The axis/angle representation is not unique and mainly useful as an input, therefore, no `get_axis_angle` method exists."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rotation = Rotation([1, 0, 0], np.pi / 3)\n",
+    "\n",
+    "print(f\"Quaternion representation:\\n{rotation.get_quaternion()}\\n\")\n",
+    "print(f\"Rotation vector representation:\\n{rotation.get_rotation_vector()}\\n\")\n",
+    "print(f\"Rotation matrix representation:\\n{rotation.get_rotation_matrix()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Finite rotation calculations\n",
+    "\n",
+    "For mesh creation purposes it is essential to compose multiple rotations, calculate relative rotations or rotate a vector by a given rotation.\n",
+    "With the `Rotation` class this can easily be achieved in a pythonic way.\n",
+    "\n",
+    "Lets start of with the rotation $\\triad_{x}$ (around $x$-axis with angle $\\pi/2$) and $\\triad_{y}$ (around $y$-axis with angle $\\pi/2$)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lambda_x = Rotation([1, 0, 0], 0.5 * np.pi)\n",
+    "lambda_y = Rotation([0, 1, 0], 0.5 * np.pi)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can visualize these rotations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with PyVistaPlotter(shape=(1, 3)) as plotter:\n",
+    "    add_cube_plot(plotter, 0, 0, Rotation(), \"Original object\")\n",
+    "    add_cube_plot(\n",
+    "        plotter,\n",
+    "        0,\n",
+    "        1,\n",
+    "        lambda_x,\n",
+    "        \"Rotated by around the $x$-axis\\nwith the angle $\\\\pi/2$ ($\\\\Lambda_{x}$)\",\n",
+    "    )\n",
+    "    add_cube_plot(\n",
+    "        plotter,\n",
+    "        0,\n",
+    "        2,\n",
+    "        lambda_y,\n",
+    "        \"Rotated by around the $y$-axis\\nwith the angle $\\\\pi/2$ ($\\\\Lambda_{y}$)\",\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now compute the composition of the two rotations $\\triad_{yx}$, i.e., first applying $\\triad_{x}$ then $\\triad_{y}$, via"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lambda_yx = lambda_y * lambda_x\n",
+    "print_rotation_matrix(\"lambda_yx\", lambda_yx)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An important property for elements of $\\SO$ is, that multiplications are non-commutative, i.e., the order of the elements in the multiplication matters.\n",
+    "Thus, $\\triad_{yx} = \\triad_{y} \\triad_{x} \\ne \\triad_{x} \\triad_{y} = \\triad_{xy}$.\n",
+    "We can easily check this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lambda_xy = lambda_x * lambda_y\n",
+    "print_rotation_matrix(\"lambda_xy\", lambda_xy)\n",
+    "\n",
+    "if lambda_xy == lambda_yx:\n",
+    "    print(\"Rotations lambda_yx and lambda_xy are equal!\")\n",
+    "else:\n",
+    "    print(\"Rotations lambda_yx and lambda_xy are NOT equal!\")\n",
+    "\n",
+    "assert not lambda_yx == lambda_xy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also visualize that these rotations are not equal to each other"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with PyVistaPlotter(shape=(1, 3)) as plotter:\n",
+    "    add_cube_plot(plotter, 0, 0, Rotation(), \"Original object\")\n",
+    "    add_cube_plot(\n",
+    "        plotter,\n",
+    "        0,\n",
+    "        1,\n",
+    "        lambda_yx,\n",
+    "        \"Rotated by $\\\\Lambda_{yx}$\\n(First by $\\\\Lambda_x$, then $\\\\Lambda_y$)\",\n",
+    "    )\n",
+    "    add_cube_plot(\n",
+    "        plotter,\n",
+    "        0,\n",
+    "        2,\n",
+    "        lambda_xy,\n",
+    "        \"Rotated by $\\\\Lambda_{xy}$\\n(First by $\\\\Lambda_y$, then $\\\\Lambda_x$)\",\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Rotations can also be inverted.\n",
+    "This allows to easily calculate $\\triad_{y}$ from $\\triad_{yx}$ and $\\triad_{x}$ via $\\triad_{y} = \\triad_{yx} (\\triad_{x})^{-1}$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lambda_y_computed = lambda_yx * lambda_x.inv()\n",
+    "assert lambda_y == lambda_y_computed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In many cases, we need to compute the rotation of a vector $\\vv{r} \\in \\R{3}$.\n",
+    "For example $\\vv{r}' = \\triad_{21} \\vv{r}$.\n",
+    "This can be done the following way"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = [1, 2, 3]\n",
+    "r_prime = lambda_yx * r\n",
+    "print(f\"Rotated vector: {r_prime}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Advanced features"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "MeshPy also provides advanced finite rotation functionality such as smallest rotation mappings and transformation matrices between additive and multiplicative increments."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Smallest rotation mapping\n",
+    "\n",
+    "A smallest rotation mapping calculates the triad $\\triad_{sr}$ that results from the smallest rotation (rotation without twist) from the triad $\\triad$ such that the rotated first basis vector aligns\n",
+    "with $\\vv{t}$.\n",
+    "In mathematical terms, $\\vv{t} = \\triad_{sr} \\vv{e}_1$, where the rotation vector for the relative triad $\\triad_{rel} = \\triad_{sr}(\\triad)^{-1}$ is a minimum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from meshpy.rotation import smallest_rotation\n",
+    "\n",
+    "rotation = Rotation([1, 2, 3], np.pi / 6.0)\n",
+    "lambda_sr = smallest_rotation(rotation, [1, 0.5, 0])\n",
+    "print(f\"First basis vector of lambda_sr: {lambda_sr * [1,0,0]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Transformation matrix $\\mm{T}$\n",
+    "\n",
+    "The infinitesimal variations of the rotation tensor $\\triad(\\vv{\\psi})$ (where $\\vv{\\psi}$ is the rotation vector) can be expressed in two ways:\n",
+    "- Additive Variation:\n",
+    "   $$\n",
+    "   \\delta \\triad = \\frac{d}{d\\epsilon} \\bigg|_{\\epsilon=0} \\triad(\\vv{\\psi} + \\epsilon \\delta \\vv{\\psi}) = \\frac{\\partial \\triad(\\vv{\\psi})}{\\partial \\vv{\\psi}} \\delta \\vv{\\psi}\n",
+    "   $$\n",
+    "   This represents the standard definition of partial differentiation, which is based on additive increments.\n",
+    "\n",
+    "- Multiplicative Variation (also referred to as the spin vector variation):\n",
+    "   $$\n",
+    "   \\delta \\triad = \\frac{d}{d\\epsilon} \\bigg|_{\\epsilon=0} \\triad(\\epsilon \\delta \\vv{\\theta}) \\triad(\\vv{\\psi}) = \\mm{S}(\\delta \\vv{\\theta}) \\triad(\\vv{\\psi})\n",
+    "   $$\n",
+    "   Here, $\\mm{S}(\\delta \\vv{\\theta})$ is the skew-symmetric matrix corresponding to the axial vector $\\delta \\vv{\\theta}$.\n",
+    "\n",
+    "The two variations are related through the transformation matrix $\\mm{T}(\\vv{\\psi})$, which satisfies:\n",
+    "$$\n",
+    "\\delta \\vv{\\psi} = \\mm{T}(\\vv{\\psi}) \\delta \\vv{\\theta}\n",
+    "$$\n",
+    "\n",
+    "MeshPy provides an explicit implementation of $\\mm{T}$ and $\\mm{T}^{-1}$ via the `Rotation` class:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rotation = Rotation([1, 2, 3], np.pi / 6.0)\n",
+    "print_matrix(\"Transformation matrix\", rotation.get_transformation_matrix())\n",
+    "print_matrix(\"Transformation matrix inverse\", rotation.get_transformation_matrix_inv())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "meshpy",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/example_2_core_mesh_generation_functions.ipynb
+++ b/examples/example_2_core_mesh_generation_functions.ipynb
@@ -1,0 +1,150 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example 2: Basic mesh generation functions\n",
+    "$\n",
+    "% Define TeX macros for this document\n",
+    "\\def\\vv#1{\\boldsymbol{#1}}\n",
+    "$\n",
+    "This example shall showcase the core mesh generation functions provided in MeshPy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import meshpy.examples.general_utils"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In a first step we define the type of beam elements we want to use in this example.\n",
+    "The mesh generation functions in MeshPy are agnostic with respect to the employed beam formulation, i.e., every possible beam type can be used with every mesh generation function.\n",
+    "For this example we use the `Beam3rLine2Line2` class, which represents a two-noded beam element.\n",
+    "Hand in hand with the beam type goes the beam material that stores information about the beam-cross section.\n",
+    "In this example we mainly use it for defining the radius of the beams for visualization purposes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from meshpy import Beam3rLine2Line2, MaterialReissner\n",
+    "\n",
+    "beam_type = Beam3rLine2Line2\n",
+    "beam_mat = MaterialReissner"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Mesh` class is the core MeshPy class that will hold all the nodes, elements, materials, and geometry sets for the created geometries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from meshpy import Mesh"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Straight lines\n",
+    "\n",
+    "We already have everything we need to create basic geometries.\n",
+    "Let's start of with the most basic one, a straight line.\n",
+    "For that we need the `create_beam_mesh_line` function.\n",
+    "Mesh generation functions always require to provide a mesh to add the created geometry to, a beam type and a beam material.\n",
+    "In this example we create a line between the points $\\vv{p} = [0,0,0]$ and $\\vv{q}=[1,0,0]$ with 3 equally spaced beam elements:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from meshpy.mesh_creation_functions import create_beam_mesh_line\n",
+    "\n",
+    "mesh = Mesh()\n",
+    "material = beam_mat(radius=0.01)\n",
+    "create_beam_mesh_line(mesh, beam_type, material, [0, 0, 0], [1, 0, 0], n_el=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see that the mesh creation function returned a dictionary containing `GeometrySet`s.\n",
+    "These geometry sets can be used to define boundary conditions.\n",
+    "In this case we get the following sets:\n",
+    "- `start`: A geometry set referring to the start node of the line\n",
+    "- `end`: A geometry set referring to the end node of the line\n",
+    "- `line`: A geometry set referring to all created beam elements along the line\n",
+    "\n",
+    "Later we will dive closer into `GeometrySets`.\n",
+    "\n",
+    "We can directly have a look at the created geometry with the `Mesh.display_pyvista` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh.display_pyvista()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TODO: describe vtu output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TODO"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "meshpy",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/utils/__init__.py
+++ b/examples/utils/__init__.py
@@ -1,0 +1,28 @@
+# MeshPy: A beam finite element input generator
+#
+# MIT License
+#
+# Copyright (c) 2018-2025
+#     Ivo Steinbrecher
+#     Institute for Mathematics and Computer-Based Simulation
+#     Universitaet der Bundeswehr Muenchen
+#     https://www.unibw.de/imcs-en
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""This module defines functionality for the MeshPy examples."""

--- a/examples/utils/example_1_utils.py
+++ b/examples/utils/example_1_utils.py
@@ -1,0 +1,135 @@
+# MeshPy: A beam finite element input generator
+#
+# MIT License
+#
+# Copyright (c) 2018-2025
+#     Ivo Steinbrecher
+#     Institute for Mathematics and Computer-Based Simulation
+#     Universitaet der Bundeswehr Muenchen
+#     https://www.unibw.de/imcs-en
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""This file contains utility functions for the examples in MeshPy."""
+
+import numpy as np
+import pyvista as pv
+
+from meshpy.examples.general_utils import reset_print_out
+from meshpy.utility import is_testing_github
+
+
+def print_matrix(name, matrix):
+    """Print a matrix to the console."""
+    print(f"{name}:\n{np.round(matrix,decimals=10)}")
+
+
+def print_rotation_matrix(name, rotation):
+    """Print the rotation matrix to the console."""
+    print_matrix(name, rotation.get_rotation_matrix())
+
+
+def add_cube_plot(plotter, row, col, rotation, text, *, plot_outlines=True):
+    """Add a cube to the plotter."""
+
+    plotter.subplot(row, col)
+
+    # Define and optionally plot the original cube
+    cube_original = pv.Cube()
+    cube_original = cube_original.scale([3, 2, 1])
+    if plot_outlines:
+        plotter.add_mesh(
+            cube_original, scalars=None, show_edges=True, style="wireframe"
+        )
+
+    # Rotate the cube
+    rotation_vector = rotation.get_rotation_vector()
+    cube = cube_original.rotate_vector(
+        vector=rotation_vector, angle=np.linalg.norm(rotation_vector) * 180 / np.pi
+    )
+
+    # Define colors for each face of the cube (Rubik's cube style)
+    face_colors = np.array(
+        [
+            [255, 165, 0],
+            [255, 0, 0],
+            [0, 255, 0],
+            [0, 0, 255],
+            [255, 255, 0],
+            [255, 255, 255],
+        ]
+    )
+    cube.cell_data["colors"] = face_colors
+
+    # Plot the cube and the title text
+    plotter.add_mesh(cube, scalars="colors", show_edges=True, rgb=True)
+    plotter.add_text(text, font_size=12)
+
+    # Plot the axes
+    for i_dir, (color, name) in enumerate(
+        zip(["red", "green", "blue"], ["x", "y", "z"])
+    ):
+        direction = np.zeros(3)
+        direction[i_dir] = 3.0
+        factor = 0.5
+        arrow = pv.Arrow(
+            start=[0, 0, 0],
+            direction=direction,
+            scale="auto",
+            tip_radius=0.1 * factor,
+            shaft_radius=0.05 * factor,
+            tip_length=0.25 * factor,
+        )
+        plotter.add_mesh(arrow, color=color)
+        plotter.add_point_labels(
+            [1.075 * direction],
+            [name],
+            shadow=True,
+            shape=None,
+            show_points=False,
+            font_size=32,
+            justification_horizontal="center",
+            justification_vertical="center",
+        )
+
+    plotter.show_axes()
+    plotter.camera.zoom(2.0)
+
+
+class PyVistaPlotter:
+    """Class to handle pyvista plotters in the examples."""
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def __enter__(self):
+        """Return the plotter with the given arguments."""
+
+        self.plotter = pv.Plotter(*self.args, **self.kwargs)
+        return self.plotter
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """When exiting the with statement, call this function.
+
+        We show the plotter (except during testing and we reset the
+        console print out).
+        """
+        if not is_testing_github():
+            self.plotter.show()
+        reset_print_out()

--- a/examples/utils/general_utils.py
+++ b/examples/utils/general_utils.py
@@ -1,0 +1,46 @@
+# MeshPy: A beam finite element input generator
+#
+# MIT License
+#
+# Copyright (c) 2018-2025
+#     Ivo Steinbrecher
+#     Institute for Mathematics and Computer-Based Simulation
+#     Universitaet der Bundeswehr Muenchen
+#     https://www.unibw.de/imcs-en
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""This file contains utility functions for the examples in MeshPy."""
+
+import sys
+
+import pyvista as pv
+
+from meshpy.utility import is_mybinder
+
+# Store the default system out, so we can reset it after pyvista changes it
+stdout = sys.stdout
+
+# If we are on mybinder, set to server side rendering
+if is_mybinder():
+    pv.start_xvfb()
+
+
+def reset_print_out():
+    """PyVista changes the printout, this resets it to the default."""
+    sys.stdout = stdout

--- a/meshpy/mesh.py
+++ b/meshpy/mesh.py
@@ -57,6 +57,7 @@ from .utility import (
     get_nodal_coordinates,
     get_nodal_quaternions,
     get_nodes_by_function,
+    is_testing_github,
 )
 from .vtk_writer import VTKWriter
 
@@ -769,11 +770,13 @@ class Mesh:
         beam_cross_section_directors=True,
         beam_radius_for_display=None,
         resolution=20,
-        is_testing=False,
         parallel_projection=False,
         **kwargs,
     ):
         """Display the mesh in pyvista.
+
+        If this is called in a GitHub testing run, nothing will be shown, instead
+        the pv.plotter object will be returned.
 
         Args
         ----
@@ -792,9 +795,6 @@ class Mesh:
         resolution: int
             Indicates how many triangulations will be performed to visualize arrows,
             tubes and spheres.
-        is_testing: bool
-            Flag if the function is used for testing. If true, the pv.plotter object
-            will be returned.
         parallel_projection: bool
             Flag to change camera view to parallel projection.
 
@@ -906,7 +906,7 @@ class Mesh:
             solid_grid = pv.UnstructuredGrid(vtk_writer_solid.grid).clean()
             plotter.add_mesh(solid_grid, color="white", show_edges=True, opacity=0.5)
 
-        if not is_testing:
+        if not is_testing_github():
             plotter.show()
         else:
             return plotter

--- a/meshpy/utility.py
+++ b/meshpy/utility.py
@@ -372,3 +372,13 @@ def get_env_variable(name, *, default="default_not_set"):
     elif default == "default_not_set":
         raise ValueError(f"Environment variable {name} is not set")
     return default
+
+
+def is_testing_github():
+    """Check if the current environment is a testing action on GitHub."""
+    return "GITHUB_ACTION" in os.environ.keys()
+
+
+def is_mybinder():
+    """Check if the current environment is running on mybinder."""
+    return "BINDER_LAUNCH_HOST" in os.environ.keys()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ packages = [
   "meshpy",
   "meshpy.abaqus",
   "meshpy.cosserat_curve",
+  "meshpy.examples",
   "meshpy.four_c",
   "meshpy.geometric_search",
   "meshpy.mesh_creation_functions",
@@ -17,6 +18,7 @@ packages = [
 [tool.setuptools.package-dir]
 meshpy_testing = "tests"
 meshpy_tutorial = "tutorial"
+"meshpy.examples" = "examples/utils"
 
 [tool.setuptools.package-data]
 "meshpy_tutorial" = ["4C_input_solid_tutorial.dat"]
@@ -35,6 +37,8 @@ dependencies = [
   "black==22.12.0",
   "Cython",
   "geomdl",
+  "ipykernel",
+  "notebook",
   "numpy",
   "numpy-quaternion",
   "pre-commit",
@@ -54,7 +58,8 @@ CI-CD = [
   "coverage==7.4.4",
   "coverage-badge",
   "cubitpy@git+https://github.com/imcs-compsim/cubitpy.git@main",
-  "setuptools" # Needed for coverage-badge
+  "setuptools", # Needed for coverage-badge
+  "testbook"
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# MeshPy: A beam finite element input generator
+#
+# MIT License
+#
+# Copyright (c) 2018-2025
+#     Ivo Steinbrecher
+#     Institute for Mathematics and Computer-Based Simulation
+#     Universitaet der Bundeswehr Muenchen
+#     https://www.unibw.de/imcs-en
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""This script is used to test the examples."""
+
+import pytest
+from testbook import testbook
+
+
+@pytest.mark.parametrize(
+    "notebook_path",
+    [
+        "examples/example_1_finite_rotations.ipynb",
+        "examples/example_2_core_mesh_generation_functions.ipynb",
+    ],
+)
+def test_notebooks(notebook_path):
+    """Parameterized test case for multiple Jupyter notebooks.
+
+    The notebook is run and it is checked that it runs through without
+    any errors/assertions.
+    """
+    with testbook(notebook_path, execute=True) as tb:
+        pass

--- a/tests/test_meshpy.py
+++ b/tests/test_meshpy.py
@@ -1913,4 +1913,4 @@ def test_meshpy_display_pyvista(reference_file_directory):
 
     mpy.import_mesh_full = True
     mesh = create_beam_to_solid_conditions_model(reference_file_directory)
-    _plotter = mesh.display_pyvista(is_testing=True, resolution=3)
+    _ = mesh.display_pyvista(resolution=3)


### PR DESCRIPTION
This PR adds a first ipython notebook example for MeshPy (how to interact with the finite rotation framework).

I like the way the notebooks like very much compared to the old tutorial.
This is definitely a better way to explain how the code works and I think we should move all the content of the tutorial to similar example notebooks (I had a look at the tutorial and this can likely be split up to show a number of different features in MeshPy).

The only drawback is that the handling of such notebooks in combination with git is somehow (even in the year 2025) very complicated.
I had a look at a number of different tools and formats and nothing is perfect in my opinion.
Good news first, with `testbook`, testing of the examples should be straight forward.

**py:percent**
I had a look at [The percent format](https://jupytext.readthedocs.io/en/latest/formats-scripts.html#the-percent-format) which seems very nice at first glance. Here are the pros and cons:
- Pros:
  - Everything is nicely stored in a simple `.py` file
  - Our code formatters and pre-commit hooks should work out of the box
  - Perfect for version control
- Cons:
  - Not as widely used as `ipynb`
  - Editing the file (at least in VSCode) is much less intuitive than with `ipynb`
  - Not rendered at all in GitHub (in `ipynb` files at least the markdown is rendered)
 
There exist ways to convert between `ipynb` and `py:percent` (https://jupytext.readthedocs.io/en/latest/index.html), however, I am not convinced yet that this is the best solution for what we need.

**ipynb**
Here are the pros and cons for `ipynb`:
- Pros:
  - More or less standard for notebooks with python
  - Markdown is always rendered in GitHub
  - Intuitively to handle in VSCode
  - Should work without any issues in combination with `my binder`
- Cons:
  - Store a lot of unnecessary data
  - Even if all the meta data and output is removed, the files are still not as nicely readable as `py:percent`
  - Code checks and pre-commit hooks are not straightforward (should be possible but one has to take a look)
 
I think for the use case we habe, i.e., around 5 examples which are not regularly updated, the way to go is with `ipynb` and use a tool that ensures that all metadata and output is striped before committing.

@davidrudlstorfer I am curios on your opinion, we can move this discussion to #171 or we can try to resolve this here with the first example.