### PR TITLE
Improve coupling checks

### DIFF
--- a/src/meshpy/core/coupling.py
+++ b/src/meshpy/core/coupling.py
@@ -96,11 +96,11 @@ class Coupling(BoundaryConditionBase):
             return
 
         nodes = self.geometry_set.get_points()
-        pos = np.zeros([len(nodes), 3])
+        diff = np.zeros([len(nodes), 3])
         for i, node in enumerate(nodes):
             # Get the difference to the first node
-            pos[i, :] = node.coordinates - nodes[0].coordinates
-        if np.linalg.norm(pos) > mpy.eps_pos:
+            diff[i, :] = node.coordinates - nodes[0].coordinates
+        if np.max(np.linalg.norm(diff, axis=1)) > mpy.eps_pos:
             raise ValueError(
                 "The nodes given to Coupling do not have the same position."
             )

--- a/tests/test_meshpy.py
+++ b/tests/test_meshpy.py
@@ -1404,6 +1404,41 @@ def test_meshpy_point_couplings(
     )
 
 
+def test_meshpy_point_couplings_check():
+    """Test that the check for points at the same spatial position works for
+    point couplings."""
+
+    def get_nodes(scale_factor):
+        """Return a list with nodes to be added to a coupling condition.
+
+        The coordinates are modified such that they are close to each
+        other within a radius of mpy.eps_pos * scale_factor
+        """
+        coordinates = np.zeros((10, 3))
+        ref_point = [1, 2, 3]
+        coordinates[0] = ref_point
+        for i in range(1, 10):
+            coordinates[i] = ref_point
+            for i_dir in range(3):
+                factor = 2 * ((i + i_dir % 3) % 2) - 1
+                # Multiply with 0.5 here, because we add the tolerance in + and - direction
+                coordinates[i, i_dir] += factor * mpy.eps_pos * scale_factor
+        return [Node(coord) for coord in coordinates]
+
+    # This should work, as the points are within the global tolerance of each
+    # other
+    Coupling(get_nodes(0.5), None, None)
+
+    with pytest.raises(ValueError):
+        # This should fail, as the points are not within the global tolerance
+        # of each other
+        Coupling(get_nodes(1.0), None, None)
+
+    # This should work, as the points are not within the global tolerance of
+    # each other but we dont perform the check
+    Coupling(get_nodes(1.0), None, None, check_at_init=False)
+
+
 def test_meshpy_vtk_writer(
     assert_results_equal, get_corresponding_reference_file_path, tmp_path
 ):


### PR DESCRIPTION
With the previous coupling checks, we had a bug in the evaluation of the distance. This fixes this and adds a test case.