### PR TITLE
Change time of daily tests

### DIFF
--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -2,7 +2,7 @@ name: Code quality
 
 on:
   schedule:
-    - cron: '0 22 * * *'
+    - cron: '0 04 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,7 +2,7 @@ name: Test suite
 
 on:
   schedule:
-    - cron: '0 22 * * *'
+    - cron: '0 04 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
Change the time of the daily tests. This should allow the daily 4C image to already be build and we don’t have the “delay” of a day any more.