### PR TITLE
Fix documentation deployment 2

### DIFF
--- a/.github/actions/code_check/action.yml
+++ b/.github/actions/code_check/action.yml
@@ -7,7 +7,7 @@ runs:
       shell: bash
       run: |
         cd ${GITHUB_WORKSPACE}
-        source python-testing-environment/bin/activate
+        source python-workflow-venv/bin/activate
         pip install -e .[CI-CD]
         pre-commit install --install-hooks
         if [ "${GITHUB_REF}" = "refs/heads/main" ]; then

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -12,7 +12,7 @@ runs:
       shell: bash
       run: |
         cd ${GITHUB_WORKSPACE}
-        source python-testing-environment/bin/activate
+        source python-workflow-venv/bin/activate
         mkdir -p coverage-badge
         coverage-badge -o coverage-badge/coverage_badge.svg
         cp .github/actions/coverage/coverage_badge_index.html coverage-badge/index.html

--- a/.github/actions/setup_virtual_python_environment/action.yml
+++ b/.github/actions/setup_virtual_python_environment/action.yml
@@ -12,6 +12,6 @@ runs:
       shell: bash
       run: |
         cd ${GITHUB_WORKSPACE}
-        ${{ inputs.python-exe }} -m venv python-testing-environment
-        source python-testing-environment/bin/activate
+        ${{ inputs.python-exe }} -m venv python-workflow-venv
+        source python-workflow-venv/bin/activate
         pip install --upgrade pip

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,9 +1,11 @@
 name: Build documentation
 
 on:
-  push:
-    branches:
-      - main
+  # Only build the documentation once the test suite has completed on the main branch (only after merged PR's)
+  workflow_run:
+    workflows: [Test suite]
+    types: [completed]
+    branches: [main]
 
 jobs:
   build_documentation:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Install dependencies
         run: |
           cd ${GITHUB_WORKSPACE}
-          source python-testing-environment/bin/activate
+          source python-workflow-venv/bin/activate
           pip install -e .[CI-CD]
       - name: Build API documentation
         run: |
-          source python-testing-environment/bin/activate
+          source python-workflow-venv/bin/activate
           pdoc --output-dir api-documentation meshpy/
       - name: Upload API documentation artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run the test suite
         uses: ./.github/actions/run_tests
         with:
-          source-command: "source python-testing-environment/bin/activate"
+          source-command: "source python-workflow-venv/bin/activate"
           install-command: "-e .[CI-CD]"
           additional-pytest-flags: "--CubitPy"
       - name: Upload test results on failure
@@ -87,7 +87,7 @@ jobs:
       - name: Run the test suite
         uses: ./.github/actions/run_tests
         with:
-          source-command: "source python-testing-environment/bin/activate"
+          source-command: "source python-workflow-venv/bin/activate"
           install-command: "-e .[CI-CD]"
           additional-pytest-flags: "--4C --ArborX"
       - name: Upload test results on failure
@@ -116,7 +116,7 @@ jobs:
       - name: Run the test suite
         uses: ./.github/actions/run_tests
         with:
-          source-command: "source python-testing-environment/bin/activate"
+          source-command: "source python-workflow-venv/bin/activate"
           install-command: "-e .[CI-CD]"
           additional-pytest-flags: "--performance-tests --exclude-standard-tests -s --no-cov"
       - name: Upload test results on failure

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,9 +1,9 @@
 name: Build and deploy website
 
 on:
-  # Only build and deploy the website once the testsuite is completed => coverage badge and report are necessary
+  # Only build and deploy the website once the documentation is built (and the test suite is completed => coverage report and badge are necessary)
   workflow_run:
-    workflows: [Test suite, Build documentation]
+    workflows: [Build documentation]
     types: [completed]
     branches: [main]
 


### PR DESCRIPTION
Problem with the old fix was that the `workflow_run` only works for one workflow. If two prior workflows are added the rule only waits on the successful finish of the first one.

~Therefore, moving back the documentation build to the website creation - which necessitates the creation of the full python venv~

EDIT: as proposed offline - a serial approach makes more sense - now after a successfull test suite run on main the documentation is built. Once this is finished, the website is deployed