### PR TITLE
Add badges for different OS tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,17 @@
 
 <div align="center">
 
-[![Code quality](https://github.com/imcs-compsim/meshpy/actions/workflows/check_code.yml/badge.svg)](https://github.com/imcs-compsim/meshpy/actions/workflows/check_code.yml)
-[![Test suite](https://github.com/imcs-compsim/meshpy/actions/workflows/testing.yml/badge.svg)](https://github.com/imcs-compsim/meshpy/actions/workflows/testing.yml)
+[![Code quality](https://github.com/imcs-compsim/meshpy/actions/workflows/check_code.yml/badge.svg)](https://github.com/imcs-compsim/meshpy/actions/workflows/check_code.yml?query=event%3Aschedule)
+[![Test suite](https://github.com/imcs-compsim/meshpy/actions/workflows/testing.yml/badge.svg)](https://github.com/imcs-compsim/meshpy/actions/workflows/testing.yml?query=event%3Aschedule)
 [![Coverage](https://imcs-compsim.github.io/meshpy/coverage-badge/coverage_badge.svg)](https://imcs-compsim.github.io/meshpy/coverage-report/)
+
+</div>
+
+<div align="center">
+
+[![Testing Linux/Ubuntu](https://raw.githubusercontent.com/imcs-compsim/meshpy/refs/heads/main/utilities/badges/testing_linux_ubuntu.svg)](https://github.com/imcs-compsim/meshpy/actions/workflows/testing.yml?query=event%3Aschedule)
+[![Testing macOS](https://raw.githubusercontent.com/imcs-compsim/meshpy/refs/heads/main/utilities/badges/testing_macos.svg)](https://github.com/imcs-compsim/meshpy/actions/workflows/testing.yml?query=event%3Aschedule)
+[![Testing Windows](https://raw.githubusercontent.com/imcs-compsim/meshpy/refs/heads/main/utilities/badges/testing_windows.svg)](https://github.com/imcs-compsim/meshpy/actions/workflows/testing.yml?query=event%3Aschedule)
 
 </div>
 

--- a/utilities/badges/testing_linux_ubuntu.svg
+++ b/utilities/badges/testing_linux_ubuntu.svg
@@ -1,0 +1,21 @@
+<!-- https://img.shields.io/badge/Linux%2FUbuntu-green?label=Tested%20on --><svg aria-label="Tested on: Linux/Ubuntu" height="20" role="img" width="150" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Tested on: Linux/Ubuntu</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect fill="#fff" height="20" rx="3" width="150"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect fill="#555" height="20" width="65"/>
+    <rect fill="#97ca00" height="20" width="85" x="65"/>
+    <rect fill="url(#s)" height="20" width="150"/>
+  </g>
+  <g fill="#fff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" text-anchor="middle" text-rendering="geometricPrecision">
+    <text aria-hidden="true" fill="#010101" fill-opacity=".3" textLength="550" transform="scale(.1)" x="335" y="150">Tested on</text>
+    <text fill="#fff" textLength="550" transform="scale(.1)" x="335" y="140">Tested on</text>
+    <text aria-hidden="true" fill="#010101" fill-opacity=".3" textLength="750" transform="scale(.1)" x="1065" y="150">Linux/Ubuntu</text>
+    <text fill="#fff" textLength="750" transform="scale(.1)" x="1065" y="140">Linux/Ubuntu</text>
+  </g>
+</svg>

--- a/utilities/badges/testing_macos.svg
+++ b/utilities/badges/testing_macos.svg
@@ -1,0 +1,21 @@
+<!-- https://img.shields.io/badge/macOS-green?label=Tested%20on --><svg aria-label="Tested on: macOS" height="20" role="img" width="114" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Tested on: macOS</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect fill="#fff" height="20" rx="3" width="114"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect fill="#555" height="20" width="65"/>
+    <rect fill="#97ca00" height="20" width="49" x="65"/>
+    <rect fill="url(#s)" height="20" width="114"/>
+  </g>
+  <g fill="#fff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" text-anchor="middle" text-rendering="geometricPrecision">
+    <text aria-hidden="true" fill="#010101" fill-opacity=".3" textLength="550" transform="scale(.1)" x="335" y="150">Tested on</text>
+    <text fill="#fff" textLength="550" transform="scale(.1)" x="335" y="140">Tested on</text>
+    <text aria-hidden="true" fill="#010101" fill-opacity=".3" textLength="390" transform="scale(.1)" x="885" y="150">macOS</text>
+    <text fill="#fff" textLength="390" transform="scale(.1)" x="885" y="140">macOS</text>
+  </g>
+</svg>

--- a/utilities/badges/testing_windows.svg
+++ b/utilities/badges/testing_windows.svg
@@ -1,0 +1,21 @@
+<!-- https://img.shields.io/badge/Windows-green?label=Tested%20on --><svg aria-label="Tested on: Windows" height="20" role="img" width="124" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Tested on: Windows</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect fill="#fff" height="20" rx="3" width="124"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect fill="#555" height="20" width="65"/>
+    <rect fill="#97ca00" height="20" width="59" x="65"/>
+    <rect fill="url(#s)" height="20" width="124"/>
+  </g>
+  <g fill="#fff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" text-anchor="middle" text-rendering="geometricPrecision">
+    <text aria-hidden="true" fill="#010101" fill-opacity=".3" textLength="550" transform="scale(.1)" x="335" y="150">Tested on</text>
+    <text fill="#fff" textLength="550" transform="scale(.1)" x="335" y="140">Tested on</text>
+    <text aria-hidden="true" fill="#010101" fill-opacity=".3" textLength="490" transform="scale(.1)" x="935" y="150">Windows</text>
+    <text fill="#fff" textLength="490" transform="scale(.1)" x="935" y="140">Windows</text>
+  </g>
+</svg>


### PR DESCRIPTION
This PR adds three badges for the different test suites (macOS, Linux/Ubuntu, Windows) and links to the latest scheduled test runs. We are not able to link to the different OS tests because they are within one Github workflow

This would conclude all badges for the MeshPy repo