### PR TITLE
Revert "Add marker to skip tests in CICD"

### DIFF
--- a/tests/test_four_c_simulation.py
+++ b/tests/test_four_c_simulation.py
@@ -774,10 +774,6 @@ def test_four_c_simulation_dbc_monitor_to_input(
     )
 
 
-# TODO remove
-@pytest.mark.skip(
-    reason="Upstream bug in 4C https://github.com/4C-multiphysics/4C/issues/385"
-)
 @pytest.mark.parametrize(*PYTEST_4C_SIMULATION_PARAMETRIZE)
 def test_four_c_simulation_dirichlet_boundary_to_neumann_boundary_with_all_values(
     enforce_four_c,


### PR DESCRIPTION
Reverts imcs-compsim/meshpy#240

This should enable all tests again, once https://github.com/4C-multiphysics/4C/pull/386 is in the 4C docker image.

Maybe it does make sense after all to should document this in case we need it again.