### PR TITLE
Update MIT license

### DIFF
--- a/.binder/Dockerfile
+++ b/.binder/Dockerfile
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 ARG BASE_IMAGE_TAG=latest
 FROM ghcr.io/pyvista/pyvista:$BASE_IMAGE_TAG
 

--- a/.binder/start
+++ b/.binder/start
@@ -1,13 +1,7 @@
 #!/bin/bash
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +18,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 
 # Copied from https://mybinder.org/v2/gh/pyvista/pyvista-examples/master
 export PYVISTA_TRAME_SERVER_PROXY_PREFIX="$JUPYTERHUB_SERVICE_PREFIX/proxy/"

--- a/LICENSE
+++ b/LICENSE
@@ -1,12 +1,6 @@
-MeshPy: A beam finite element input generator
+The MIT License (MIT)
 
-MIT License
-
-Copyright (c) 2018-2025
-    Ivo Steinbrecher
-    Institute for Mathematics and Computer-Based Simulation
-    Universitaet der Bundeswehr Muenchen
-    https://www.unibw.de/imcs-en
+Copyright (c) 2018-2025 MeshPy Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -23,5 +17,5 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/examples/utils/example_1_utils.py
+++ b/examples/utils/example_1_utils.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file contains utility functions for the examples in MeshPy."""
 
 import numpy as np

--- a/examples/utils/general_utils.py
+++ b/examples/utils/general_utils.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file contains utility functions for the examples in MeshPy."""
 
 import sys

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """
 This script can be used to compile the cython code:
 > python setup.py build_ext --inplace

--- a/src/meshpy/__init__.py
+++ b/src/meshpy/__init__.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +17,6 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """MeshPy - A general purpose 3D beam finite element input generator."""

--- a/src/meshpy/abaqus/__init__.py
+++ b/src/meshpy/abaqus/__init__.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +17,7 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module defines classes and functions to create an Abaqus beam input
 file."""

--- a/src/meshpy/abaqus/beam.py
+++ b/src/meshpy/abaqus/beam.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file provides functions to create Abaqus beam element classes to be
 used with MeshPy."""
 

--- a/src/meshpy/abaqus/input_file.py
+++ b/src/meshpy/abaqus/input_file.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module defines the class that is used to create an input file for
 Abaqus."""
 

--- a/src/meshpy/core/__init__.py
+++ b/src/meshpy/core/__init__.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +17,7 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module defines classes and functions to create and edit a 4C input
 file."""

--- a/src/meshpy/core/base_mesh_item.py
+++ b/src/meshpy/core/base_mesh_item.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module implements the class that will be used as the base for all items
 that are in a mesh."""
 

--- a/src/meshpy/core/boundary_condition.py
+++ b/src/meshpy/core/boundary_condition.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module implements a class to represent boundary conditions in
 MeshPy."""
 

--- a/src/meshpy/core/conf.py
+++ b/src/meshpy/core/conf.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module defines a global object that manages all kind of stuff regarding
 meshpy."""
 

--- a/src/meshpy/core/container.py
+++ b/src/meshpy/core/container.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module implements containers to manage boundary conditions and geometry
 sets in one object."""
 

--- a/src/meshpy/core/coupling.py
+++ b/src/meshpy/core/coupling.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module implements a class to couple geometry together."""
 
 import numpy as np

--- a/src/meshpy/core/element.py
+++ b/src/meshpy/core/element.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module implements the class that represents one element in the Mesh."""
 
 from meshpy.core.base_mesh_item import BaseMeshItemFull

--- a/src/meshpy/core/element_beam.py
+++ b/src/meshpy/core/element_beam.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file defines the base beam element in MeshPy."""
 
 from typing import Any, Optional

--- a/src/meshpy/core/element_volume.py
+++ b/src/meshpy/core/element_volume.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file defines the base volume element in MeshPy."""
 
 import numpy as np

--- a/src/meshpy/core/geometry_set.py
+++ b/src/meshpy/core/geometry_set.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module implements a basic class to manage geometry in the input
 file."""
 

--- a/src/meshpy/core/material.py
+++ b/src/meshpy/core/material.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file implements basic classes to manage materials in MeshPy."""
 
 import numpy as np

--- a/src/meshpy/core/mesh.py
+++ b/src/meshpy/core/mesh.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module defines the Mesh class, which holds the content (nodes,
 elements, sets, ...) for a meshed geometry."""
 

--- a/src/meshpy/core/mesh_utils.py
+++ b/src/meshpy/core/mesh_utils.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module defines utility functions for meshes."""
 
 from typing import Dict, List, Tuple

--- a/src/meshpy/core/node.py
+++ b/src/meshpy/core/node.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module implements the class that represents one node in the Mesh."""
 
 import numpy as np

--- a/src/meshpy/core/nurbs_patch.py
+++ b/src/meshpy/core/nurbs_patch.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module implements NURBS patches for the mesh."""
 
 import numpy as np

--- a/src/meshpy/core/rotation.py
+++ b/src/meshpy/core/rotation.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module defines a class that represents a rotation in 3D."""
 
 import copy

--- a/src/meshpy/core/vtk_writer.py
+++ b/src/meshpy/core/vtk_writer.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module provides a class that is used to write VTK files."""
 
 import numbers

--- a/src/meshpy/cosserat_curve/__init__.py
+++ b/src/meshpy/cosserat_curve/__init__.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module contains functionality to convert a curve in 3D to a Cosserat
 curve.
 

--- a/src/meshpy/cosserat_curve/cosserat_curve.py
+++ b/src/meshpy/cosserat_curve/cosserat_curve.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Define a Cosserat curve object that can be used to describe warping of
 curve-like objects."""
 

--- a/src/meshpy/cosserat_curve/warping_along_cosserat_curve.py
+++ b/src/meshpy/cosserat_curve/warping_along_cosserat_curve.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file contains functionality to warp an existing mesh along a 1D
 curve."""
 

--- a/src/meshpy/four_c/__init__.py
+++ b/src/meshpy/four_c/__init__.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +17,7 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module defines classes and functions for the interaction of MeshPy with
 4C."""

--- a/src/meshpy/four_c/beam_potential.py
+++ b/src/meshpy/four_c/beam_potential.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file includes functions to ease the creation of input files using beam
 interaction potentials."""
 

--- a/src/meshpy/four_c/boundary_condition.py
+++ b/src/meshpy/four_c/boundary_condition.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module implements a class to handle boundary conditions in 4C."""
 
 import warnings

--- a/src/meshpy/four_c/dbc_monitor.py
+++ b/src/meshpy/four_c/dbc_monitor.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This function converts the DBC monitor log files to Neumann input
 sections."""
 

--- a/src/meshpy/four_c/element_beam.py
+++ b/src/meshpy/four_c/element_beam.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file implements beam elements for 4C."""
 
 import warnings

--- a/src/meshpy/four_c/element_volume.py
+++ b/src/meshpy/four_c/element_volume.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file implements volume elements for 4C."""
 
 from meshpy.core.element_volume import VolumeElement

--- a/src/meshpy/four_c/function.py
+++ b/src/meshpy/four_c/function.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module implements a basic class to manage functions in the 4C input
 file."""
 

--- a/src/meshpy/four_c/function_utility.py
+++ b/src/meshpy/four_c/function_utility.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module implements utility functions to create 4C space time
 function."""
 

--- a/src/meshpy/four_c/header_functions.py
+++ b/src/meshpy/four_c/header_functions.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module defines functions that can be used to add header information to
 an input file."""
 

--- a/src/meshpy/four_c/input_file.py
+++ b/src/meshpy/four_c/input_file.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module defines the classes that are used to create an input file for
 4C."""
 

--- a/src/meshpy/four_c/locsys_condition.py
+++ b/src/meshpy/four_c/locsys_condition.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file contains the wrapper for the LocSys condition for 4c."""
 
 from meshpy.core.conf import mpy

--- a/src/meshpy/four_c/material.py
+++ b/src/meshpy/four_c/material.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file implements materials for 4C beams and solids."""
 
 from meshpy.core.material import Material, MaterialBeam

--- a/src/meshpy/four_c/run_four_c.py
+++ b/src/meshpy/four_c/run_four_c.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Provide a function that allows to run 4C."""
 
 import os

--- a/src/meshpy/four_c/solid_shell_thickness_direction.py
+++ b/src/meshpy/four_c/solid_shell_thickness_direction.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This function allows to reorder the connectivity of solid shell elements
 such that the solid shell direction is correctly represented."""
 

--- a/src/meshpy/geometric_search/__init__.py
+++ b/src/meshpy/geometric_search/__init__.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +17,6 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module defines geometric search functionality."""

--- a/src/meshpy/geometric_search/find_close_points.py
+++ b/src/meshpy/geometric_search/find_close_points.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Find unique points in a point cloud, i.e., points that are within a certain
 tolerance of each other will be considered as unique."""
 

--- a/src/meshpy/geometric_search/geometric_search_arborx.py
+++ b/src/meshpy/geometric_search/geometric_search_arborx.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file defines the interface to the ArborX geometric search
 functionality."""
 

--- a/src/meshpy/geometric_search/geometric_search_cython.py
+++ b/src/meshpy/geometric_search/geometric_search_cython.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file defines the interface to the Cython geometric search
 functionality."""
 

--- a/src/meshpy/geometric_search/geometric_search_cython_lib.pyx
+++ b/src/meshpy/geometric_search/geometric_search_cython_lib.pyx
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 # cython: language_level=3
 """
 This script contains functions that calculate points that are close together.

--- a/src/meshpy/geometric_search/geometric_search_scipy.py
+++ b/src/meshpy/geometric_search/geometric_search_scipy.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file defines the interface to the Scipy spatial geometric search
 functionality."""
 

--- a/src/meshpy/geometric_search/src/CMakeLists.txt
+++ b/src/meshpy/geometric_search/src/CMakeLists.txt
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 
 cmake_minimum_required(VERSION 3.0)
 

--- a/src/meshpy/geometric_search/src/find_close_points.cpp
+++ b/src/meshpy/geometric_search/src/find_close_points.cpp
@@ -1,12 +1,6 @@
-// MeshPy: A beam finite element input generator
+// The MIT License (MIT)
 //
-// MIT License
-//
-// Copyright (c) 2018-2025
-//     Ivo Steinbrecher
-//     Institute for Mathematics and Computer-Based Simulation
-//     Universitaet der Bundeswehr Muenchen
-//     https://www.unibw.de/imcs-en
+// Copyright (c) 2018-2025 MeshPy Authors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #include <ArborX_LinearBVH.hpp>
 #include <ArborX_HyperPoint.hpp>

--- a/src/meshpy/geometric_search/src/find_close_points.h
+++ b/src/meshpy/geometric_search/src/find_close_points.h
@@ -1,12 +1,6 @@
-// MeshPy: A beam finite element input generator
+// The MIT License (MIT)
 //
-// MIT License
-//
-// Copyright (c) 2018-2025
-//     Ivo Steinbrecher
-//     Institute for Mathematics and Computer-Based Simulation
-//     Universitaet der Bundeswehr Muenchen
-//     https://www.unibw.de/imcs-en
+// Copyright (c) 2018-2025 MeshPy Authors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #ifndef FIND_CLOSE_POINTS_
 #define FIND_CLOSE_POINTS_

--- a/src/meshpy/geometric_search/src/geometric_search.cpp
+++ b/src/meshpy/geometric_search/src/geometric_search.cpp
@@ -1,12 +1,6 @@
-// MeshPy: A beam finite element input generator
+// The MIT License (MIT)
 //
-// MIT License
-//
-// Copyright (c) 2018-2025
-//     Ivo Steinbrecher
-//     Institute for Mathematics and Computer-Based Simulation
-//     Universitaet der Bundeswehr Muenchen
-//     https://www.unibw.de/imcs-en
+// Copyright (c) 2018-2025 MeshPy Authors
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 #include <pybind11/pybind11.h>
 #include <Kokkos_Core.hpp>

--- a/src/meshpy/mesh_creation_functions/__init__.py
+++ b/src/meshpy/mesh_creation_functions/__init__.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module stores all functions to create beam meshes.
 
 From simple lines to complex stent craft structures.

--- a/src/meshpy/mesh_creation_functions/beam_basic_geometry.py
+++ b/src/meshpy/mesh_creation_functions/beam_basic_geometry.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file has functions to create basic geometry items with meshpy."""
 
 import warnings

--- a/src/meshpy/mesh_creation_functions/beam_curve.py
+++ b/src/meshpy/mesh_creation_functions/beam_curve.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file has functions to create a beam from a parametric curve."""
 
 import numpy as np

--- a/src/meshpy/mesh_creation_functions/beam_fibers_in_rectangle.py
+++ b/src/meshpy/mesh_creation_functions/beam_fibers_in_rectangle.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file has functions to generate multiple parallel fibers within a
 rectangle.
 

--- a/src/meshpy/mesh_creation_functions/beam_generic.py
+++ b/src/meshpy/mesh_creation_functions/beam_generic.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Generic function used to create all beams within meshpy."""
 
 import numpy as np

--- a/src/meshpy/mesh_creation_functions/beam_honeycomb.py
+++ b/src/meshpy/mesh_creation_functions/beam_honeycomb.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file has functions to create a honeycomb beam mesh."""
 
 import numpy as np

--- a/src/meshpy/mesh_creation_functions/beam_nurbs.py
+++ b/src/meshpy/mesh_creation_functions/beam_nurbs.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Create a beam filament from a NURBS curve represented with splinepy."""
 
 import numpy as np

--- a/src/meshpy/mesh_creation_functions/beam_stent.py
+++ b/src/meshpy/mesh_creation_functions/beam_stent.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file has functions to create a stent according to Auricchio 2012."""
 
 import numpy as np

--- a/src/meshpy/mesh_creation_functions/beam_wire.py
+++ b/src/meshpy/mesh_creation_functions/beam_wire.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Create a steel wire."""
 
 import numpy as np

--- a/src/meshpy/mesh_creation_functions/nurbs_generic.py
+++ b/src/meshpy/mesh_creation_functions/nurbs_generic.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Generic function used to create NURBS meshes within meshpy."""
 
 import numpy as np

--- a/src/meshpy/mesh_creation_functions/nurbs_geometries.py
+++ b/src/meshpy/mesh_creation_functions/nurbs_geometries.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This file has functions to create NURBS geometries using Geomdl."""
 
 import numpy as np

--- a/src/meshpy/space_time/__init__.py
+++ b/src/meshpy/space_time/__init__.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +17,7 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module contains functionality to create space time meshes with
 MeshPy."""

--- a/src/meshpy/space_time/beam_to_space_time.py
+++ b/src/meshpy/space_time/beam_to_space_time.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Convert a MeshPy beam to a space time surface mesh."""
 
 from typing import Callable, Dict, List, Tuple, Type, Union, cast

--- a/src/meshpy/utils/__init__.py
+++ b/src/meshpy/utils/__init__.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +17,6 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """MeshPy utilities."""

--- a/src/meshpy/utils/environment.py
+++ b/src/meshpy/utils/environment.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Helper functions to interact with the MeshPy environment."""
 
 import os

--- a/src/meshpy/utils/nodes.py
+++ b/src/meshpy/utils/nodes.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Helper functions to find, filter and interact with nodes."""
 
 import numpy as np

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +17,6 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This module tests MeshPy."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Testing framework infrastructure."""
 
 import json

--- a/tests/create_cubit_input.py
+++ b/tests/create_cubit_input.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This script creates solid input files with CubitPy which are then used in
 MeshPy testing."""
 

--- a/tests/test_abaqus.py
+++ b/tests/test_abaqus.py
@@ -1,13 +1,7 @@
 # -*- coding: utf-8 -*-
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +18,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This script is used to test the creation of Abaqus input files."""
 
 import numpy as np

--- a/tests/test_cosserat_curve.py
+++ b/tests/test_cosserat_curve.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Test the functionality of the Cosserat curve module."""
 
 import numpy as np

--- a/tests/test_create_cubit_input.py
+++ b/tests/test_create_cubit_input.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Test that the input files created with CubitPy are up to date."""
 
 import pytest

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,13 +1,7 @@
 # -*- coding: utf-8 -*-
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +18,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This script is used to test the examples."""
 
 import pytest

--- a/tests/test_four_c.py
+++ b/tests/test_four_c.py
@@ -1,13 +1,7 @@
 # -*- coding: utf-8 -*-
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +18,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This script is used to test the functionality of MeshPy for creating 4C
 input files."""
 

--- a/tests/test_four_c_simulation.py
+++ b/tests/test_four_c_simulation.py
@@ -1,13 +1,7 @@
 # -*- coding: utf-8 -*-
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +18,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This script is used to simulate 4C input files created with MeshPy."""
 
 import os

--- a/tests/test_function_utilities.py
+++ b/tests/test_function_utilities.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This script is used to test the functionality of the meshpy.function_utility
 module."""
 

--- a/tests/test_geometric_search.py
+++ b/tests/test_geometric_search.py
@@ -1,13 +1,7 @@
 # -*- coding: utf-8 -*-
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +18,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This script is used to test the functionality of the meshpy.geometric_search
 module."""
 

--- a/tests/test_header_functions.py
+++ b/tests/test_header_functions.py
@@ -1,13 +1,7 @@
 # -*- coding: utf-8 -*-
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +18,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This script is used to test the header functions."""
 
 import pytest

--- a/tests/test_input_file_utils.py
+++ b/tests/test_input_file_utils.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This script is used to test the functionality of the input file utils."""
 
 from meshpy.core.mesh import Mesh

--- a/tests/test_mesh_creation_functions.py
+++ b/tests/test_mesh_creation_functions.py
@@ -1,13 +1,7 @@
 # -*- coding: utf-8 -*-
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +18,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This script is used to test the mesh creation functions."""
 
 import re

--- a/tests/test_meshpy.py
+++ b/tests/test_meshpy.py
@@ -1,13 +1,7 @@
 # -*- coding: utf-8 -*-
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +18,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This script is used to test the functionality of the meshpy module."""
 
 import os

--- a/tests/test_nurbs.py
+++ b/tests/test_nurbs.py
@@ -1,13 +1,7 @@
 # -*- coding: utf-8 -*-
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +18,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This script is used to test the mesh creation functions for NURBS."""
 
 import numpy as np

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Create a couple of different mesh cases and test the performance."""
 
 import time

--- a/tests/test_rotations.py
+++ b/tests/test_rotations.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This script is used to test the functionality of the Rotation class in the
 meshpy module."""
 

--- a/tests/test_space_time.py
+++ b/tests/test_space_time.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Test the MeshPy beam to space-time surface functionality."""
 
 import numpy as np

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Test utilities of MeshPy."""
 
 from meshpy.core.node import Node

--- a/tutorial/tutorial.py
+++ b/tutorial/tutorial.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """This script contains a tutorial for meshpy.
 
 Most basic functionality is covered by this tutorial. For more

--- a/website/docs/source/conf.py
+++ b/website/docs/source/conf.py
@@ -1,12 +1,6 @@
-# MeshPy: A beam finite element input generator
+# The MIT License (MIT)
 #
-# MIT License
-#
-# Copyright (c) 2018-2025
-#     Ivo Steinbrecher
-#     Institute for Mathematics and Computer-Based Simulation
-#     Universitaet der Bundeswehr Muenchen
-#     https://www.unibw.de/imcs-en
+# Copyright (c) 2018-2025 MeshPy Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +17,8 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 
 # Configuration file for the Sphinx documentation builder.
 #


### PR DESCRIPTION
Successor of #236 

Closes #234 

@isteinbrecher now this works as expected.

> Works for me. Is there any reason you did not force push to this branch?

Regarding this - I did not want to rebase everything and I took some sort of manual approach to update all licenses because the pre-commit hook always copies in a second license above the first one.

> should we maybe also add the website or GitHub link there?

I would not add the website or the github repo - the license should be tied to the code and not the hosting website or repo

Regarding the additions of the MeshPy description - I tried the following things: 

```
The MIT License (MIT)

Copyright (c) 2018-2025 MeshPy Authors

Permission is hereby granted, free of charge, to any person obtaining a copy
....
```

was successfully recognized by Github on my fork

```
The MIT License (MIT)

MeshPy: A general purpose 3D beam finite element input generator
Copyright (c) 2018-2025 MeshPy Authors

Permission is hereby granted, free of charge, to any person obtaining a copy
....
```

was not recognized at all

```
The MIT License (MIT)

Copyright (c) 2018-2025 MeshPy Authors
MeshPy: A general purpose 3D beam finite element input generator


Permission is hereby granted, free of charge, to any person obtaining a copy
....
```

was also not recognized at all

I would, therefore, stay with the here propposed approach so it is recognized by Github. We could differentiate between a file header and our license - like we do it in 4C. But I think for this repo we could save us the hassle to maintain differing license formats.

If ok for you we could merge