### PR TITLE
Allow ArborX search for 1D arrays

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
     hooks:
       - id: clang-format
         name: Run clang-format (C/C++ formatter)
-        types: [c, c++]
+        types_or: [c, c++]
   - repo: https://github.com/PyCQA/docformatter
     rev: "eb1df347edd128b30cd3368dddc3aa65edcfac38" # change back to version once bug is fixed in latest version to be compatible with pre-commit
     hooks:

--- a/src/meshpy/geometric_search/src/find_close_points.cpp
+++ b/src/meshpy/geometric_search/src/find_close_points.cpp
@@ -159,10 +159,22 @@ namespace GeometricSearch
     {
         switch (coordinates.shape(1))
         {
+            case 1:
+                return find_close_points_template<1>(coordinates, tol);
+            case 2:
+                return find_close_points_template<2>(coordinates, tol);
             case 3:
                 return find_close_points_template<3>(coordinates, tol);
+            case 4:
+                return find_close_points_template<4>(coordinates, tol);
+            case 5:
+                return find_close_points_template<5>(coordinates, tol);
             case 6:
                 return find_close_points_template<6>(coordinates, tol);
+            case 7:
+                return find_close_points_template<7>(coordinates, tol);
+            case 8:
+                return find_close_points_template<8>(coordinates, tol);
             default:
                 throw std::out_of_range("Got unexpected number of spatial dimensions");
         }

--- a/tests/test_geometric_search.py
+++ b/tests/test_geometric_search.py
@@ -454,12 +454,45 @@ def test_find_close_points_binning_flat(algorithm):
 
 
 @pytest.mark.parametrize(*PYTEST_GEOMETRIC_SEARCH_PARAMETRIZE)
-def test_find_close_points_dimension(algorithm):
+def test_find_close_points_single_dimension(algorithm):
+    """Test that the find_close_points function works properly with a 1D
+    dimensional array (internally a n x 1 array is required)"""
+
+    # Create array with coordinates
+    eps = 1e-10
+    coords = np.array(
+        [[0, 1, 2, 3 + eps, 4, 5, 3, 6, 7 + eps, 2, 8, 7 - eps, 9, 10, 10 + eps, 7]]
+    ).transpose()
+
+    # Expected results
+    has_partner_expected = [-1, -1, 0, 1, -1, -1, 1, -1, 2, 0, -1, 2, -1, 3, 3, 2]
+    partner_expected = 4
+
+    # Get results
+    has_partner, partner = find_close_points(coords, algorithm=algorithm, tol=10 * eps)
+
+    # Check the results
+    assert np.array_equal(has_partner_expected, has_partner)
+    assert partner_expected == partner
+
+    # Test unique IDs
+    unique_indices_ref = [0, 1, 2, 3, 4, 5, 7, 8, 10, 12, 13]
+    inverse_indices_ref = [0, 1, 2, 3, 4, 5, 3, 6, 7, 2, 8, 7, 9, 10, 10, 7]
+    assert_unique_id_coordinates(
+        coords,
+        has_partner,
+        partner,
+        algorithm,
+        10 * eps,
+        unique_indices_ref,
+        inverse_indices_ref,
+    )
+
+
+@pytest.mark.parametrize(*PYTEST_GEOMETRIC_SEARCH_PARAMETRIZE)
+def test_find_close_points_multi_dimension(algorithm):
     """Test that the find_close_points function also works properly with
     multidimensional points."""
-
-    # Set the seed for the pseudo random numbers.
-    random.seed(0)
 
     # Create array with coordinates.
     coords = np.array(


### PR DESCRIPTION
Until now the ArborX search only worked for points in $\mathbb{R}^3$ and $\mathbb{R}^6$. This PR allows for points from $\mathbb{R}^1$ up to $\mathbb{R}^8$, which should also cover some of the more crazy space-time formulations.