### PR TITLE
Update `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ _site
 *.lock
 website/public/
 
+# Documentation
+api-documentation/
+
 # Don't ignore directory of Github workflows
 !.github
 !.pre-commit-config.yaml


### PR DESCRIPTION
Add the default api documentation folder to the `.gitignore. file.