### PR TITLE
Add MeshPy API documentation

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  build_website_and_documentation:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -35,13 +35,21 @@ jobs:
         with:
           name: website
           path: website/docs/build/
+      - name: Build API documentation
+        run: |
+          pdoc --output-dir api-documentation meshpy/
+      - name: Upload API documentation artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-documentation
+          path: api-documentation/
 
   deploy:
     environment:
       name: Website
       url: http://imcs-compsim.github.io/meshpy
     runs-on: ubuntu-latest
-    needs: build
+    needs: build_website_and_documentation
     permissions:
       pages: write
       id-token: write
@@ -52,6 +60,11 @@ jobs:
         with:
           name: website
           path: ${{ github.workspace }}
+      - name: Download API documentation artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: api-documentation
+          path: ${{ github.workspace }}/api-documentation
       - name: Download coverage report artifact
         uses: dawidd6/action-download-artifact@v8
         with:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 <div align="center">
 
 [![website](https://raw.githubusercontent.com/imcs-compsim/meshpy/refs/heads/main/utilities/badges/website.svg)](https://imcs-compsim.github.io/meshpy/)
+[![documentation](https://raw.githubusercontent.com/imcs-compsim/meshpy/refs/heads/main/utilities/badges/documentation.svg)](https://imcs-compsim.github.io/meshpy/api-documentation)
 
 </div>
 

--- a/utilities/badges/documentation.svg
+++ b/utilities/badges/documentation.svg
@@ -1,0 +1,21 @@
+<!-- https://img.shields.io/badge/MeshPy-documentation?label=documentation&color=blue --><svg aria-label="documentation: MeshPy" height="20" role="img" width="144" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>documentation: MeshPy</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect fill="#fff" height="20" rx="3" width="144"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect fill="#555" height="20" width="93"/>
+    <rect fill="#007ec6" height="20" width="51" x="93"/>
+    <rect fill="url(#s)" height="20" width="144"/>
+  </g>
+  <g fill="#fff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" text-anchor="middle" text-rendering="geometricPrecision">
+    <text aria-hidden="true" fill="#010101" fill-opacity=".3" textLength="830" transform="scale(.1)" x="475" y="150">documentation</text>
+    <text fill="#fff" textLength="830" transform="scale(.1)" x="475" y="140">documentation</text>
+    <text aria-hidden="true" fill="#010101" fill-opacity=".3" textLength="410" transform="scale(.1)" x="1175" y="150">MeshPy</text>
+    <text fill="#fff" textLength="410" transform="scale(.1)" x="1175" y="140">MeshPy</text>
+  </g>
+</svg>

--- a/website/requirements.txt
+++ b/website/requirements.txt
@@ -1,4 +1,5 @@
 linkify-it-py
 myst-parser
+pdoc
 pydata-sphinx-theme
 sphinx


### PR DESCRIPTION
This PR adds the first version of the MeshPy API documentation which is based on the docstrings. The API documentation is created with https://pdoc.dev/

The structure of the documentation now only includes the core MeshPy module - I intentionally did not add the other submodules as the MeshPy modularity will change with #159 

The API documentation looks like this

[docs.zip](https://github.com/user-attachments/files/18584906/docs.zip)
