### PR TITLE
Src layout fixes and improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
     hooks:
       - id: ruff # linter
         name: Run ruff (linter for Python)
-        args: ["--fix", "--select", "I"] # "--select I" -> sort imports
+        args: ["--fix", "--select", "I,TID252"] # "I => sort imports, TID252 => ban relative imports
       - id: ruff-format # formatter
         name: Run ruff (formatter for Python)
   - repo: https://github.com/crate-ci/typos

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
       - id: mypy
         name: Run mypy (static type checker for python)
         args: ["--install-types", "--non-interactive", "--ignore-missing-imports", "--follow-imports=silent"]
-        exclude: ^website/
+        exclude: "^website/|^tutorial/"
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1
     hooks:

--- a/src/meshpy/__init__.py
+++ b/src/meshpy/__init__.py
@@ -1,0 +1,28 @@
+# MeshPy: A beam finite element input generator
+#
+# MIT License
+#
+# Copyright (c) 2018-2025
+#     Ivo Steinbrecher
+#     Institute for Mathematics and Computer-Based Simulation
+#     Universitaet der Bundeswehr Muenchen
+#     https://www.unibw.de/imcs-en
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""MeshPy - A general purpose 3D beam finite element input generator."""


### PR DESCRIPTION
This PR adds the missing init file at the top-level of MeshPy (note that this Docstring is the landing "page" of the API docu

This PR also enables the pre-commit hook to ban relative imports. If a relative import is present the following error gets thrown:
```
Run ruff (linter for Python).........................................................Failed
- hook id: ruff
- exit code: 1
- files were modified by this hook

src/meshpy/core/container.py:35:1: TID252 Prefer absolute imports over relative imports from parent modules
   |
33 | from meshpy.core.geometry_set import GeometrySetBase
34 | 
35 | from ..core.conf import mpy
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ TID252
   |
   = help: Replace relative imports from parent modules with absolute imports

Found 2 errors (1 fixed, 1 remaining).
No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).
```


Part of #243 