### PR TITLE
Fix import problems

### DIFF
--- a/meshpy/four_c/dbc_monitor.py
+++ b/meshpy/four_c/dbc_monitor.py
@@ -32,10 +32,12 @@ from typing import Optional
 
 import numpy as np
 
-from meshpy import BoundaryCondition, GeometrySet, InputFile, mpy
+from meshpy.boundary_condition import BoundaryCondition, GeometrySet
+from meshpy.conf import mpy
 from meshpy.function_utility import (
     create_linear_interpolation_function,
 )
+from meshpy.inputfile import InputFile
 
 from .. import BoundaryCondition, Function, GeometrySet, mpy
 

--- a/meshpy/rotation.py
+++ b/meshpy/rotation.py
@@ -31,7 +31,7 @@ import copy
 
 import numpy as np
 
-from . import mpy
+from .conf import mpy
 
 
 def skew_matrix(vector):

--- a/meshpy/vtk_writer.py
+++ b/meshpy/vtk_writer.py
@@ -34,7 +34,7 @@ import warnings
 import numpy as np
 import vtk
 
-from meshpy.conf import mpy
+from .conf import mpy
 
 
 def add_point_data_node_sets(point_data, nodes, *, extra_points=0):


### PR DESCRIPTION
When MeshPy is used as a submodule (i.e., specifically not at the toplevel but in a src layout) the imports do not resolve and MeshPy does not work at all

This temporarily fixes these problems

**Will be fixed soon with #159 - this is a quick fix to enable the usage of the current main branch as a submodule**