### PR TITLE
Allow math in pdoc documenation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build API documentation
         run: |
           source python-workflow-venv/bin/activate
-          pdoc --output-dir api-documentation src/meshpy/
+          pdoc --math --output-dir api-documentation src/meshpy/
       - name: Upload API documentation artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build API documentation
         run: |
           source python-workflow-venv/bin/activate
-          pdoc --math --output-dir api-documentation src/meshpy/
+          pdoc --math --docformat google --output-dir api-documentation src/meshpy/
       - name: Upload API documentation artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This allows mathjax formatted math in the API documentation.