### PR TITLE
Add marker to skip tests in CICD

### DIFF
--- a/tests/test_four_c_simulation.py
+++ b/tests/test_four_c_simulation.py
@@ -774,6 +774,10 @@ def test_four_c_simulation_dbc_monitor_to_input(
     )
 
 
+# TODO remove
+@pytest.mark.skip(
+    reason="Upstream bug in 4C https://github.com/4C-multiphysics/4C/issues/385"
+)
 @pytest.mark.parametrize(*PYTEST_4C_SIMULATION_PARAMETRIZE)
 def test_four_c_simulation_dirichlet_boundary_to_neumann_boundary_with_all_values(
     enforce_four_c,


### PR DESCRIPTION
This PR does two things:
1. It temporarily deactivates `test_four_c_simulation_dirichlet_boundary_to_neumann_boundary_with_all_values` due to a bug in 4C
2. It introduces a new marker in our `pytest` framework to mark temporarily excluded tests.