### PR TITLE
Improve plotting in example 1

### DIFF
--- a/examples/example_1_finite_rotations.ipynb
+++ b/examples/example_1_finite_rotations.ipynb
@@ -43,7 +43,10 @@
     "    add_cube_plot,\n",
     "    print_matrix,\n",
     "    print_rotation_matrix,\n",
-    ")"
+    ")\n",
+    "\n",
+    "# For this example we only require static pyvista plots\n",
+    "pv.set_jupyter_backend(\"static\")"
    ]
   },
   {
@@ -223,21 +226,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with PyVistaPlotter(shape=(1, 3)) as plotter:\n",
+    "with PyVistaPlotter(shape=(1, 3), window_size=(1400, 500)) as plotter:\n",
     "    add_cube_plot(plotter, 0, 0, Rotation(), \"Original object\")\n",
     "    add_cube_plot(\n",
     "        plotter,\n",
     "        0,\n",
     "        1,\n",
     "        lambda_x,\n",
-    "        \"Rotated by around the $x$-axis\\nwith the angle $\\\\pi/2$ ($\\\\Lambda_{x}$)\",\n",
+    "        \"Rotated around the $x$-axis\\nwith the angle $\\\\pi/2$ ($\\\\Lambda_{x}$)\",\n",
     "    )\n",
     "    add_cube_plot(\n",
     "        plotter,\n",
     "        0,\n",
     "        2,\n",
     "        lambda_y,\n",
-    "        \"Rotated by around the $y$-axis\\nwith the angle $\\\\pi/2$ ($\\\\Lambda_{y}$)\",\n",
+    "        \"Rotated around the $y$-axis\\nwith the angle $\\\\pi/2$ ($\\\\Lambda_{y}$)\",\n",
     "    )"
    ]
   },
@@ -245,7 +248,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now compute the composition of the two rotations $\\triad_{yx}$, i.e., first applying $\\triad_{x}$ then $\\triad_{y}$, via"
+    "We can now compute the composition of the two rotations $\\triad_{yx}$, i.e., first applying $\\triad_{x}$ then $\\triad_{y}$.\n",
+    "This can be done with the standard multiply operator `*`:"
    ]
   },
   {
@@ -297,21 +301,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with PyVistaPlotter(shape=(1, 3)) as plotter:\n",
+    "with PyVistaPlotter(shape=(1, 3), window_size=(1400, 500)) as plotter:\n",
     "    add_cube_plot(plotter, 0, 0, Rotation(), \"Original object\")\n",
     "    add_cube_plot(\n",
     "        plotter,\n",
     "        0,\n",
     "        1,\n",
     "        lambda_yx,\n",
-    "        \"Rotated by $\\\\Lambda_{yx}$\\n(First by $\\\\Lambda_x$, then $\\\\Lambda_y$)\",\n",
+    "        \"Rotated by $\\\\Lambda_{yx}$\\n(First by $\\\\Lambda_x$, then by $\\\\Lambda_y$)\",\n",
     "    )\n",
     "    add_cube_plot(\n",
     "        plotter,\n",
     "        0,\n",
     "        2,\n",
     "        lambda_xy,\n",
-    "        \"Rotated by $\\\\Lambda_{xy}$\\n(First by $\\\\Lambda_y$, then $\\\\Lambda_x$)\",\n",
+    "        \"Rotated by $\\\\Lambda_{xy}$\\n(First by $\\\\Lambda_y$, then by $\\\\Lambda_x$)\",\n",
     "    )"
    ]
   },

--- a/examples/utils/example_1_utils.py
+++ b/examples/utils/example_1_utils.py
@@ -108,7 +108,6 @@ def add_cube_plot(plotter, row, col, rotation, text, *, plot_outlines=True):
         )
 
     plotter.show_axes()
-    plotter.camera.zoom(2.0)
 
 
 class PyVistaPlotter:


### PR DESCRIPTION
This PR changes the way we display PyVista plots in the first example. Up until now we used the `trame` framework which provides server side rendering, but is very unresponsive in a binder instance. For the first example it makes sense to set this to static rendering as rotating the "figures" is not really needed and the client side rendering has issues with labels which are essential for this example.

For the other (yet to create) examples, I can envision that we enable client side rendering (opposed to "static" or "trame"), due to the cleaner visualisation and responsiveness.

Also, this PR fixes some typos.