### PR TITLE
Fix node locsys condition

### DIFF
--- a/src/meshpy/four_c/dbc_monitor.py
+++ b/src/meshpy/four_c/dbc_monitor.py
@@ -32,6 +32,7 @@ from meshpy.four_c.boundary_condition import BoundaryCondition
 from meshpy.four_c.function import Function
 from meshpy.four_c.function_utility import (
     create_linear_interpolation_function,
+    ensure_length_of_function_array,
 )
 from meshpy.four_c.input_file import InputFile
 
@@ -176,15 +177,7 @@ def add_point_neuman_condition_to_input_file(
             f"The forces vector must have dimensions [3x1] not [{force.size}x1]"
         )
 
-    # repeat function automatically if it is only provided once
-    if len(function_array) == 1:
-        function_array.append(function_array[0])
-        function_array.append(function_array[0])
-
-    if len(function_array) != 3:
-        raise ValueError(
-            f"The function array must have length 3 not {len(function_array)}."
-        )
+    function_array = ensure_length_of_function_array(function_array, 3)
 
     # Add the function to the input file, if they are not previously added.
     for function in function_array:

--- a/src/meshpy/four_c/function_utility.py
+++ b/src/meshpy/four_c/function_utility.py
@@ -22,6 +22,8 @@
 """This module implements utility functions to create 4C space time
 function."""
 
+from typing import List
+
 import numpy as np
 
 from meshpy.four_c.function import Function
@@ -77,3 +79,26 @@ def create_linear_interpolation_function(
 
     variable_string = create_linear_interpolation_string(t, values, variable_name="var")
     return Function(f"{function_type} var\n" + variable_string)
+
+
+def ensure_length_of_function_array(
+    function_array: List[Function], length: int = 3
+) -> List[Function]:
+    """Performs size check of a function array and appends the function array to the given length, if a list with only one item is provided.
+    Args:
+        function_array: list with functions
+        length: expected length of function array
+
+    Returns:
+        function_array: list with functions with provided length
+    """
+
+    # extend items of function automatically if it is only provided once
+    if len(function_array) == 1:
+        return function_array * length
+
+    if len(function_array) != length:
+        raise ValueError(
+            f"The function array must have length {length} not {len(function_array)}."
+        )
+    return function_array

--- a/src/meshpy/four_c/function_utility.py
+++ b/src/meshpy/four_c/function_utility.py
@@ -81,10 +81,10 @@ def create_linear_interpolation_function(
     return Function(f"{function_type} var\n" + variable_string)
 
 
-def ensure_length_of_function_array(
-    function_array: List[Function], length: int = 3
-) -> List[Function]:
-    """Performs size check of a function array and appends the function array to the given length, if a list with only one item is provided.
+def ensure_length_of_function_array(function_array: List, length: int = 3):
+    """Performs size check of a function array and appends the function array
+    to the given length, if a list with only one item is provided.
+
     Args:
         function_array: list with functions
         length: expected length of function array
@@ -95,7 +95,7 @@ def ensure_length_of_function_array(
 
     # extend items of function automatically if it is only provided once
     if len(function_array) == 1:
-        return function_array * length
+        function_array = function_array * length
 
     if len(function_array) != length:
         raise ValueError(

--- a/tests/reference-files/test_meshpy_locsys_condition.dat
+++ b/tests/reference-files/test_meshpy_locsys_condition.dat
@@ -10,14 +10,24 @@
 MAT 1 MAT_BeamReissnerElastHyper YOUNG -1.0 POISSONRATIO 0.0 DENS 0.0 CROSSAREA 3.141592653589793 SHEARCORR 1 MOMINPOL 1.5707963267948966 MOMIN2 0.7853981633974483 MOMIN3 0.7853981633974483
 --------------------------------------------------------------------------FUNCT1
 SYMBOLIC_FUNCTION_OF_SPACE_TIME t
+--------------------------------------------------------------------------FUNCT2
+SYMBOLIC_FUNCTION_OF_SPACE_TIME 2.0*t
 --------------------------------------------------DESIGN POINT DIRICH CONDITIONS
 E 1 NUMDOF 9 ONOFF 1 1 1 1 1 1 0 0 0 VAL 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 FUNCT 0 0 0 0 0 0 0 0 0
 E 2 NUMDOF 9 ONOFF 1 0 0 0 0 0 0 0 0 VAL 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 FUNCT 1 0 0 0 0 0 0 0 0
 --------------------------------------------------DESIGN POINT LOCSYS CONDITIONS
-E 2 ROTANGLE 0.0 0.0 0.1 FUNCT 0 0 0 USEUPDATEDNODEPOS 0 USECONSISTENTNODENORMAL 0
+E 2 ROTANGLE 0.0 0.0 0.1 FUNCT 0 0 0 USEUPDATEDNODEPOS 0
+E 3 ROTANGLE 0.0 0.0 0.1 FUNCT 1 2 2 USEUPDATEDNODEPOS 1
+---------------------------------------------------DESIGN LINE LOCSYS CONDITIONS
+E 1 ROTANGLE 0.0 0.0 0.1 FUNCT 2 2 2 USEUPDATEDNODEPOS 1 USECONSISTENTNODENORMAL 1
 -------------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 3 DNODE 2
+NODE 1 DNODE 3
+-------------------------------------------------------------DLINE-NODE TOPOLOGY
+NODE 1 DLINE 1
+NODE 2 DLINE 1
+NODE 3 DLINE 1
 ---------------------------------------------------------------------NODE COORDS
 NODE 1 COORD 2.5 2.5 2.5
 NODE 2 COORD 3.5 2.5 2.5

--- a/tests/test_four_c.py
+++ b/tests/test_four_c.py
@@ -237,8 +237,9 @@ def test_meshpy_locsys_condition(
 ):
     """Test case for point locsys condition for beams.
 
-    The testcase is similar to beam3r_herm2line3_static_locsys.dat, but
-    with simpler material.
+    The testcase is adapted from to beam3r_herm2line3_static_locsys.dat.
+    However it has a simpler material, and an additional line locsys
+    condition.
     """
 
     # Create the input file with function and material.
@@ -274,6 +275,39 @@ def test_meshpy_locsys_condition(
 
     # Add locsys condition with rotation
     input_file.add(LocSysCondition(beam_set["end"], Rotation([0, 0, 1], 0.1)))
+
+    # Add line Function with function array
+
+    fun_2 = Function("SYMBOLIC_FUNCTION_OF_SPACE_TIME 2.0*t")
+    input_file.add(fun_2)
+
+    # Check if the LocSys condition is added correctly for a line with additional options.
+    input_file.add(
+        LocSysCondition(
+            GeometrySet(beam_set["line"]),
+            Rotation(
+                [0, 0, 1],
+                0.1,
+            ),
+            function_array=[fun_2],
+            update_node_position=True,
+            use_consistent_node_normal=True,
+        )
+    )
+
+    # Check that the Locsys condition works with 3 given functions
+    input_file.add(
+        LocSysCondition(
+            GeometrySet(beam_set["start"]),
+            Rotation(
+                [0, 0, 1],
+                0.1,
+            ),
+            function_array=[fun, fun_2, fun_2],
+            update_node_position=True,
+            use_consistent_node_normal=False,
+        )
+    )
 
     # Compare with the reference solution.
     assert_results_equal(get_corresponding_reference_file_path(), input_file)


### PR DESCRIPTION
### Previous state
The locsys condition in 4c were only written correct for the line geometry, namely:

`DESIGN LINE LOCSYS CONDITIONS`
`E 3 ROTANGLE 0.0 0.0 0.0 FUNCT 0 0 0 USEUPDATEDNODEPOS 0 USECONSISTENTNODENORMAL 0`

However, the option `USEUPDATEDNODEPOS` should be removed for a point and volume geometry resulting in the condition string:
`DESIGN POINT/VOL LOCSYS CONDITIONS`
`E 2 ROTANGLE 0.0 0.0 0.0 FUNCT 0 0 0 USEUPDATEDNODEPOS 0 `


### This MR 

- extracts a small function utility to ensure correct length of the user provided function array 
- checks the provided geometry before initialization of the LocSys condition to ensure that the correct string is added
- adds the possibility to provide a `function array `, `update_node_position` and `use_consistent_node_normal` to the LocSys condition
- adds all changes to the testcase. 