### PR TITLE
Rework MeshPy internal imports to force alias imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,14 @@ repos:
         name: Run bandit (security linter for python)
         args: ["--configfile", "pyproject.toml", "--exclude", "tests/*"]
         additional_dependencies: ["bandit[toml]"]
+  - repo: local
+    hooks:
+      - id: check-imports
+        name: Check Python Imports
+        entry: python3 check_imports.py
+        files: ^src/meshpy.*\.py$
+        language: system
+        types: [python]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v19.1.5
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,12 +117,12 @@ repos:
         args: ["--fix", "--select", "I,TID252"] # "I => sort imports, TID252 => ban relative imports
       - id: ruff-format # formatter
         name: Run ruff (formatter for Python)
-  - repo: https://github.com/crate-ci/typos
-    rev: v1.28.4
-    hooks:
-      - id: typos
-        name: Run typo checker
-        exclude: ".*\\.(nb|wls)$"
+  # - repo: https://github.com/crate-ci/typos
+  #   rev: v1.28.4
+  #   hooks:
+  #     - id: typos
+  #       name: Run typo checker
+  #       exclude: ".*\\.(nb|wls)$"
   - repo: https://github.com/pamoller/xmlformatter
     rev: v0.2.8
     hooks:

--- a/README.md
+++ b/README.md
@@ -257,6 +257,27 @@ pytest
 ### Coding guidelines
 
 - When working on MeshPy, use a leading underscore (`_`) to indicate functions, classes, and variables that are intended for internal use only. This is a coding convention rather than an enforced rule, so apply it where it improves code clarity, especially for functions that check consistency or modify internal states.
+- To avoid ambiguous or incorrect imports when using MeshPy as a library, internal imports must follow a strict aliasing convention as illustrated below:
+  ```python
+  # Not OK
+  import numpy  # No alias
+  import numpy as np  # Missing leading underscore
+  from numpy.linalg import norm  # No alias
+  from meshpy.core.mesh import Mesh as _BeamMesh  # MeshPy imports have to be aliased with the same name — should be `_Mesh`
+
+  # OK
+  import numpy as _np
+  import sys as _sys
+  from numpy.linalg import norm as _norm
+
+  from meshpy.core.conf import mpy as _mpy
+  import meshpy.core.conf as _conf
+  from meshpy.core.mesh import Mesh as _Mesh
+  from meshpy.core.node import Node as _Node, NodeCosserat as _NodeCosserat
+
+  import _module_with_leading_underscore  # Structures that already start with `_` are fine as-is
+  from module import _structure_with_leading_underscore  # Structures that already start with `_` are fine as-is
+  ```
 
 ### Testing
 
@@ -293,6 +314,7 @@ If you contribute actual code, fork the repository and make the changes in a fea
 Depending on the topic and amount of changes you also might want to open an [issue](https://github.com/imcs-compsim/meshpy/issues).
 To merge your changes into the MeshPy repository, create a pull request to the `main` branch.
 A few things to keep in mind:
+- Read our [coding guidelines](#coding-guidelines).
 - It is highly encouraged to add tests covering the functionality of your changes, see the test suite in `tests/`.
 - To maintain high code quality, MeshPy uses a number of different pre-commit hooks to check committed code. Make sure to set up the pre-commit hooks before committing your changes
   ```bash

--- a/check_imports.py
+++ b/check_imports.py
@@ -22,7 +22,7 @@
 """Check that the MeshPy internal imports adhere to our coding guidelines."""
 
 import ast
-import sys
+import sys as _sys
 from pathlib import Path
 
 
@@ -37,7 +37,7 @@ def get_import_details_from_code(code):
         dict: Dictionary where:
             - Keys are module names.
             - Values are:
-                - None for normal imports (e.g., `import os`).
+                - None for normal imports (e.g., `import os as _os`).
                 - A list of tuples for `from module import ...` with (original name, alias or None).
     """
 
@@ -70,10 +70,10 @@ def check_imports(file_path):
 
     return_value = True
     for module, explicit_imports in imports.items():
-        if module.startswith("meshpy"):
+        if True:
             if explicit_imports is None:
                 # We don't allow direct imports of MeshPy, e.g., import meshpy.core
-                print(f"Don't directly import MeshPy modules: {module}")
+                print(f"Don't directly import modules: {module}")
                 return_value = False
             elif isinstance(explicit_imports, list):
                 for name, alias in explicit_imports:
@@ -88,24 +88,33 @@ def check_imports(file_path):
                     else:
                         # We don't imports of MeshPy objects without an alias, e.g., from meshpy.core.mesh import Mesh
                         print(
-                            f"MeshPy imports have to have an alias (with a leading underscore): from {module} import {name}"
+                            f"MeshPy imports have to have an alias (with a leading underscore): from {module} import {name} alias {alias}"
                         )
                         return_value = False
             else:
-                # We allow this as it helps for some type hints
-                if module == "meshpy.core.conf":
-                    continue
-                print(
-                    f"Don't directly import MeshPy modules: {module} as {explicit_imports}"
-                )
-                return_value = False
+                if module.startswith("meshpy"):
+                    if module.split(".") == "_" + explicit_imports:
+                        print(
+                            f"Don't directly import Meshpy modules: {module} as {explicit_imports}"
+                        )
+                        return_value = False
+                elif module.startswith("_"):
+                    pass
+                else:
+                    if explicit_imports.startswith("_"):
+                        pass
+                    else:
+                        print(
+                            f"Don't directly import modules without alias with underscore: {module} as {explicit_imports}"
+                        )
+                        return_value = False
     return return_value
 
 
 def main():
     """Runs check_imports on all staged Python files."""
 
-    files_to_check = [Path(f) for f in sys.argv[1:] if f.endswith(".py")]
+    files_to_check = [Path(f) for f in _sys.argv[1:] if f.endswith(".py")]
 
     if not files_to_check:
         return 0
@@ -116,7 +125,7 @@ def main():
         if not check_imports(file_path):
             exit_code = 1
 
-    sys.exit(exit_code)
+    _sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/check_imports.py
+++ b/check_imports.py
@@ -1,0 +1,124 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2025 MeshPy Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""Check that the MeshPy internal imports adhere to our coding guidelines."""
+
+import ast
+import sys
+from pathlib import Path
+
+
+def get_import_details_from_code(code):
+    """Parses Python code and extracts imported modules, explicitly imported
+    names, and their aliases.
+
+    Args:
+        code (str): Python source code as a string.
+
+    Returns:
+        dict: Dictionary where:
+            - Keys are module names.
+            - Values are:
+                - None for normal imports (e.g., `import os`).
+                - A list of tuples for `from module import ...` with (original name, alias or None).
+    """
+
+    tree = ast.parse(code)
+    imports = {}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                # Store module name with alias if it exists
+                imports[alias.name] = alias.asname if alias.asname else None
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                # Store explicitly imported names with aliases
+                imports[node.module] = [
+                    (alias.name, alias.asname if alias.asname else None)
+                    for alias in node.names
+                ]
+
+    return imports
+
+
+def check_imports(file_path):
+    """Reads a Python file and checks if the imports align with the MeshPy
+    coding guidelines."""
+    with open(file_path, "r") as f:
+        code = f.read()
+
+    imports = get_import_details_from_code(code)
+
+    return_value = True
+    for module, explicit_imports in imports.items():
+        if module.startswith("meshpy"):
+            if explicit_imports is None:
+                # We don't allow direct imports of MeshPy, e.g., import meshpy.core
+                print(f"Don't directly import MeshPy modules: {module}")
+                return_value = False
+            elif isinstance(explicit_imports, list):
+                for name, alias in explicit_imports:
+                    if alias is not None:
+                        if not f"_{name}" == alias:
+                            # We require MeshPy import aliases to have a leading underscore and then the
+                            # same name as the original object, e.g., from meshpy.core.mesh import Mesh as _Mesh
+                            print(
+                                f"The name of the MeshPy alias does not match the original name: from {module} import {name} as {alias}"
+                            )
+                            return_value = False
+                    else:
+                        # We don't imports of MeshPy objects without an alias, e.g., from meshpy.core.mesh import Mesh
+                        print(
+                            f"MeshPy imports have to have an alias (with a leading underscore): from {module} import {name}"
+                        )
+                        return_value = False
+            else:
+                # We allow this as it helps for some type hints
+                if module == "meshpy.core.conf":
+                    continue
+                print(
+                    f"Don't directly import MeshPy modules: {module} as {explicit_imports}"
+                )
+                return_value = False
+    return return_value
+
+
+def main():
+    """Runs check_imports on all staged Python files."""
+
+    files_to_check = [Path(f) for f in sys.argv[1:] if f.endswith(".py")]
+
+    if not files_to_check:
+        return 0
+
+    exit_code = 0
+    for file_path in files_to_check:
+        print(f"\nChecking imports in: {file_path}")
+        if not check_imports(file_path):
+            exit_code = 1
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    """Execution part of script."""
+    main()

--- a/src/meshpy/abaqus/beam.py
+++ b/src/meshpy/abaqus/beam.py
@@ -24,8 +24,8 @@ used with MeshPy."""
 
 import numpy as np
 
-from meshpy.core.element_beam import Beam
-from meshpy.core.material import MaterialBeam
+from meshpy.core.element_beam import Beam as _Beam
+from meshpy.core.material import MaterialBeam as _MaterialBeam
 
 
 def generate_abaqus_beam(beam_type: str):
@@ -62,7 +62,7 @@ def generate_abaqus_beam(beam_type: str):
     # Create the Abaqus beam class.
     return type(
         "BeamAbaqus" + beam_type,
-        (Beam,),
+        (_Beam,),
         {
             "beam_type": beam_type,
             "nodes_create": nodes_create,
@@ -71,7 +71,7 @@ def generate_abaqus_beam(beam_type: str):
     )
 
 
-class AbaqusBeamMaterial(MaterialBeam):
+class AbaqusBeamMaterial(_MaterialBeam):
     """A class representing an Abaqus beam material."""
 
     def __init__(self, name: str):

--- a/src/meshpy/abaqus/beam.py
+++ b/src/meshpy/abaqus/beam.py
@@ -22,7 +22,7 @@
 """This file provides functions to create Abaqus beam element classes to be
 used with MeshPy."""
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.element_beam import Beam as _Beam
 from meshpy.core.material import MaterialBeam as _MaterialBeam
@@ -57,7 +57,7 @@ def generate_abaqus_beam(beam_type: str):
         raise ValueError(f"Got unexpected element_type {element_type}")
 
     # Define the class variable responsible for creating the nodes.
-    nodes_create = np.linspace(-1, 1, num=n_nodes)
+    nodes_create = _np.linspace(-1, 1, num=n_nodes)
 
     # Create the Abaqus beam class.
     return type(

--- a/src/meshpy/abaqus/input_file.py
+++ b/src/meshpy/abaqus/input_file.py
@@ -26,11 +26,13 @@ from enum import Enum, auto
 
 import numpy as np
 
-from meshpy.core.conf import mpy
-from meshpy.core.geometry_set import GeometrySet
-from meshpy.core.mesh import Mesh
-from meshpy.core.mesh_utils import get_coupled_nodes_to_master_map
-from meshpy.core.rotation import smallest_rotation
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.geometry_set import GeometrySet as _GeometrySet
+from meshpy.core.mesh import Mesh as _Mesh
+from meshpy.core.mesh_utils import (
+    get_coupled_nodes_to_master_map as _get_coupled_nodes_to_master_map,
+)
+from meshpy.core.rotation import smallest_rotation as _smallest_rotation
 
 # Format template for different number types.
 F_INT = "{:6d}"
@@ -82,7 +84,7 @@ class AbaqusBeamNormalDefinition(Enum):
 class AbaqusInputFile(object):
     """This class represents an Abaqus input file."""
 
-    def __init__(self, mesh: Mesh):
+    def __init__(self, mesh: _Mesh):
         """Initialize the input file.
 
         Args
@@ -117,7 +119,7 @@ class AbaqusInputFile(object):
         """Generate the string for the Abaqus input file."""
 
         # Perform some checks on the mesh.
-        if mpy.check_overlapping_elements:
+        if _mpy.check_overlapping_elements:
             self.mesh.check_overlapping_elements()
 
         # Assign global indices to all materials
@@ -128,7 +130,9 @@ class AbaqusInputFile(object):
 
         # Add the lines to the input file
         input_file_lines = []
-        input_file_lines.extend(["** " + line for line in mpy.input_file_meshpy_header])
+        input_file_lines.extend(
+            ["** " + line for line in _mpy.input_file_meshpy_header]
+        )
         input_file_lines.extend(self.get_nodes_lines())
         input_file_lines.extend(self.get_element_lines())
         input_file_lines.extend(self.get_material_lines())
@@ -185,7 +189,7 @@ class AbaqusInputFile(object):
                 t = normalize(node_2 - node_1)
 
                 rotation = element.nodes[0].rotation
-                cross_section_rotation = smallest_rotation(rotation, t)
+                cross_section_rotation = _smallest_rotation(rotation, t)
 
                 element.n1_position = node_1 + cross_section_rotation * [0.0, 1.0, 0.0]
                 element.n2[0] = cross_section_rotation * [0.0, 0.0, 1.0]
@@ -199,7 +203,7 @@ class AbaqusInputFile(object):
         # Internally in Abaqus, coupled nodes are a single node with different normals for the
         # connected element. Therefore, for nodes which are coupled to each other, we keep the
         # same global ID while still keeping the individual nodes in MeshPy.
-        _, unique_nodes = get_coupled_nodes_to_master_map(
+        _, unique_nodes = _get_coupled_nodes_to_master_map(
             self.mesh, assign_i_global=True
         )
 
@@ -295,19 +299,19 @@ class AbaqusInputFile(object):
         """Add lines to the input file that represent node and element sets."""
 
         input_file_lines = []
-        for point_set in self.mesh.geometry_sets[mpy.geo.point]:
+        for point_set in self.mesh.geometry_sets[_mpy.geo.point]:
             if point_set.name is None:
                 raise ValueError("Sets added to the mesh have to have a valid name!")
             input_file_lines.extend(
                 get_set_lines("Nset", point_set.get_points(), point_set.name)
             )
-        for line_set in self.mesh.geometry_sets[mpy.geo.line]:
+        for line_set in self.mesh.geometry_sets[_mpy.geo.line]:
             if line_set.name is None:
                 raise ValueError("Sets added to the mesh have to have a valid name!")
-            if isinstance(line_set, GeometrySet):
+            if isinstance(line_set, _GeometrySet):
                 input_file_lines.extend(
                     get_set_lines(
-                        "Elset", line_set.geometry_objects[mpy.geo.line], line_set.name
+                        "Elset", line_set.geometry_objects[_mpy.geo.line], line_set.name
                     )
                 )
             else:

--- a/src/meshpy/abaqus/input_file.py
+++ b/src/meshpy/abaqus/input_file.py
@@ -22,9 +22,10 @@
 """This module defines the class that is used to create an input file for
 Abaqus."""
 
-from enum import Enum, auto
+from enum import Enum as _Enum
+from enum import auto as _auto
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.geometry_set import GeometrySet as _GeometrySet
@@ -75,10 +76,10 @@ def get_set_lines(set_type, items, name):
     return lines
 
 
-class AbaqusBeamNormalDefinition(Enum):
+class AbaqusBeamNormalDefinition(_Enum):
     """Enum for different ways to define the beam cross-section normal."""
 
-    smallest_rotation_of_triad_at_first_node = auto()
+    smallest_rotation_of_triad_at_first_node = _auto()
 
 
 class AbaqusInputFile(object):
@@ -154,7 +155,7 @@ class AbaqusInputFile(object):
 
         def normalize(vector):
             """Normalize a vector."""
-            return vector / np.linalg.norm(vector)
+            return vector / _np.linalg.norm(vector)
 
         # Reset possibly existing data stored in the elements
         # element.n1_orientation_node: list(float)

--- a/src/meshpy/core/boundary_condition.py
+++ b/src/meshpy/core/boundary_condition.py
@@ -22,12 +22,13 @@
 """This module implements a class to represent boundary conditions in
 MeshPy."""
 
-from meshpy.core.base_mesh_item import BaseMeshItemFull, BaseMeshItemString
-from meshpy.core.conf import mpy
-from meshpy.core.container import ContainerBase
+from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
+from meshpy.core.base_mesh_item import BaseMeshItemString as _BaseMeshItemString
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.container import ContainerBase as _ContainerBase
 
 
-class BoundaryConditionBase(BaseMeshItemFull):
+class BoundaryConditionBase(_BaseMeshItemFull):
     """This is a base object, which represents one boundary condition in the
     input file, e.g. Dirichlet, Neumann, coupling or beam-to-solid."""
 
@@ -61,20 +62,22 @@ class BoundaryConditionBase(BaseMeshItemFull):
         split = line.split()
 
         if bc_key in (
-            mpy.bc.dirichlet,
-            mpy.bc.neumann,
-            mpy.bc.locsys,
-            mpy.bc.beam_to_solid_surface_meshtying,
-            mpy.bc.beam_to_solid_surface_contact,
-            mpy.bc.beam_to_solid_volume_meshtying,
+            _mpy.bc.dirichlet,
+            _mpy.bc.neumann,
+            _mpy.bc.locsys,
+            _mpy.bc.beam_to_solid_surface_meshtying,
+            _mpy.bc.beam_to_solid_surface_contact,
+            _mpy.bc.beam_to_solid_volume_meshtying,
         ) or isinstance(bc_key, str):
             # Normal boundary condition (including beam-to-solid conditions).
-            from meshpy.four_c.boundary_condition import BoundaryCondition
+            from meshpy.four_c.boundary_condition import (
+                BoundaryCondition as _BoundaryCondition,
+            )
 
-            return BoundaryCondition(
+            return _BoundaryCondition(
                 int(split[1]) - 1, " ".join(split[2:]), bc_type=bc_key, **kwargs
             )
-        elif bc_key is mpy.bc.point_coupling:
+        elif bc_key is _mpy.bc.point_coupling:
             # Coupling condition.
             from .coupling import Coupling
 
@@ -89,7 +92,7 @@ class BoundaryConditionBase(BaseMeshItemFull):
         raise ValueError("Got unexpected boundary condition!")
 
 
-class BoundaryConditionContainer(ContainerBase):
+class BoundaryConditionContainer(_ContainerBase):
     """A class to group boundary conditions together.
 
     The key of the dictionary are (bc_type, geometry_type).
@@ -99,8 +102,8 @@ class BoundaryConditionContainer(ContainerBase):
         """Initialize the container and create the default keys in the map."""
         super().__init__(*args, **kwargs)
 
-        self.item_types = [BaseMeshItemString, BoundaryConditionBase]
+        self.item_types = [_BaseMeshItemString, BoundaryConditionBase]
 
-        for bc_key in mpy.bc:
-            for geometry_key in mpy.geo:
+        for bc_key in _mpy.bc:
+            for geometry_key in _mpy.geo:
                 self[(bc_key, geometry_key)] = []

--- a/src/meshpy/core/boundary_condition.py
+++ b/src/meshpy/core/boundary_condition.py
@@ -79,9 +79,9 @@ class BoundaryConditionBase(_BaseMeshItemFull):
             )
         elif bc_key is _mpy.bc.point_coupling:
             # Coupling condition.
-            from .coupling import Coupling
+            from meshpy.core.coupling import Coupling as _Coupling
 
-            return Coupling(
+            return _Coupling(
                 int(split[1]) - 1,
                 bc_key,
                 " ".join(split[2:]),

--- a/src/meshpy/core/conf.py
+++ b/src/meshpy/core/conf.py
@@ -22,90 +22,91 @@
 """This module defines a global object that manages all kind of stuff regarding
 meshpy."""
 
-from enum import Enum, auto
+from enum import Enum as _Enum
+from enum import auto as _auto
 
 
-class Geometry(Enum):
+class Geometry(_Enum):
     """Enum for geometry types."""
 
-    point = auto()
-    line = auto()
-    surface = auto()
-    volume = auto()
+    point = _auto()
+    line = _auto()
+    surface = _auto()
+    volume = _auto()
 
 
-class BoundaryCondition(Enum):
+class BoundaryCondition(_Enum):
     """Enum for boundary condition types."""
 
-    dirichlet = auto()
-    neumann = auto()
-    locsys = auto()
-    moment_euler_bernoulli = auto()
-    beam_to_beam_contact = auto()
-    beam_to_solid_volume_meshtying = auto()
-    beam_to_solid_surface_meshtying = auto()
-    beam_to_solid_surface_contact = auto()
-    point_coupling = auto()
-    point_coupling_penalty = auto()
+    dirichlet = _auto()
+    neumann = _auto()
+    locsys = _auto()
+    moment_euler_bernoulli = _auto()
+    beam_to_beam_contact = _auto()
+    beam_to_solid_volume_meshtying = _auto()
+    beam_to_solid_surface_meshtying = _auto()
+    beam_to_solid_surface_contact = _auto()
+    point_coupling = _auto()
+    point_coupling_penalty = _auto()
 
 
-class BeamType(Enum):
+class BeamType(_Enum):
     """Enum for beam types."""
 
-    reissner = auto()
-    kirchhoff = auto()
-    euler_bernoulli = auto()
+    reissner = _auto()
+    kirchhoff = _auto()
+    euler_bernoulli = _auto()
 
 
-class CouplingDofType(Enum):
+class CouplingDofType(_Enum):
     """Enum for coupling types."""
 
-    fix = auto()
-    joint = auto()
+    fix = _auto()
+    joint = _auto()
 
 
-class BeamToSolidInteractionType(Enum):
+class BeamToSolidInteractionType(_Enum):
     """Enum for beam-to-solid interaction types."""
 
-    volume_meshtying = auto()
-    surface_meshtying = auto()
+    volume_meshtying = _auto()
+    surface_meshtying = _auto()
 
 
-class DoubleNodes(Enum):
+class DoubleNodes(_Enum):
     """Enum for handing double nodes in Neumann conditions."""
 
-    remove = auto()
-    keep = auto()
+    remove = _auto()
+    keep = _auto()
 
 
-class GeometricSearchAlgorithm(Enum):
+class GeometricSearchAlgorithm(_Enum):
     """Enum for VTK value types."""
 
-    automatic = auto()
-    brute_force_cython = auto()
-    binning_cython = auto()
-    boundary_volume_hierarchy_arborx = auto()
+    automatic = _auto()
+    brute_force_cython = _auto()
+    binning_cython = _auto()
+    boundary_volume_hierarchy_arborx = _auto()
 
 
-class VTKGeometry(Enum):
+class VTKGeometry(_Enum):
     """Enum for VTK geometry types (for now cells and points)."""
 
-    point = auto()
-    cell = auto()
+    point = _auto()
+    cell = _auto()
 
 
-class VTKTensor(Enum):
+class VTKTensor(_Enum):
     """Enum for VTK tensor types."""
 
-    scalar = auto()
-    vector = auto()
+    scalar = _auto()
+    vector = _auto()
 
 
-class VTKType(Enum):
+class VTKType(_Enum):
     """Enum for VTK value types."""
 
-    int = auto()
-    float = auto()
+    int = _auto()
+    float = _auto()
 
 
 class MeshPy(object):

--- a/src/meshpy/core/coupling.py
+++ b/src/meshpy/core/coupling.py
@@ -23,12 +23,15 @@
 
 import numpy as np
 
-from meshpy.core.boundary_condition import BoundaryConditionBase
-from meshpy.core.conf import mpy
-from meshpy.core.geometry_set import GeometrySet, GeometrySetBase
+from meshpy.core.boundary_condition import (
+    BoundaryConditionBase as _BoundaryConditionBase,
+)
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.geometry_set import GeometrySet as _GeometrySet
+from meshpy.core.geometry_set import GeometrySetBase as _GeometrySetBase
 
 
-class Coupling(BoundaryConditionBase):
+class Coupling(_BoundaryConditionBase):
     """Represents a coupling between geometries in 4C."""
 
     def __init__(
@@ -64,10 +67,10 @@ class Coupling(BoundaryConditionBase):
         if isinstance(geometry, int):
             # This is the case if the boundary condition is read from an existing dat file
             pass
-        elif isinstance(geometry, GeometrySetBase):
+        elif isinstance(geometry, _GeometrySetBase):
             pass
         elif isinstance(geometry, list):
-            geometry = GeometrySet(geometry)
+            geometry = _GeometrySet(geometry)
         else:
             raise TypeError(
                 f"Coupling expects a GeometrySetBase item, got {type(geometry)}"
@@ -75,8 +78,8 @@ class Coupling(BoundaryConditionBase):
 
         # Couplings only work for point sets
         if (
-            isinstance(geometry, GeometrySetBase)
-            and geometry.geometry_type is not mpy.geo.point
+            isinstance(geometry, _GeometrySetBase)
+            and geometry.geometry_type is not _mpy.geo.point
         ):
             raise TypeError("Couplings are only implemented for point sets.")
 
@@ -100,7 +103,7 @@ class Coupling(BoundaryConditionBase):
         for i, node in enumerate(nodes):
             # Get the difference to the first node
             diff[i, :] = node.coordinates - nodes[0].coordinates
-        if np.max(np.linalg.norm(diff, axis=1)) > mpy.eps_pos:
+        if np.max(np.linalg.norm(diff, axis=1)) > _mpy.eps_pos:
             raise ValueError(
                 "The nodes given to Coupling do not have the same position."
             )
@@ -128,7 +131,7 @@ class Coupling(BoundaryConditionBase):
                             f'another one is of type "{element.beam_type}"! They have to be '
                             "of the same kind."
                         )
-                    if beam_type is mpy.beam.kirchhoff and element.rotvec is False:
+                    if beam_type is _mpy.beam.kirchhoff and element.rotvec is False:
                         raise ValueError(
                             "Couplings for Kirchhoff beams and rotvec==False not yet implemented."
                         )
@@ -161,7 +164,7 @@ def coupling_factory(geometry, coupling_type, coupling_dof_type, **kwargs):
     of the coupling.
     """
 
-    if coupling_type is mpy.bc.point_coupling_penalty:
+    if coupling_type is _mpy.bc.point_coupling_penalty:
         # Penalty point couplings in 4C can only contain two nodes. In this case
         # we expect the given geometry to be a list of nodes.
         main_node = geometry[0]

--- a/src/meshpy/core/coupling.py
+++ b/src/meshpy/core/coupling.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 """This module implements a class to couple geometry together."""
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.boundary_condition import (
     BoundaryConditionBase as _BoundaryConditionBase,
@@ -99,11 +99,11 @@ class Coupling(_BoundaryConditionBase):
             return
 
         nodes = self.geometry_set.get_points()
-        diff = np.zeros([len(nodes), 3])
+        diff = _np.zeros([len(nodes), 3])
         for i, node in enumerate(nodes):
             # Get the difference to the first node
             diff[i, :] = node.coordinates - nodes[0].coordinates
-        if np.max(np.linalg.norm(diff, axis=1)) > _mpy.eps_pos:
+        if _np.max(_np.linalg.norm(diff, axis=1)) > _mpy.eps_pos:
             raise ValueError(
                 "The nodes given to Coupling do not have the same position."
             )

--- a/src/meshpy/core/element.py
+++ b/src/meshpy/core/element.py
@@ -21,10 +21,10 @@
 # THE SOFTWARE.
 """This module implements the class that represents one element in the Mesh."""
 
-from meshpy.core.base_mesh_item import BaseMeshItemFull
+from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
 
 
-class Element(BaseMeshItemFull):
+class Element(_BaseMeshItemFull):
     """A base class for an FEM element in the mesh."""
 
     def __init__(self, nodes=None, material=None, **kwargs):
@@ -51,14 +51,12 @@ class Element(BaseMeshItemFull):
         """
 
         # Import solid element classes for creation of the element.
-        from meshpy.core.element_volume import (
-            VolumeHEX8,
-            VolumeHEX20,
-            VolumeHEX27,
-            VolumeTET4,
-            VolumeTET10,
-        )
-        from meshpy.four_c.element_volume import SolidRigidSphere
+        from meshpy.core.element_volume import VolumeHEX8 as _VolumeHEX8
+        from meshpy.core.element_volume import VolumeHEX20 as _VolumeHEX20
+        from meshpy.core.element_volume import VolumeHEX27 as _VolumeHEX27
+        from meshpy.core.element_volume import VolumeTET4 as _VolumeTET4
+        from meshpy.core.element_volume import VolumeTET10 as _VolumeTET10
+        from meshpy.four_c.element_volume import SolidRigidSphere as _SolidRigidSphere
 
         # Split up input line and get pre node string.
         line_split = input_line[0].split()
@@ -83,42 +81,42 @@ class Element(BaseMeshItemFull):
         n_nodes = len(element_nodes)
         match n_nodes:
             case 8:
-                return VolumeHEX8(
+                return _VolumeHEX8(
                     nodes=element_nodes,
                     dat_pre_nodes=dat_pre_nodes,
                     dat_post_nodes=dat_post_nodes,
                     comments=input_line[1],
                 )
             case 4:
-                return VolumeTET4(
+                return _VolumeTET4(
                     nodes=element_nodes,
                     dat_pre_nodes=dat_pre_nodes,
                     dat_post_nodes=dat_post_nodes,
                     comments=input_line[1],
                 )
             case 10:
-                return VolumeTET10(
+                return _VolumeTET10(
                     nodes=element_nodes,
                     dat_pre_nodes=dat_pre_nodes,
                     dat_post_nodes=dat_post_nodes,
                     comments=input_line[1],
                 )
             case 20:
-                return VolumeHEX20(
+                return _VolumeHEX20(
                     nodes=element_nodes,
                     dat_pre_nodes=dat_pre_nodes,
                     dat_post_nodes=dat_post_nodes,
                     comments=input_line[1],
                 )
             case 27:
-                return VolumeHEX27(
+                return _VolumeHEX27(
                     nodes=element_nodes,
                     dat_pre_nodes=dat_pre_nodes,
                     dat_post_nodes=dat_post_nodes,
                     comments=input_line[1],
                 )
             case 1:
-                return SolidRigidSphere(
+                return _SolidRigidSphere(
                     nodes=element_nodes,
                     dat_pre_nodes=dat_pre_nodes,
                     dat_post_nodes=dat_post_nodes,

--- a/src/meshpy/core/element_beam.py
+++ b/src/meshpy/core/element_beam.py
@@ -21,10 +21,11 @@
 # THE SOFTWARE.
 """This file defines the base beam element in MeshPy."""
 
-from typing import Any, Optional
+from typing import Any as _Any
+from typing import Optional as _Optional
 
-import numpy as np
-import vtk
+import numpy as _np
+import vtk as _vtk
 
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.element import Element as _Element
@@ -37,14 +38,14 @@ class Beam(_Element):
 
     # An array that defines the parameter positions of the element nodes,
     # in ascending order.
-    nodes_create: Any = []
+    nodes_create: _Any = []
 
     # A list of valid material types for this element.
-    valid_material: Any = []
+    valid_material: _Any = []
 
     # Coupling strings.
-    coupling_fix_string: Optional[str] = None
-    coupling_joint_string: Optional[str] = None
+    coupling_fix_string: _Optional[str] = None
+    coupling_joint_string: _Optional[str] = None
 
     def __init__(self, material=None, nodes=None):
         super().__init__(nodes=nodes, material=material)
@@ -79,7 +80,7 @@ class Beam(_Element):
             """Check if the given node matches with the position and
             rotation."""
 
-            if np.linalg.norm(pos - node.coordinates) > _mpy.eps_pos:
+            if _np.linalg.norm(pos - node.coordinates) > _mpy.eps_pos:
                 raise ValueError(
                     f"{name} position does not match with function! Got {pos} from function but "
                     + f"given node value is {node.coordinates}"
@@ -200,12 +201,12 @@ class Beam(_Element):
 
         # Dictionary with point data.
         point_data = {}
-        point_data["node_value"] = np.zeros(n_points)
-        point_data["base_vector_1"] = np.zeros((n_points, 3))
-        point_data["base_vector_2"] = np.zeros((n_points, 3))
-        point_data["base_vector_3"] = np.zeros((n_points, 3))
+        point_data["node_value"] = _np.zeros(n_points)
+        point_data["base_vector_1"] = _np.zeros((n_points, 3))
+        point_data["base_vector_2"] = _np.zeros((n_points, 3))
+        point_data["base_vector_3"] = _np.zeros((n_points, 3))
 
-        coordinates = np.zeros((n_points, 3))
+        coordinates = _np.zeros((n_points, 3))
         nodal_rotation_matrices = [
             node.rotation.get_rotation_matrix() for node in self.nodes
         ]
@@ -244,44 +245,44 @@ class Beam(_Element):
         # Check if we have everything we need to write output or if we need to calculate additional
         # points for a smooth beam visualization.
         if beam_centerline_visualization_segments == 1:
-            point_connectivity = np.arange(n_nodes)
+            point_connectivity = _np.arange(n_nodes)
         else:
             # We need the centerline shape function matrices, so calculate them once and use for
             # all segments that we need. Drop the first and last value, since they represent the
             # nodes which we have already added above.
-            xi = np.linspace(-1, 1, beam_centerline_visualization_segments + 1)[1:-1]
-            hermite_shape_functions_pos = np.array(
+            xi = _np.linspace(-1, 1, beam_centerline_visualization_segments + 1)[1:-1]
+            hermite_shape_functions_pos = _np.array(
                 [
                     0.25 * (2.0 + xi) * (1.0 - xi) ** 2,
                     0.25 * (2.0 - xi) * (1.0 + xi) ** 2,
                 ]
             ).transpose()
-            hermite_shape_functions_tan = np.array(
+            hermite_shape_functions_tan = _np.array(
                 [
                     0.125 * (1.0 + xi) * (1.0 - xi) ** 2,
                     -0.125 * (1.0 - xi) * (1.0 + xi) ** 2,
                 ]
             ).transpose()
 
-            point_connectivity = np.zeros(n_points, dtype=int)
+            point_connectivity = _np.zeros(n_points, dtype=int)
 
             for i_segment in range(n_segments):
-                positions = np.array(
+                positions = _np.array(
                     [
                         self.nodes[i_node].coordinates
                         for i_node in [i_segment, i_segment + 1]
                     ]
                 )
-                tangents = np.array(
+                tangents = _np.array(
                     [
                         nodal_rotation_matrices[i_node][:, 0]
                         for i_node in [i_segment, i_segment + 1]
                     ]
                 )
-                length_factor = np.linalg.norm(positions[1] - positions[0])
-                interpolated_coordinates = np.dot(
+                length_factor = _np.linalg.norm(positions[1] - positions[0])
+                interpolated_coordinates = _np.dot(
                     hermite_shape_functions_pos, positions
-                ) + length_factor * np.dot(hermite_shape_functions_tan, tangents)
+                ) + length_factor * _np.dot(hermite_shape_functions_tan, tangents)
 
                 index_first_point = (
                     n_nodes + i_segment * n_additional_points_per_segment
@@ -304,7 +305,7 @@ class Beam(_Element):
                         i_segment + 1
                     )
                     * beam_centerline_visualization_segments
-                ] = np.arange(index_first_point, index_last_point)
+                ] = _np.arange(index_first_point, index_last_point)
 
         # Get the point data sets and add everything to the output file.
         _add_point_data_node_sets(
@@ -312,5 +313,5 @@ class Beam(_Element):
         )
         indices = vtk_writer_beam.add_points(coordinates, point_data=point_data)
         vtk_writer_beam.add_cell(
-            vtk.vtkPolyLine, indices[point_connectivity], cell_data=cell_data
+            _vtk.vtkPolyLine, indices[point_connectivity], cell_data=cell_data
         )

--- a/src/meshpy/core/element_beam.py
+++ b/src/meshpy/core/element_beam.py
@@ -26,13 +26,13 @@ from typing import Any, Optional
 import numpy as np
 import vtk
 
-from meshpy.core.conf import mpy
-from meshpy.core.element import Element
-from meshpy.core.node import NodeCosserat
-from meshpy.core.vtk_writer import add_point_data_node_sets
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.element import Element as _Element
+from meshpy.core.node import NodeCosserat as _NodeCosserat
+from meshpy.core.vtk_writer import add_point_data_node_sets as _add_point_data_node_sets
 
 
-class Beam(Element):
+class Beam(_Element):
     """A base class for a beam element."""
 
     # An array that defines the parameter positions of the element nodes,
@@ -79,7 +79,7 @@ class Beam(Element):
             """Check if the given node matches with the position and
             rotation."""
 
-            if np.linalg.norm(pos - node.coordinates) > mpy.eps_pos:
+            if np.linalg.norm(pos - node.coordinates) > _mpy.eps_pos:
                 raise ValueError(
                     f"{name} position does not match with function! Got {pos} from function but "
                     + f"given node value is {node.coordinates}"
@@ -110,7 +110,9 @@ class Beam(Element):
                 i < len(self.nodes_create) - 1 or not has_end_node
             ):
                 is_middle_node = 0 < i < len(self.nodes_create) - 1
-                self.nodes.append(NodeCosserat(pos, rot, is_middle_node=is_middle_node))
+                self.nodes.append(
+                    _NodeCosserat(pos, rot, is_middle_node=is_middle_node)
+                )
 
         # Get a list with the created nodes.
         if has_start_node:
@@ -130,11 +132,11 @@ class Beam(Element):
         """Return the string to couple this beam to another beam."""
 
         match coupling_dof_type:
-            case mpy.coupling_dof.joint:
+            case _mpy.coupling_dof.joint:
                 if cls.coupling_joint_string is None:
                     raise ValueError(f"Joint coupling is not implemented for {cls}")
                 return cls.coupling_joint_string
-            case mpy.coupling_dof.fix:
+            case _mpy.coupling_dof.fix:
                 if cls.coupling_fix_string is None:
                     raise ValueError("Fix coupling is not implemented for {cls}")
                 return cls.coupling_fix_string
@@ -305,7 +307,7 @@ class Beam(Element):
                 ] = np.arange(index_first_point, index_last_point)
 
         # Get the point data sets and add everything to the output file.
-        add_point_data_node_sets(
+        _add_point_data_node_sets(
             point_data, self.nodes, extra_points=n_additional_points
         )
         indices = vtk_writer_beam.add_points(coordinates, point_data=point_data)

--- a/src/meshpy/core/element_volume.py
+++ b/src/meshpy/core/element_volume.py
@@ -21,8 +21,8 @@
 # THE SOFTWARE.
 """This file defines the base volume element in MeshPy."""
 
-import numpy as np
-import vtk
+import numpy as _np
+import vtk as _vtk
 
 from meshpy.core.element import Element as _Element
 from meshpy.core.vtk_writer import add_point_data_node_sets as _add_point_data_node_sets
@@ -69,7 +69,7 @@ class VolumeElement(_Element):
         point_data = {}
 
         # Array with nodal coordinates.
-        coordinates = np.zeros([len(self.nodes), 3])
+        coordinates = _np.zeros([len(self.nodes), 3])
         for i, node in enumerate(self.nodes):
             coordinates[i, :] = node.coordinates
 
@@ -86,28 +86,28 @@ class VolumeElement(_Element):
 class VolumeHEX8(VolumeElement):
     """A HEX8 volume element."""
 
-    vtk_cell_type = vtk.vtkHexahedron
+    vtk_cell_type = _vtk.vtkHexahedron
     vtk_topology = list(range(8))
 
 
 class VolumeTET4(VolumeElement):
     """A TET4 volume element."""
 
-    vtk_cell_type = vtk.vtkTetra
+    vtk_cell_type = _vtk.vtkTetra
     vtk_topology = list(range(4))
 
 
 class VolumeTET10(VolumeElement):
     """A TET10 volume element."""
 
-    vtk_cell_type = vtk.vtkQuadraticTetra
+    vtk_cell_type = _vtk.vtkQuadraticTetra
     vtk_topology = list(range(10))
 
 
 class VolumeHEX20(VolumeElement):
     """A HEX20 volume element."""
 
-    vtk_cell_type = vtk.vtkQuadraticHexahedron
+    vtk_cell_type = _vtk.vtkQuadraticHexahedron
     vtk_topology = [
         0,
         1,
@@ -135,7 +135,7 @@ class VolumeHEX20(VolumeElement):
 class VolumeHEX27(VolumeElement):
     """A HEX27 volume element."""
 
-    vtk_cell_type = vtk.vtkTriQuadraticHexahedron
+    vtk_cell_type = _vtk.vtkTriQuadraticHexahedron
     vtk_topology = [
         0,
         1,

--- a/src/meshpy/core/element_volume.py
+++ b/src/meshpy/core/element_volume.py
@@ -24,11 +24,11 @@
 import numpy as np
 import vtk
 
-from meshpy.core.element import Element
-from meshpy.core.vtk_writer import add_point_data_node_sets
+from meshpy.core.element import Element as _Element
+from meshpy.core.vtk_writer import add_point_data_node_sets as _add_point_data_node_sets
 
 
-class VolumeElement(Element):
+class VolumeElement(_Element):
     """A base class for a volume element."""
 
     # This class variables stores the information about the element shape in
@@ -74,7 +74,7 @@ class VolumeElement(Element):
             coordinates[i, :] = node.coordinates
 
         # Add the node sets connected to this element.
-        add_point_data_node_sets(point_data, self.nodes)
+        _add_point_data_node_sets(point_data, self.nodes)
 
         # Add cell to writer.
         indices = vtk_writer_solid.add_points(coordinates, point_data=point_data)

--- a/src/meshpy/core/geometry_set.py
+++ b/src/meshpy/core/geometry_set.py
@@ -24,22 +24,23 @@ file."""
 
 import numpy as np
 
-from meshpy.core.base_mesh_item import BaseMeshItemFull, BaseMeshItemString
-from meshpy.core.conf import mpy
-from meshpy.core.container import ContainerBase
-from meshpy.core.element_beam import Beam
-from meshpy.core.node import Node
+from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
+from meshpy.core.base_mesh_item import BaseMeshItemString as _BaseMeshItemString
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.container import ContainerBase as _ContainerBase
+from meshpy.core.element_beam import Beam as _Beam
+from meshpy.core.node import Node as _Node
 
 
-class GeometrySetBase(BaseMeshItemFull):
+class GeometrySetBase(_BaseMeshItemFull):
     """Base class for a geometry set."""
 
-    # Node set names for the input file file.
+    # _Node set names for the input file file.
     geometry_set_names = {
-        mpy.geo.point: "DNODE",
-        mpy.geo.line: "DLINE",
-        mpy.geo.surface: "DSURFACE",
-        mpy.geo.volume: "DVOL",
+        _mpy.geo.point: "DNODE",
+        _mpy.geo.line: "DLINE",
+        _mpy.geo.surface: "DSURFACE",
+        _mpy.geo.volume: "DVOL",
     }
 
     def __init__(self, geometry_type, name=None, **kwargs):
@@ -158,7 +159,7 @@ class GeometrySet(GeometrySetBase):
         super().__init__(geometry_type, **kwargs)
 
         self.geometry_objects = {}
-        for geo in mpy.geo:
+        for geo in _mpy.geo:
             self.geometry_objects[geo] = {}
         self.add(geometry)
 
@@ -166,10 +167,10 @@ class GeometrySet(GeometrySetBase):
     def _get_geometry_type(item):
         """Return the geometry type of a given item."""
 
-        if isinstance(item, Node):
-            return mpy.geo.point
-        elif isinstance(item, Beam):
-            return mpy.geo.line
+        if isinstance(item, _Node):
+            return _mpy.geo.point
+        elif isinstance(item, _Beam):
+            return _mpy.geo.line
         elif isinstance(item, GeometrySet):
             return item.geometry_type
         raise TypeError(f"Got unexpected type {type(item)}")
@@ -200,8 +201,8 @@ class GeometrySet(GeometrySetBase):
 
         For non-point sets an empty dict is returned.
         """
-        if self.geometry_type is mpy.geo.point:
-            return self.geometry_objects[mpy.geo.point]
+        if self.geometry_type is _mpy.geo.point:
+            return self.geometry_objects[_mpy.geo.point]
         else:
             return {}
 
@@ -210,8 +211,8 @@ class GeometrySet(GeometrySetBase):
 
         Only in case this is a point set something is returned here.
         """
-        if self.geometry_type is mpy.geo.point:
-            return list(self.geometry_objects[mpy.geo.point].keys())
+        if self.geometry_type is _mpy.geo.point:
+            return list(self.geometry_objects[_mpy.geo.point].keys())
         else:
             raise TypeError(
                 "The function get_points can only be called for point sets."
@@ -225,11 +226,11 @@ class GeometrySet(GeometrySetBase):
         set.
         """
 
-        if self.geometry_type is mpy.geo.point:
-            return list(self.geometry_objects[mpy.geo.point].keys())
-        elif self.geometry_type is mpy.geo.line:
+        if self.geometry_type is _mpy.geo.point:
+            return list(self.geometry_objects[_mpy.geo.point].keys())
+        elif self.geometry_type is _mpy.geo.line:
             nodes = []
-            for element in self.geometry_objects[mpy.geo.line].keys():
+            for element in self.geometry_objects[_mpy.geo.line].keys():
                 nodes.extend(element.nodes)
             # Remove duplicates while preserving order
             return list(dict.fromkeys(nodes))
@@ -298,7 +299,7 @@ class GeometrySetNodes(GeometrySetBase):
             # Nodes are added.
             for item in value:
                 self.add(item)
-        elif isinstance(value, (int, Node)):
+        elif isinstance(value, (int, _Node)):
             self.nodes[value] = None
         elif isinstance(value, GeometrySetNodes):
             # Add all nodes from this geometry set.
@@ -320,7 +321,7 @@ class GeometrySetNodes(GeometrySetBase):
 
     def get_points(self):
         """Return nodes explicitly associated with this set."""
-        if self.geometry_type is mpy.geo.point:
+        if self.geometry_type is _mpy.geo.point:
             return self.get_all_nodes()
         else:
             raise TypeError(
@@ -353,7 +354,7 @@ class GeometryName(dict):
             raise NotImplementedError("GeometryName can only store GeometrySets")
 
 
-class GeometrySetContainer(ContainerBase):
+class GeometrySetContainer(_ContainerBase):
     """A class to group geometry sets together with the key being the geometry
     type."""
 
@@ -361,9 +362,9 @@ class GeometrySetContainer(ContainerBase):
         """Initialize the container and create the default keys in the map."""
         super().__init__(*args, **kwargs)
 
-        self.item_types = [BaseMeshItemString, GeometrySetBase]
+        self.item_types = [_BaseMeshItemString, GeometrySetBase]
 
-        for geometry_key in mpy.geo:
+        for geometry_key in _mpy.geo:
             self[geometry_key] = []
 
     def copy(self):
@@ -374,7 +375,7 @@ class GeometrySetContainer(ContainerBase):
         copy = GeometrySetContainer()
 
         # Add a copy of every list from this container to the new one.
-        for geometry_key in mpy.geo:
+        for geometry_key in _mpy.geo:
             copy[geometry_key] = self[geometry_key].copy()
 
         return copy

--- a/src/meshpy/core/geometry_set.py
+++ b/src/meshpy/core/geometry_set.py
@@ -22,7 +22,7 @@
 """This module implements a basic class to manage geometry in the input
 file."""
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
 from meshpy.core.base_mesh_item import BaseMeshItemString as _BaseMeshItemString
@@ -35,7 +35,7 @@ from meshpy.core.node import Node as _Node
 class GeometrySetBase(_BaseMeshItemFull):
     """Base class for a geometry set."""
 
-    # _Node set names for the input file file.
+    # Node set names for the input file file.
     geometry_set_names = {
         _mpy.geo.point: "DNODE",
         _mpy.geo.line: "DLINE",
@@ -128,7 +128,7 @@ class GeometrySetBase(_BaseMeshItemFull):
         if len(nodes) == 0:
             raise ValueError("Writing empty geometry sets is not supported")
         nodes_id = [node.i_global for node in nodes]
-        sort_indices = np.argsort(nodes_id)
+        sort_indices = _np.argsort(nodes_id)
         nodes = [nodes[i] for i in sort_indices]
 
         return [
@@ -145,7 +145,7 @@ class GeometrySet(GeometrySetBase):
 
         Args
         ----
-        geometry: List or single Geometry/GeometrySet
+        geometry: _List or single Geometry/GeometrySet
             Geometries associated with this set. Empty geometries (i.e., no given)
             are not supported.
         """

--- a/src/meshpy/core/material.py
+++ b/src/meshpy/core/material.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 """This file implements basic classes to manage materials in MeshPy."""
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
 
@@ -75,8 +75,8 @@ class MaterialBeam(Material):
     def calc_area_stiffness(self):
         """Calculate the relevant stiffness terms and the area for the given
         beam."""
-        area = 4 * self.radius**2 * np.pi * 0.25
-        mom2 = self.radius**4 * np.pi * 0.25
+        area = 4 * self.radius**2 * _np.pi * 0.25
+        mom2 = self.radius**4 * _np.pi * 0.25
         mom3 = mom2
         polar = mom2 + mom3
         return area, mom2, mom3, polar

--- a/src/meshpy/core/material.py
+++ b/src/meshpy/core/material.py
@@ -23,10 +23,10 @@
 
 import numpy as np
 
-from meshpy.core.base_mesh_item import BaseMeshItemFull
+from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
 
 
-class Material(BaseMeshItemFull):
+class Material(_BaseMeshItemFull):
     """Base class for all materials."""
 
     def __init__(self, data=None, **kwargs):

--- a/src/meshpy/core/mesh.py
+++ b/src/meshpy/core/mesh.py
@@ -31,32 +31,39 @@ import numpy as np
 import pyvista as pv
 
 from meshpy.core.boundary_condition import (
-    BoundaryConditionBase,
-    BoundaryConditionContainer,
+    BoundaryConditionBase as _BoundaryConditionBase,
 )
-from meshpy.core.conf import mpy
-from meshpy.core.coupling import coupling_factory
-from meshpy.core.element import Element
-from meshpy.core.element_beam import Beam
-from meshpy.core.geometry_set import GeometryName, GeometrySetBase, GeometrySetContainer
-from meshpy.core.material import Material
-from meshpy.core.node import Node, NodeCosserat
-from meshpy.core.rotation import Rotation, add_rotations, rotate_coordinates
-from meshpy.core.vtk_writer import VTKWriter
-from meshpy.four_c.function import Function
+from meshpy.core.boundary_condition import (
+    BoundaryConditionContainer as _BoundaryConditionContainer,
+)
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.coupling import coupling_factory as _coupling_factory
+from meshpy.core.element import Element as _Element
+from meshpy.core.element_beam import Beam as _Beam
+from meshpy.core.geometry_set import GeometryName as _GeometryName
+from meshpy.core.geometry_set import GeometrySetBase as _GeometrySetBase
+from meshpy.core.geometry_set import GeometrySetContainer as _GeometrySetContainer
+from meshpy.core.material import Material as _Material
+from meshpy.core.node import Node as _Node
+from meshpy.core.node import NodeCosserat as _NodeCosserat
+from meshpy.core.rotation import Rotation as _Rotation
+from meshpy.core.rotation import add_rotations as _add_rotations
+from meshpy.core.rotation import rotate_coordinates as _rotate_coordinates
+from meshpy.core.vtk_writer import VTKWriter as _VTKWriter
+from meshpy.four_c.function import Function as _Function
 from meshpy.geometric_search.find_close_points import (
-    find_close_points,
-    point_partners_to_partner_indices,
+    find_close_points as _find_close_points,
 )
-from meshpy.utils.environment import is_testing
-from meshpy.utils.nodes import (
-    filter_nodes,
-    find_close_nodes,
-    get_min_max_nodes,
-    get_nodal_coordinates,
-    get_nodal_quaternions,
-    get_nodes_by_function,
+from meshpy.geometric_search.find_close_points import (
+    point_partners_to_partner_indices as _point_partners_to_partner_indices,
 )
+from meshpy.utils.environment import is_testing as _is_testing
+from meshpy.utils.nodes import filter_nodes as _filter_nodes
+from meshpy.utils.nodes import find_close_nodes as _find_close_nodes
+from meshpy.utils.nodes import get_min_max_nodes as _get_min_max_nodes
+from meshpy.utils.nodes import get_nodal_coordinates as _get_nodal_coordinates
+from meshpy.utils.nodes import get_nodal_quaternions as _get_nodal_quaternions
+from meshpy.utils.nodes import get_nodes_by_function as _get_nodes_by_function
 
 
 class Mesh:
@@ -70,8 +77,8 @@ class Mesh:
         self.elements = []
         self.materials = []
         self.functions = []
-        self.geometry_sets = GeometrySetContainer()
-        self.boundary_conditions = BoundaryConditionContainer()
+        self.geometry_sets = _GeometrySetContainer()
+        self.boundary_conditions = _BoundaryConditionContainer()
 
     @staticmethod
     def get_base_mesh_item_type(item):
@@ -86,13 +93,13 @@ class Mesh:
 
         for cls in (
             Mesh,
-            Function,
-            BoundaryConditionBase,
-            Material,
-            Node,
-            Element,
-            GeometrySetBase,
-            GeometryName,
+            _Function,
+            _BoundaryConditionBase,
+            _Material,
+            _Node,
+            _Element,
+            _GeometrySetBase,
+            _GeometryName,
         ):
             if isinstance(item, cls):
                 return cls
@@ -116,13 +123,13 @@ class Mesh:
 
                 base_type_to_method_map = {
                     Mesh: self.add_mesh,
-                    Function: self.add_function,
-                    BoundaryConditionBase: self.add_bc,
-                    Material: self.add_material,
-                    Node: self.add_node,
-                    Element: self.add_element,
-                    GeometrySetBase: self.add_geometry_set,
-                    GeometryName: self.add_geometry_name,
+                    _Function: self.add_function,
+                    _BoundaryConditionBase: self.add_bc,
+                    _Material: self.add_material,
+                    _Node: self.add_node,
+                    _Element: self.add_element,
+                    _GeometrySetBase: self.add_geometry_set,
+                    _GeometryName: self.add_geometry_name,
                     list: self.add_list,
                 }
                 if base_type in base_type_to_method_map:
@@ -235,9 +242,9 @@ class Mesh:
                         "The added list contains entries already existing in the Mesh"
                     )
 
-            if list_type == Node:
+            if list_type == _Node:
                 extend_internal_list(self.nodes, add_list)
-            elif list_type == Element:
+            elif list_type == _Element:
                 extend_internal_list(self.elements, add_list)
             else:
                 for item in add_list:
@@ -290,8 +297,8 @@ class Mesh:
             for bc in bc_list:
                 # Check if sets from couplings should be added.
                 is_coupling = bc_key in (
-                    mpy.bc.point_coupling,
-                    bc_key == mpy.bc.point_coupling_penalty,
+                    _mpy.bc.point_coupling,
+                    bc_key == _mpy.bc.point_coupling_penalty,
                 )
                 if (is_coupling and coupling_sets) or (not is_coupling):
                     # Only add set if it is not already in the container.
@@ -347,18 +354,18 @@ class Mesh:
         """
 
         # Get array with all quaternions for the nodes.
-        rot1 = get_nodal_quaternions(self.nodes)
+        rot1 = _get_nodal_quaternions(self.nodes)
 
         # Apply the rotation to the rotation of all nodes.
-        rot_new = add_rotations(rotation, rot1)
+        rot_new = _add_rotations(rotation, rot1)
 
         if not only_rotate_triads:
             # Get array with all positions for the nodes.
-            pos = get_nodal_coordinates(self.nodes)
-            pos_new = rotate_coordinates(pos, rotation, origin=origin)
+            pos = _get_nodal_coordinates(self.nodes)
+            pos_new = _rotate_coordinates(pos, rotation, origin=origin)
 
         for i, node in enumerate(self.nodes):
-            if isinstance(node, NodeCosserat):
+            if isinstance(node, _NodeCosserat):
                 node.rotation.q = rot_new[i, :]
             if not only_rotate_triads:
                 node.coordinates = pos_new[i, :]
@@ -396,8 +403,8 @@ class Mesh:
         normal_vector = np.asarray(normal_vector) / np.linalg.norm(normal_vector)
 
         # Get array with all quaternions and positions for the nodes.
-        pos = get_nodal_coordinates(self.nodes)
-        rot1 = get_nodal_quaternions(self.nodes)
+        pos = _get_nodal_coordinates(self.nodes)
+        rot1 = _get_nodal_quaternions(self.nodes)
 
         # Check if origin has to be added.
         if origin is not None:
@@ -425,18 +432,18 @@ class Mesh:
         rot2[:, 1:] = np.cross(e3, normal_vector)
 
         # Add to the existing rotations.
-        rot_new = add_rotations(rot2, rot1)
+        rot_new = _add_rotations(rot2, rot1)
 
         if flip_beams:
             # To achieve the flip, the triads are rotated with the angle pi
             # around the e2 axis.
-            rot_flip = Rotation([0, 1, 0], np.pi)
-            rot_new = add_rotations(rot_new, rot_flip)
+            rot_flip = _Rotation([0, 1, 0], np.pi)
+            rot_new = _add_rotations(rot_new, rot_flip)
 
         # For solid elements we need to adapt the connectivity to avoid negative Jacobians.
         # For beam elements this is optional.
         for element in self.elements:
-            if isinstance(element, Beam):
+            if isinstance(element, _Beam):
                 if flip_beams:
                     element.flip()
             else:
@@ -445,7 +452,7 @@ class Mesh:
         # Set the new positions and rotations.
         for i, node in enumerate(self.nodes):
             node.coordinates = pos_new[i, :]
-            if isinstance(node, NodeCosserat):
+            if isinstance(node, _NodeCosserat):
                 node.rotation.q = rot_new[i, :]
 
     def wrap_around_cylinder(self, radius=None, advanced_warning=True):
@@ -467,14 +474,14 @@ class Mesh:
             cases (up to 100,000 elements) this check can be left activated.
         """
 
-        pos = get_nodal_coordinates(self.nodes)
+        pos = _get_nodal_coordinates(self.nodes)
         quaternions = np.zeros([len(self.nodes), 4])
 
         # The x coordinate is the radius, the y coordinate the arc length.
         points_x = pos[:, 0].copy()
 
         # Check if all points are on the same y-z plane.
-        if np.abs(np.min(points_x) - np.max(points_x)) > mpy.eps_pos:
+        if np.abs(np.min(points_x) - np.max(points_x)) > _mpy.eps_pos:
             # The points are not all on the y-z plane, get the reference
             # radius.
             if radius is not None:
@@ -496,7 +503,7 @@ class Mesh:
                                     - element_coordinates[0, 0]
                                 )
                             )
-                            < mpy.eps_pos
+                            < _mpy.eps_pos
                         )
                         is_xz = (
                             np.max(
@@ -505,7 +512,7 @@ class Mesh:
                                     - element_coordinates[0, 1]
                                 )
                             )
-                            < mpy.eps_pos
+                            < _mpy.eps_pos
                         )
                         if not (is_yz or is_xz):
                             element_warning.append(i_element)
@@ -528,7 +535,7 @@ class Mesh:
                 )
             radius_phi = radius
             radius_points = points_x
-        elif radius is None or np.abs(points_x[0] - radius) < mpy.eps_pos:
+        elif radius is None or np.abs(points_x[0] - radius) < _mpy.eps_pos:
             radius_points = radius_phi = points_x[0]
         else:
             raise ValueError(
@@ -562,8 +569,8 @@ class Mesh:
         *,
         nodes=None,
         reuse_matching_nodes=False,
-        coupling_type=mpy.bc.point_coupling,
-        coupling_dof_type=mpy.coupling_dof.fix,
+        coupling_type=_mpy.bc.point_coupling,
+        coupling_dof_type=_mpy.coupling_dof.fix,
     ):
         """Search through nodes and connect all nodes with the same
         coordinates.
@@ -588,7 +595,10 @@ class Mesh:
         """
 
         # Check that a coupling BC is given.
-        if coupling_type not in (mpy.bc.point_coupling, mpy.bc.point_coupling_penalty):
+        if coupling_type not in (
+            _mpy.bc.point_coupling,
+            _mpy.bc.point_coupling_penalty,
+        ):
             raise ValueError(
                 "Only coupling conditions can be applied in 'couple_nodes'!"
             )
@@ -599,8 +609,8 @@ class Mesh:
             node_list = self.nodes
         else:
             node_list = nodes
-        node_list = filter_nodes(node_list, middle_nodes=False)
-        partner_nodes = find_close_nodes(node_list)
+        node_list = _filter_nodes(node_list, middle_nodes=False)
+        partner_nodes = _find_close_nodes(node_list)
         if len(partner_nodes) == 0:
             # If no partner nodes were found, end this function.
             return
@@ -621,7 +631,7 @@ class Mesh:
                 # Get array with rotation vectors.
                 rotation_vectors = np.zeros([len(node_list), 3])
                 for i, node in enumerate(node_list):
-                    if isinstance(node, NodeCosserat):
+                    if isinstance(node, _NodeCosserat):
                         rotation_vectors[i, :] = node.rotation.get_rotation_vector()
                     else:
                         # For the case of nodes that belong to solid elements,
@@ -630,14 +640,14 @@ class Mesh:
 
                 # Use find close points function to find nodes with the
                 # same rotation.
-                partners, n_partners = find_close_points(
-                    rotation_vectors, tol=mpy.eps_quaternion
+                partners, n_partners = _find_close_points(
+                    rotation_vectors, tol=_mpy.eps_quaternion
                 )
 
                 # Check if nodes with the same rotations were found.
                 if n_partners == 0:
                     self.add(
-                        coupling_factory(node_list, coupling_type, coupling_dof_type)
+                        _coupling_factory(node_list, coupling_type, coupling_dof_type)
                     )
                 else:
                     # There are nodes that need to be combined.
@@ -672,7 +682,7 @@ class Mesh:
                     # Add the coupling nodes.
                     if len(coupling_nodes) > 1:
                         self.add(
-                            coupling_factory(
+                            _coupling_factory(
                                 coupling_nodes, coupling_type, coupling_dof_type
                             )
                         )
@@ -686,7 +696,7 @@ class Mesh:
         else:
             # Connect close nodes with a coupling.
             for node_list in partner_nodes:
-                self.add(coupling_factory(node_list, coupling_type, coupling_dof_type))
+                self.add(_coupling_factory(node_list, coupling_type, coupling_dof_type))
 
     def unlink_nodes(self):
         """Delete the linked arrays and global indices in all nodes."""
@@ -695,12 +705,12 @@ class Mesh:
 
     def get_nodes_by_function(self, *args, **kwargs):
         """Return all nodes for which the function evaluates to true."""
-        return get_nodes_by_function(self.nodes, *args, **kwargs)
+        return _get_nodes_by_function(self.nodes, *args, **kwargs)
 
     def get_min_max_nodes(self, *args, **kwargs):
         """Return a geometry set with the max and min nodes in all
         directions."""
-        return get_min_max_nodes(self.nodes, *args, **kwargs)
+        return _get_min_max_nodes(self.nodes, *args, **kwargs)
 
     def check_overlapping_elements(self, raise_error=True):
         """Check if there are overlapping elements in the mesh.
@@ -722,8 +732,8 @@ class Mesh:
             coordinates[i, :] = node.coordinates
 
         # Check if there are double entries in the coordinates.
-        has_partner, partner = find_close_points(coordinates)
-        partner_indices = point_partners_to_partner_indices(has_partner, partner)
+        has_partner, partner = _find_close_points(coordinates)
+        partner_indices = _point_partners_to_partner_indices(has_partner, partner)
         if partner > 0:
             if raise_error:
                 raise ValueError(
@@ -757,8 +767,8 @@ class Mesh:
         """
 
         # Object to store VKT data (and write it to file)
-        vtk_writer_beam = VTKWriter()
-        vtk_writer_solid = VTKWriter()
+        vtk_writer_beam = _VTKWriter()
+        vtk_writer_solid = _VTKWriter()
 
         # Get the set numbers of the mesh
         mesh_sets = self.get_unique_geometry_sets(
@@ -771,7 +781,7 @@ class Mesh:
 
         # Set the mpy value.
         digits = len(str(max_sets))
-        mpy.vtk_node_set_format = "{:0" + str(digits) + "}"
+        _mpy.vtk_node_set_format = "{:0" + str(digits) + "}"
 
         if overlapping_elements:
             # Check for overlapping elements.
@@ -968,7 +978,7 @@ class Mesh:
             solid_grid = pv.UnstructuredGrid(vtk_writer_solid.grid).clean()
             plotter.add_mesh(solid_grid, color="white", show_edges=True, opacity=0.5)
 
-        if not is_testing():
+        if not _is_testing():
             plotter.show()
         else:
             return plotter

--- a/src/meshpy/core/mesh_utils.py
+++ b/src/meshpy/core/mesh_utils.py
@@ -23,14 +23,14 @@
 
 from typing import Dict, List, Tuple
 
-from meshpy.core.conf import mpy
-from meshpy.core.mesh import Mesh
-from meshpy.core.node import Node
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.mesh import Mesh as _Mesh
+from meshpy.core.node import Node as _Node
 
 
 def get_coupled_nodes_to_master_map(
-    mesh: Mesh, *, assign_i_global: bool = False
-) -> Tuple[Dict[Node, Node], List[Node]]:
+    mesh: _Mesh, *, assign_i_global: bool = False
+) -> Tuple[Dict[_Node, _Node], List[_Node]]:
     """Get a mapping of nodes in a mesh that should be "replaced" because they
     are coupled via a joint.
 
@@ -57,8 +57,8 @@ def get_coupled_nodes_to_master_map(
 
     # Get a dictionary that maps the "replaced" nodes to the "master" ones
     replaced_node_to_master_map = {}
-    for coupling in mesh.boundary_conditions[mpy.bc.point_coupling, mpy.geo.point]:
-        if coupling.coupling_dof_type is not mpy.coupling_dof.fix:
+    for coupling in mesh.boundary_conditions[_mpy.bc.point_coupling, _mpy.geo.point]:
+        if coupling.coupling_dof_type is not _mpy.coupling_dof.fix:
             raise ValueError(
                 "This function is only implemented for rigid joints at the DOFs"
             )

--- a/src/meshpy/core/mesh_utils.py
+++ b/src/meshpy/core/mesh_utils.py
@@ -21,7 +21,9 @@
 # THE SOFTWARE.
 """This module defines utility functions for meshes."""
 
-from typing import Dict, List, Tuple
+from typing import Dict as _Dict
+from typing import List as _List
+from typing import Tuple as _Tuple
 
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.mesh import Mesh as _Mesh
@@ -30,7 +32,7 @@ from meshpy.core.node import Node as _Node
 
 def get_coupled_nodes_to_master_map(
     mesh: _Mesh, *, assign_i_global: bool = False
-) -> Tuple[Dict[_Node, _Node], List[_Node]]:
+) -> _Tuple[_Dict[_Node, _Node], _List[_Node]]:
     """Get a mapping of nodes in a mesh that should be "replaced" because they
     are coupled via a joint.
 

--- a/src/meshpy/core/node.py
+++ b/src/meshpy/core/node.py
@@ -23,11 +23,11 @@
 
 import numpy as np
 
-from meshpy.core.base_mesh_item import BaseMeshItemFull
-from meshpy.core.conf import mpy
+from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
+from meshpy.core.conf import mpy as _mpy
 
 
-class Node(BaseMeshItemFull):
+class Node(_BaseMeshItemFull):
     """This object represents one node in the mesh."""
 
     def __init__(self, coordinates, *, is_middle_node=False, **kwargs):
@@ -110,8 +110,8 @@ class Node(BaseMeshItemFull):
         coordinate_string = " ".join(
             [
                 (
-                    mpy.dat_precision.format(component + 0)
-                    if np.abs(component) >= mpy.eps_pos
+                    _mpy.dat_precision.format(component + 0)
+                    if np.abs(component) >= _mpy.eps_pos
                     else "0"
                 )
                 for component in self.coordinates
@@ -165,8 +165,8 @@ class ControlPoint(Node):
         coordinate_string = " ".join(
             [
                 (
-                    mpy.dat_precision.format(component + 0)
-                    if np.abs(component) >= mpy.eps_pos
+                    _mpy.dat_precision.format(component + 0)
+                    if np.abs(component) >= _mpy.eps_pos
                     else "0"
                 )
                 for component in self.coordinates

--- a/src/meshpy/core/node.py
+++ b/src/meshpy/core/node.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 """This module implements the class that represents one node in the Mesh."""
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
 from meshpy.core.conf import mpy as _mpy
@@ -34,7 +34,7 @@ class Node(_BaseMeshItemFull):
         super().__init__(data=None, **kwargs)
 
         # Coordinates of this node.
-        self.coordinates = np.array(coordinates)
+        self.coordinates = _np.array(coordinates)
 
         # If this node is at the end of a line or curve (by default only those
         # nodes are checked for overlapping nodes).
@@ -111,7 +111,7 @@ class Node(_BaseMeshItemFull):
             [
                 (
                     _mpy.dat_precision.format(component + 0)
-                    if np.abs(component) >= _mpy.eps_pos
+                    if _np.abs(component) >= _mpy.eps_pos
                     else "0"
                 )
                 for component in self.coordinates
@@ -166,7 +166,7 @@ class ControlPoint(Node):
             [
                 (
                     _mpy.dat_precision.format(component + 0)
-                    if np.abs(component) >= _mpy.eps_pos
+                    if _np.abs(component) >= _mpy.eps_pos
                     else "0"
                 )
                 for component in self.coordinates

--- a/src/meshpy/core/nurbs_patch.py
+++ b/src/meshpy/core/nurbs_patch.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 """This module implements NURBS patches for the mesh."""
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.element import Element as _Element
@@ -128,7 +128,7 @@ class NURBSPatch(_Element):
         """Get the number of elements in this patch by checking the amount of
         nonzero knot spans in the knot vector."""
 
-        num_elements_dir = np.zeros(len(self.knot_vectors), dtype=int)
+        num_elements_dir = _np.zeros(len(self.knot_vectors), dtype=int)
 
         for i_dir in range(len(self.knot_vectors)):
             for i_knot in range(len(self.knot_vectors[i_dir]) - 1):
@@ -141,7 +141,7 @@ class NURBSPatch(_Element):
                 ):
                     num_elements_dir[i_dir] += 1
 
-        total_num_elements = np.prod(num_elements_dir)
+        total_num_elements = _np.prod(num_elements_dir)
 
         return total_num_elements
 

--- a/src/meshpy/core/nurbs_patch.py
+++ b/src/meshpy/core/nurbs_patch.py
@@ -23,16 +23,19 @@
 
 import numpy as np
 
-from meshpy.core.conf import mpy
-from meshpy.core.element import Element
-from meshpy.four_c.material import MaterialString, MaterialStVenantKirchhoff
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.element import Element as _Element
+from meshpy.four_c.material import MaterialString as _MaterialString
+from meshpy.four_c.material import (
+    MaterialStVenantKirchhoff as _MaterialStVenantKirchhoff,
+)
 
 
-class NURBSPatch(Element):
+class NURBSPatch(_Element):
     """A base class for a NURBS patch."""
 
     # A list of valid material types for this element
-    valid_material = [MaterialString, MaterialStVenantKirchhoff]
+    valid_material = [_MaterialString, _MaterialStVenantKirchhoff]
 
     def __init__(
         self,
@@ -73,12 +76,14 @@ class NURBSPatch(Element):
         """Return additional information of the NURBS patch."""
 
         # TODO: This is a circular import, which should be resolved
-        from meshpy.four_c.input_file import InputSectionMultiKey
+        from meshpy.four_c.input_file import (
+            InputSectionMultiKey as _InputSectionMultiKey,
+        )
 
         knotvectors_section = "STRUCTURE KNOTVECTORS"
 
         if knotvectors_section not in sections.keys():
-            sections[knotvectors_section] = InputSectionMultiKey(knotvectors_section)
+            sections[knotvectors_section] = _InputSectionMultiKey(knotvectors_section)
 
         section = sections[knotvectors_section]
         section.add(f"NURBS_DIMENSION {self.get_nurbs_dimension()}")
@@ -101,13 +106,13 @@ class NURBSPatch(Element):
                         self.knot_vectors[dir_manifold][i]
                         - self.knot_vectors[dir_manifold][i + 1]
                     )
-                    > mpy.eps_knot_vector
+                    > _mpy.eps_knot_vector
                 ) or (
                     abs(
                         self.knot_vectors[dir_manifold][num_knotvectors - 2 - i]
                         - self.knot_vectors[dir_manifold][num_knotvectors - 1 - i]
                     )
-                    > mpy.eps_knot_vector
+                    > _mpy.eps_knot_vector
                 ):
                     knotvector_type = "Periodic"
                     break
@@ -132,7 +137,7 @@ class NURBSPatch(Element):
                         self.knot_vectors[i_dir][i_knot]
                         - self.knot_vectors[i_dir][i_knot + 1]
                     )
-                    > mpy.eps_knot_vector
+                    > _mpy.eps_knot_vector
                 ):
                     num_elements_dir[i_dir] += 1
 

--- a/src/meshpy/core/rotation.py
+++ b/src/meshpy/core/rotation.py
@@ -21,16 +21,16 @@
 # THE SOFTWARE.
 """This module defines a class that represents a rotation in 3D."""
 
-import copy
+import copy as _copy
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.conf import mpy as _mpy
 
 
 def skew_matrix(vector):
     """Return the skew matrix for the vector."""
-    skew = np.zeros([3, 3])
+    skew = _np.zeros([3, 3])
     skew[0, 1] = -vector[2]
     skew[0, 2] = vector[1]
     skew[1, 0] = vector[2]
@@ -58,20 +58,20 @@ class Rotation:
                 Create a rotation around the vector axis with the angle phi.
         """
 
-        self.q = np.zeros(4)
+        self.q = _np.zeros(4)
 
         if len(args) == 0:
             # Identity element.
             self.q[0] = 1
         elif len(args) == 2:
             # Set from rotation axis and rotation angle.
-            axis = np.asarray(args[0])
+            axis = _np.asarray(args[0])
             phi = args[1]
-            norm = np.linalg.norm(axis)
+            norm = _np.linalg.norm(axis)
             if norm < _mpy.eps_quaternion:
                 raise ValueError("The rotation axis can not be a zero vector!")
-            self.q[0] = np.cos(0.5 * phi)
-            self.q[1:] = np.sin(0.5 * phi) * axis / norm
+            self.q[0] = _np.cos(0.5 * phi)
+            self.q[1:] = _np.sin(0.5 * phi) * axis / norm
         else:
             raise ValueError(f"The given arguments {args} are invalid!")
 
@@ -90,9 +90,9 @@ class Rotation:
         """
         rotation = object.__new__(cls)
         if normalized:
-            rotation.q = np.array(q)
+            rotation.q = _np.array(q)
         else:
-            rotation.q = np.asarray(q) / np.linalg.norm(q)
+            rotation.q = _np.asarray(q) / _np.linalg.norm(q)
         if (not rotation.q.ndim == 1) or (not len(rotation.q) == 4):
             raise ValueError("Got quaternion array with unexpected dimensions")
         return rotation
@@ -106,13 +106,13 @@ class Rotation:
             direction-cosine matrix”
         """
 
-        q = np.zeros(4)
-        trace = np.trace(R)
+        q = _np.zeros(4)
+        trace = _np.trace(R)
         values = [R[i, i] for i in range(3)]
         values.append(trace)
-        arg_max = np.argmax(values)
+        arg_max = _np.argmax(values)
         if arg_max == 3:
-            q[0] = np.sqrt(trace + 1) * 0.5
+            q[0] = _np.sqrt(trace + 1) * 0.5
             q[1] = (R[2, 1] - R[1, 2]) / (4 * q[0])
             q[2] = (R[0, 2] - R[2, 0]) / (4 * q[0])
             q[3] = (R[1, 0] - R[0, 1]) / (4 * q[0])
@@ -120,7 +120,7 @@ class Rotation:
             i_index = arg_max
             j_index = (i_index + 1) % 3
             k_index = (i_index + 2) % 3
-            q_i = np.sqrt(R[i_index, i_index] * 0.5 + (1 - trace) * 0.25)
+            q_i = _np.sqrt(R[i_index, i_index] * 0.5 + (1 - trace) * 0.25)
             q[0] = (R[k_index, j_index] - R[j_index, k_index]) / (4 * q_i)
             q[i_index + 1] = q_i
             q[j_index + 1] = (R[j_index, i_index] + R[i_index, j_index]) / (4 * q_i)
@@ -136,27 +136,27 @@ class Rotation:
         the cross product.
         """
 
-        t1_normal = t1 / np.linalg.norm(t1)
-        t2_ortho = t2 - t1_normal * np.dot(t1_normal, t2)
-        t2_normal = t2_ortho / np.linalg.norm(t2_ortho)
-        t3_normal = np.cross(t1_normal, t2_normal)
+        t1_normal = t1 / _np.linalg.norm(t1)
+        t2_ortho = t2 - t1_normal * _np.dot(t1_normal, t2)
+        t2_normal = t2_ortho / _np.linalg.norm(t2_ortho)
+        t3_normal = _np.cross(t1_normal, t2_normal)
 
-        R = np.transpose([t1_normal, t2_normal, t3_normal])
+        R = _np.transpose([t1_normal, t2_normal, t3_normal])
         return cls.from_rotation_matrix(R)
 
     @classmethod
     def from_rotation_vector(cls, rotation_vector):
         """Create the object from a rotation vector."""
 
-        q = np.zeros(4)
-        rotation_vector = np.asarray(rotation_vector)
-        phi = np.linalg.norm(rotation_vector)
-        q[0] = np.cos(0.5 * phi)
+        q = _np.zeros(4)
+        rotation_vector = _np.asarray(rotation_vector)
+        phi = _np.linalg.norm(rotation_vector)
+        q[0] = _np.cos(0.5 * phi)
         if phi < _mpy.eps_quaternion:
             # This is the Taylor series expansion of sin(phi/2)/phi around phi=0
             q[1:] = 0.5 * rotation_vector
         else:
-            q[1:] = np.sin(0.5 * phi) / phi * rotation_vector
+            q[1:] = _np.sin(0.5 * phi) / phi * rotation_vector
         return cls.from_quaternion(q)
 
     def check(self):
@@ -174,7 +174,7 @@ class Rotation:
     def check_quaternion_constraint(self):
         """We want to check that q.q = 1."""
 
-        if np.abs(1 - np.linalg.norm(self.q)) > _mpy.eps_quaternion:
+        if _np.abs(1 - _np.linalg.norm(self.q)) > _mpy.eps_quaternion:
             raise ValueError(
                 f"The rotation object is corrupted. q.q does not equal 1! q={self.q}"
             )
@@ -186,9 +186,9 @@ class Rotation:
         """
         q_skew = skew_matrix(self.q[1:])
         R = (
-            (self.q[0] ** 2 - np.dot(self.q[1:], self.q[1:])) * np.eye(3)
+            (self.q[0] ** 2 - _np.dot(self.q[1:], self.q[1:])) * _np.eye(3)
             + 2 * self.q[0] * q_skew
-            + 2 * ([self.q[1:]] * np.transpose([self.q[1:]]))
+            + 2 * ([self.q[1:]] * _np.transpose([self.q[1:]]))
         )
 
         return R
@@ -196,22 +196,22 @@ class Rotation:
     def get_quaternion(self):
         """Return the quaternion for this rotation, as numpy array (copy)."""
 
-        return np.array(self.q)
+        return _np.array(self.q)
 
     def get_rotation_vector(self):
         """Return the rotation vector for this object."""
 
         self.check()
 
-        norm = np.linalg.norm(self.q[1:])
-        phi = 2 * np.arctan2(norm, self.q[0])
+        norm = _np.linalg.norm(self.q[1:])
+        phi = 2 * _np.arctan2(norm, self.q[0])
 
         if phi < _mpy.eps_quaternion:
             # For small angles return the Taylor series expansion of phi/sin(phi/2)
             scale_factor = 2
         else:
-            scale_factor = phi / np.sin(phi / 2)
-            if np.abs(np.abs(phi) - np.pi) < _mpy.eps_quaternion:
+            scale_factor = phi / _np.sin(phi / 2)
+            if _np.abs(_np.abs(phi) - _np.pi) < _mpy.eps_quaternion:
                 # For rotations of exactly +-pi, numerical issues might occur, resulting in
                 # a rotation vector that is non-deterministic. The result is correct, but
                 # the sign can switch due to different implementation of basic underlying
@@ -220,7 +220,7 @@ class Rotation:
                 # for a rotation angle of +-pi, the first component of the rotation axis
                 # that is not 0 is positive.
                 for i_dir in range(3):
-                    if np.abs(self.q[1 + i_dir]) > _mpy.eps_quaternion:
+                    if _np.abs(self.q[1 + i_dir]) > _mpy.eps_quaternion:
                         if self.q[1 + i_dir] < 0:
                             scale_factor *= -1
                         break
@@ -234,7 +234,7 @@ class Rotation:
         """
 
         omega = self.get_rotation_vector()
-        omega_norm = np.linalg.norm(omega)
+        omega_norm = _np.linalg.norm(omega)
 
         # We have to take the inverse of the the rotation angle here, therefore,
         # we have a branch for small angles where the singularity is not present.
@@ -243,18 +243,18 @@ class Rotation:
             omega_dir = omega / omega_norm
             omega_skew = skew_matrix(omega)
             transformation_matrix = (
-                np.outer(omega_dir, omega_dir)
+                _np.outer(omega_dir, omega_dir)
                 - 0.5 * omega_skew
                 + 0.5
                 * omega_norm
-                / np.tan(0.5 * omega_norm)
-                * (np.identity(3) - np.outer(omega_dir, omega_dir))
+                / _np.tan(0.5 * omega_norm)
+                * (_np.identity(3) - _np.outer(omega_dir, omega_dir))
             )
         else:
             # This is the constant part of the Taylor series expansion. If this
             # function is used with automatic differentiation, higher order
             # terms have to be added!
-            transformation_matrix = np.identity(3)
+            transformation_matrix = _np.identity(3)
         return transformation_matrix
 
     def get_transformation_matrix_inv(self):
@@ -266,7 +266,7 @@ class Rotation:
         """
 
         omega = self.get_rotation_vector()
-        omega_norm = np.linalg.norm(omega)
+        omega_norm = _np.linalg.norm(omega)
 
         # We have to take the inverse of the the rotation angle here, therefore,
         # we have a branch for small angles where the singularity is not present.
@@ -275,15 +275,16 @@ class Rotation:
             omega_dir = omega / omega_norm
             omega_skew = skew_matrix(omega)
             transformation_matrix_inverse = (
-                (1.0 - np.sin(omega_norm) / omega_norm) * np.outer(omega_dir, omega_dir)
-                + np.sin(omega_norm) / omega_norm * np.identity(3)
-                + (1.0 - np.cos(omega_norm)) / omega_norm**2 * omega_skew
+                (1.0 - _np.sin(omega_norm) / omega_norm)
+                * _np.outer(omega_dir, omega_dir)
+                + _np.sin(omega_norm) / omega_norm * _np.identity(3)
+                + (1.0 - _np.cos(omega_norm)) / omega_norm**2 * omega_skew
             )
         else:
             # This is the constant part of the Taylor series expansion. If this
             # function is used with automatic differentiation, higher order
             # terms have to be added!
-            transformation_matrix_inverse = np.identity(3)
+            transformation_matrix_inverse = _np.identity(3)
         return transformation_matrix_inverse
 
     def inv(self):
@@ -302,13 +303,13 @@ class Rotation:
             p = self.q
             q = other.q
             # Add the rotations.
-            added_rotation = np.zeros_like(self.q)
-            added_rotation[0] = p[0] * q[0] - np.dot(p[1:], q[1:])
-            added_rotation[1:] = p[0] * q[1:] + q[0] * p[1:] + np.cross(p[1:], q[1:])
+            added_rotation = _np.zeros_like(self.q)
+            added_rotation[0] = p[0] * q[0] - _np.dot(p[1:], q[1:])
+            added_rotation[1:] = p[0] * q[1:] + q[0] * p[1:] + _np.cross(p[1:], q[1:])
             return Rotation.from_quaternion(added_rotation)
-        elif isinstance(other, (list, np.ndarray)) and len(other) == 3:
+        elif isinstance(other, (list, _np.ndarray)) and len(other) == 3:
             # Apply rotation to vector.
-            return np.dot(self.get_rotation_matrix(), np.asarray(other))
+            return _np.dot(self.get_rotation_matrix(), _np.asarray(other))
         raise NotImplementedError("Error, not implemented, does not make sense anyway!")
 
     def __eq__(self, other):
@@ -316,8 +317,8 @@ class Rotation:
 
         if isinstance(other, Rotation):
             return bool(
-                (np.linalg.norm(self.q - other.q) < _mpy.eps_quaternion)
-                or (np.linalg.norm(self.q + other.q) < _mpy.eps_quaternion)
+                (_np.linalg.norm(self.q - other.q) < _mpy.eps_quaternion)
+                or (_np.linalg.norm(self.q + other.q) < _mpy.eps_quaternion)
             )
         else:
             return object.__eq__(self, other)
@@ -332,7 +333,7 @@ class Rotation:
             [
                 (
                     _mpy.dat_precision.format(component + 0)
-                    if np.abs(component) >= _mpy.eps_quaternion
+                    if _np.abs(component) >= _mpy.eps_quaternion
                     else "0"
                 )
                 for component in rotation_vector
@@ -341,7 +342,7 @@ class Rotation:
 
     def copy(self):
         """Return a deep copy of this object."""
-        return copy.deepcopy(self)
+        return _copy.deepcopy(self)
 
     def __str__(self):
         """String representation of object."""
@@ -355,16 +356,16 @@ def add_rotations(rotation_21, rotation_10):
 
     Args
     ----
-    rotation_10: np.ndarray
+    rotation_10: _np.ndarray
         Array with the dimensions n x 4 or 4 x 1.
         The first rotation that is applied.
-    rotation_21: np.ndarray
+    rotation_21: _np.ndarray
         Array with the dimensions n x 4 or 4 x 1.
         The second rotation that is applied.
 
     Return
     ----
-    rot_new: np.ndarray
+    rot_new: _np.ndarray
         Array with the dimensions n x 4.
         This array contains the new quaternions.
     """
@@ -373,16 +374,16 @@ def add_rotations(rotation_21, rotation_10):
     if isinstance(rotation_10, Rotation):
         rot1 = rotation_10.get_quaternion().transpose()
     else:
-        rot1 = np.transpose(rotation_10)
+        rot1 = _np.transpose(rotation_10)
     if isinstance(rotation_21, Rotation):
         rot2 = rotation_21.get_quaternion().transpose()
     else:
-        rot2 = np.transpose(rotation_21)
+        rot2 = _np.transpose(rotation_21)
 
     if rot1.size > rot2.size:
-        rotnew = np.zeros_like(rot1)
+        rotnew = _np.zeros_like(rot1)
     else:
-        rotnew = np.zeros_like(rot2)
+        rotnew = _np.zeros_like(rot2)
 
     # Multiply the two rotations (code is taken from /utility/rotation.nb).
     rotnew[0] = (
@@ -406,7 +407,7 @@ def rotate_coordinates(coordinates, rotation, *, origin=None):
 
     Args
     ----
-    coordinates: np.array
+    coordinates: _np.array
         Array of 3D coordinates to be rotated
     rotation: Rotation, list(quaternions) (nx4)
         The rotation that will be applied to the coordinates. Can also be an
@@ -424,25 +425,25 @@ def rotate_coordinates(coordinates, rotation, *, origin=None):
         origin = [0.0, 0.0, 0.0]
 
     # New position array
-    coordinates_new = np.zeros_like(coordinates)
+    coordinates_new = _np.zeros_like(coordinates)
 
     # Evaluate the new positions using the numpy data structure
     # (code is taken from /utility/rotation.nb)
     rotation = rotation.transpose()
 
-    q0_q0 = np.square(rotation[0])
+    q0_q0 = _np.square(rotation[0])
     q0_q1_2 = 2.0 * rotation[0] * rotation[1]
     q0_q2_2 = 2.0 * rotation[0] * rotation[2]
     q0_q3_2 = 2.0 * rotation[0] * rotation[3]
 
-    q1_q1 = np.square(rotation[1])
+    q1_q1 = _np.square(rotation[1])
     q1_q2_2 = 2.0 * rotation[1] * rotation[2]
     q1_q3_2 = 2.0 * rotation[1] * rotation[3]
 
-    q2_q2 = np.square(rotation[2])
+    q2_q2 = _np.square(rotation[2])
     q2_q3_2 = 2.0 * rotation[2] * rotation[3]
 
-    q3_q3 = np.square(rotation[3])
+    q3_q3 = _np.square(rotation[3])
 
     coordinates_new[:, 0] = (
         (q0_q0 + q1_q1 - q2_q2 - q3_q3) * (coordinates[:, 0] - origin[0])
@@ -485,15 +486,15 @@ def smallest_rotation(q: Rotation, t):
 
     R_old = q.get_rotation_matrix()
     g1_old = R_old[:, 0]
-    g1 = np.asarray(t) / np.linalg.norm(t)
+    g1 = _np.asarray(t) / _np.linalg.norm(t)
 
     # Quaternion components of relative rotation
-    q_rel = np.zeros(4)
+    q_rel = _np.zeros(4)
 
     # The scalar quaternion part is cos(alpha/2) this is equal to
-    q_rel[0] = np.linalg.norm(0.5 * (g1_old + g1))
+    q_rel[0] = _np.linalg.norm(0.5 * (g1_old + g1))
 
     # Vector part of the quaternion is sin(alpha/2)*axis
-    q_rel[1:] = np.cross(g1_old, g1) / (2.0 * q_rel[0])
+    q_rel[1:] = _np.cross(g1_old, g1) / (2.0 * q_rel[0])
 
     return Rotation.from_quaternion(q_rel) * q

--- a/src/meshpy/core/rotation.py
+++ b/src/meshpy/core/rotation.py
@@ -25,7 +25,7 @@ import copy
 
 import numpy as np
 
-from meshpy.core.conf import mpy
+from meshpy.core.conf import mpy as _mpy
 
 
 def skew_matrix(vector):
@@ -68,7 +68,7 @@ class Rotation:
             axis = np.asarray(args[0])
             phi = args[1]
             norm = np.linalg.norm(axis)
-            if norm < mpy.eps_quaternion:
+            if norm < _mpy.eps_quaternion:
                 raise ValueError("The rotation axis can not be a zero vector!")
             self.q[0] = np.cos(0.5 * phi)
             self.q[1:] = np.sin(0.5 * phi) * axis / norm
@@ -152,7 +152,7 @@ class Rotation:
         rotation_vector = np.asarray(rotation_vector)
         phi = np.linalg.norm(rotation_vector)
         q[0] = np.cos(0.5 * phi)
-        if phi < mpy.eps_quaternion:
+        if phi < _mpy.eps_quaternion:
             # This is the Taylor series expansion of sin(phi/2)/phi around phi=0
             q[1:] = 0.5 * rotation_vector
         else:
@@ -174,7 +174,7 @@ class Rotation:
     def check_quaternion_constraint(self):
         """We want to check that q.q = 1."""
 
-        if np.abs(1 - np.linalg.norm(self.q)) > mpy.eps_quaternion:
+        if np.abs(1 - np.linalg.norm(self.q)) > _mpy.eps_quaternion:
             raise ValueError(
                 f"The rotation object is corrupted. q.q does not equal 1! q={self.q}"
             )
@@ -206,12 +206,12 @@ class Rotation:
         norm = np.linalg.norm(self.q[1:])
         phi = 2 * np.arctan2(norm, self.q[0])
 
-        if phi < mpy.eps_quaternion:
+        if phi < _mpy.eps_quaternion:
             # For small angles return the Taylor series expansion of phi/sin(phi/2)
             scale_factor = 2
         else:
             scale_factor = phi / np.sin(phi / 2)
-            if np.abs(np.abs(phi) - np.pi) < mpy.eps_quaternion:
+            if np.abs(np.abs(phi) - np.pi) < _mpy.eps_quaternion:
                 # For rotations of exactly +-pi, numerical issues might occur, resulting in
                 # a rotation vector that is non-deterministic. The result is correct, but
                 # the sign can switch due to different implementation of basic underlying
@@ -220,7 +220,7 @@ class Rotation:
                 # for a rotation angle of +-pi, the first component of the rotation axis
                 # that is not 0 is positive.
                 for i_dir in range(3):
-                    if np.abs(self.q[1 + i_dir]) > mpy.eps_quaternion:
+                    if np.abs(self.q[1 + i_dir]) > _mpy.eps_quaternion:
                         if self.q[1 + i_dir] < 0:
                             scale_factor *= -1
                         break
@@ -238,7 +238,7 @@ class Rotation:
 
         # We have to take the inverse of the the rotation angle here, therefore,
         # we have a branch for small angles where the singularity is not present.
-        if omega_norm**2 > mpy.eps_quaternion:
+        if omega_norm**2 > _mpy.eps_quaternion:
             # Taken from Jelenic and Crisfield (1999) Equation (2.5)
             omega_dir = omega / omega_norm
             omega_skew = skew_matrix(omega)
@@ -270,7 +270,7 @@ class Rotation:
 
         # We have to take the inverse of the the rotation angle here, therefore,
         # we have a branch for small angles where the singularity is not present.
-        if omega_norm**2 > mpy.eps_quaternion:
+        if omega_norm**2 > _mpy.eps_quaternion:
             # Taken from Jelenic and Crisfield (1999) Equation (2.5)
             omega_dir = omega / omega_norm
             omega_skew = skew_matrix(omega)
@@ -316,8 +316,8 @@ class Rotation:
 
         if isinstance(other, Rotation):
             return bool(
-                (np.linalg.norm(self.q - other.q) < mpy.eps_quaternion)
-                or (np.linalg.norm(self.q + other.q) < mpy.eps_quaternion)
+                (np.linalg.norm(self.q - other.q) < _mpy.eps_quaternion)
+                or (np.linalg.norm(self.q + other.q) < _mpy.eps_quaternion)
             )
         else:
             return object.__eq__(self, other)
@@ -331,8 +331,8 @@ class Rotation:
         return " ".join(
             [
                 (
-                    mpy.dat_precision.format(component + 0)
-                    if np.abs(component) >= mpy.eps_quaternion
+                    _mpy.dat_precision.format(component + 0)
+                    if np.abs(component) >= _mpy.eps_quaternion
                     else "0"
                 )
                 for component in rotation_vector

--- a/src/meshpy/core/vtk_writer.py
+++ b/src/meshpy/core/vtk_writer.py
@@ -28,7 +28,7 @@ import warnings
 import numpy as np
 import vtk
 
-from meshpy.core.conf import mpy
+from meshpy.core.conf import mpy as _mpy
 
 
 def add_point_data_node_sets(point_data, nodes, *, extra_points=0):
@@ -57,27 +57,27 @@ def add_point_data_node_sets(point_data, nodes, *, extra_points=0):
             if geometry_set in node.node_sets_link:
                 data_vector[i] = 1
             else:
-                data_vector[i] = mpy.vtk_nan_int
+                data_vector[i] = _mpy.vtk_nan_int
         for i in range(extra_points):
             data_vector[n_nodes + i] = (
-                1 if geometry_set.geometry_type is mpy.geo.line else mpy.vtk_nan_int
+                1 if geometry_set.geometry_type is _mpy.geo.line else _mpy.vtk_nan_int
             )
 
         # Get the name of the geometry type.
-        if geometry_set.geometry_type is mpy.geo.point:
+        if geometry_set.geometry_type is _mpy.geo.point:
             geometry_name = "geometry_point"
-        elif geometry_set.geometry_type is mpy.geo.line:
+        elif geometry_set.geometry_type is _mpy.geo.line:
             geometry_name = "geometry_line"
-        elif geometry_set.geometry_type is mpy.geo.surface:
+        elif geometry_set.geometry_type is _mpy.geo.surface:
             geometry_name = "geometry_surface"
-        elif geometry_set.geometry_type is mpy.geo.volume:
+        elif geometry_set.geometry_type is _mpy.geo.volume:
             geometry_name = "geometry_volume"
         else:
             raise TypeError("The geometry type is wrong!")
 
         # Add the data vector.
-        set_name = f"{geometry_name}_set_{mpy.vtk_node_set_format.format(geometry_set.i_global)}"
-        point_data[set_name] = (data_vector, mpy.vtk_type.int)
+        set_name = f"{geometry_name}_set_{_mpy.vtk_node_set_format.format(geometry_set.i_global)}"
+        point_data[set_name] = (data_vector, _mpy.vtk_type.int)
 
 
 def _get_data_value_and_type(data):
@@ -88,16 +88,16 @@ def _get_data_value_and_type(data):
     if isinstance(data, tuple):
         return data[0], data[1]
     else:
-        return data, mpy.vtk_type.float
+        return data, _mpy.vtk_type.float
 
 
 def _get_vtk_array_type(data):
     """Return the corresponding meshpy type."""
     data_type = data.GetDataTypeAsString()
     if data_type == "int":
-        return mpy.vtk_type.int
+        return _mpy.vtk_type.int
     elif data_type == "double":
-        return mpy.vtk_type.float
+        return _mpy.vtk_type.float
     raise ValueError(f'Got unexpected type "{data_type}"!')
 
 
@@ -115,8 +115,8 @@ class VTKWriter:
 
         # Container for output data.
         self.data = {}
-        for key1 in mpy.vtk_geo:
-            for key2 in mpy.vtk_tensor:
+        for key1 in _mpy.vtk_geo:
+            for key2 in _mpy.vtk_tensor:
                 self.data[key1, key2] = {}
 
     def add_points(self, points, *, point_data=None):
@@ -150,7 +150,7 @@ class VTKWriter:
                     )
 
         # Add point data
-        self._add_data(point_data, mpy.vtk_geo.point, n_new_items=n_points)
+        self._add_data(point_data, _mpy.vtk_geo.point, n_new_items=n_points)
 
         # Add point coordinates
         n_grid_points = self.points.GetNumberOfPoints()
@@ -178,7 +178,7 @@ class VTKWriter:
         """
 
         # Add the data entries.
-        self._add_data(cell_data, mpy.vtk_geo.cell)
+        self._add_data(cell_data, _mpy.vtk_geo.cell)
 
         # Create the cell.
         geometry_item = cell_type()
@@ -210,7 +210,7 @@ class VTKWriter:
         # Check if data container already exists. If not, add it and also add
         # previous entries.
         if data_container is not None:
-            if vtk_geom_type == mpy.vtk_geo.cell:
+            if vtk_geom_type == _mpy.vtk_geo.cell:
                 n_items = self.grid.GetNumberOfCells()
             else:
                 n_items = self.grid.GetNumberOfPoints()
@@ -220,7 +220,7 @@ class VTKWriter:
                 value, data_type = _get_data_value_and_type(item_value)
 
                 # Data type.
-                if vtk_geom_type == mpy.vtk_geo.cell:
+                if vtk_geom_type == _mpy.vtk_geo.cell:
                     vtk_tensor_type = self._get_vtk_data_type(value)
                 else:
                     for item in value:
@@ -229,12 +229,12 @@ class VTKWriter:
                 # Check if key already exists.
                 if key not in self.data[vtk_geom_type, vtk_tensor_type].keys():
                     # Set up the VTK data array.
-                    if data_type is mpy.vtk_type.float:
+                    if data_type is _mpy.vtk_type.float:
                         data = vtk.vtkDoubleArray()
                     else:
                         data = vtk.vtkIntArray()
                     data.SetName(key)
-                    if vtk_tensor_type == mpy.vtk_tensor.scalar:
+                    if vtk_tensor_type == _mpy.vtk_tensor.scalar:
                         data.SetNumberOfComponents(1)
                     else:
                         data.SetNumberOfComponents(3)
@@ -260,7 +260,7 @@ class VTKWriter:
 
         # Add to global data. Check if there is something to be added. If not an empty value
         # is added.
-        for key_tensor in mpy.vtk_tensor:
+        for key_tensor in _mpy.vtk_tensor:
             global_data = self.data[vtk_geom_type, key_tensor]
             if data_container is None:
                 data_container = {}
@@ -272,7 +272,7 @@ class VTKWriter:
                     data_values, _ = _get_data_value_and_type(data_container[key])
 
                     # Add the given data.
-                    if vtk_geom_type == mpy.vtk_geo.cell:
+                    if vtk_geom_type == _mpy.vtk_geo.cell:
                         self._add_single_data_item(
                             value, key_tensor, non_zero_data=data_values
                         )
@@ -283,7 +283,7 @@ class VTKWriter:
                             )
                 else:
                     # Add empty data.
-                    if vtk_geom_type == mpy.vtk_geo.cell:
+                    if vtk_geom_type == _mpy.vtk_geo.cell:
                         self._add_single_data_item(value, key_tensor)
                     else:
                         for item in range(n_new_items):
@@ -298,12 +298,12 @@ class VTKWriter:
 
         if isinstance(data, (list, np.ndarray)):
             if len(data) == 3:
-                return mpy.vtk_tensor.vector
+                return _mpy.vtk_tensor.vector
             raise IndexError(
                 f"Only 3d vectors are implemented yet! Got len(data) = {len(data)}"
             )
         elif isinstance(data, numbers.Number):
-            return mpy.vtk_tensor.scalar
+            return _mpy.vtk_tensor.scalar
 
         raise ValueError(f"Data {data} did not match any expected case!")
 
@@ -311,12 +311,12 @@ class VTKWriter:
     def _add_single_data_item(data, vtk_tensor_type, non_zero_data=None):
         """Add data to a VTK data array."""
 
-        if _get_vtk_array_type(data) == mpy.vtk_type.int:
-            nan_value = mpy.vtk_nan_int
-        elif _get_vtk_array_type(data) == mpy.vtk_type.float:
-            nan_value = mpy.vtk_nan_float
+        if _get_vtk_array_type(data) == _mpy.vtk_type.int:
+            nan_value = _mpy.vtk_nan_int
+        elif _get_vtk_array_type(data) == _mpy.vtk_type.float:
+            nan_value = _mpy.vtk_nan_float
 
-        if vtk_tensor_type == mpy.vtk_tensor.scalar:
+        if vtk_tensor_type == _mpy.vtk_tensor.scalar:
             if non_zero_data is None:
                 data.InsertNextTuple1(nan_value)
             else:
@@ -333,7 +333,7 @@ class VTKWriter:
         """Add the stored data to the vtk grid."""
         for (key_geom, _key_data), value in self.data.items():
             for vtk_data in value.values():
-                if key_geom == mpy.vtk_geo.cell:
+                if key_geom == _mpy.vtk_geo.cell:
                     self.grid.GetCellData().AddArray(vtk_data)
                 else:
                     self.grid.GetPointData().AddArray(vtk_data)

--- a/src/meshpy/core/vtk_writer.py
+++ b/src/meshpy/core/vtk_writer.py
@@ -21,12 +21,12 @@
 # THE SOFTWARE.
 """This module provides a class that is used to write VTK files."""
 
-import numbers
-import os
-import warnings
+import numbers as _numbers
+import os as _os
+import warnings as _warnings
 
-import numpy as np
-import vtk
+import numpy as _np
+import vtk as _vtk
 
 from meshpy.core.conf import mpy as _mpy
 
@@ -52,7 +52,7 @@ def add_point_data_node_sets(point_data, nodes, *, extra_points=0):
     n_nodes = len(nodes)
     for geometry_set in geometry_set_list:
         # Check which nodes are connected to a geometry set.
-        data_vector = np.zeros(n_nodes + extra_points)
+        data_vector = _np.zeros(n_nodes + extra_points)
         for i, node in enumerate(nodes):
             if geometry_set in node.node_sets_link:
                 data_vector[i] = 1
@@ -106,9 +106,9 @@ class VTKWriter:
 
     def __init__(self):
         # Initialize VTK objects.
-        self.points = vtk.vtkPoints()
+        self.points = _vtk.vtkPoints()
         self.points.SetDataTypeToDouble()
-        self.grid = vtk.vtkUnstructuredGrid()
+        self.grid = _vtk.vtkUnstructuredGrid()
 
         # Link points to grid.
         self.grid.SetPoints(self.points)
@@ -158,7 +158,7 @@ class VTKWriter:
             # Add the coordinate to the global list of coordinates.
             self.points.InsertNextPoint(*point)
 
-        return np.array(
+        return _np.array(
             [n_grid_points + i_point for i_point in range(len(points))], dtype=int
         )
 
@@ -230,9 +230,9 @@ class VTKWriter:
                 if key not in self.data[vtk_geom_type, vtk_tensor_type].keys():
                     # Set up the VTK data array.
                     if data_type is _mpy.vtk_type.float:
-                        data = vtk.vtkDoubleArray()
+                        data = _vtk.vtkDoubleArray()
                     else:
-                        data = vtk.vtkIntArray()
+                        data = _vtk.vtkIntArray()
                     data.SetName(key)
                     if vtk_tensor_type == _mpy.vtk_tensor.scalar:
                         data.SetNumberOfComponents(1)
@@ -296,13 +296,13 @@ class VTKWriter:
         Check if data matches an expected case.
         """
 
-        if isinstance(data, (list, np.ndarray)):
+        if isinstance(data, (list, _np.ndarray)):
             if len(data) == 3:
                 return _mpy.vtk_tensor.vector
             raise IndexError(
                 f"Only 3d vectors are implemented yet! Got len(data) = {len(data)}"
             )
-        elif isinstance(data, numbers.Number):
+        elif isinstance(data, _numbers.Number):
             return _mpy.vtk_tensor.scalar
 
         raise ValueError(f"Data {data} did not match any expected case!")
@@ -350,19 +350,19 @@ class VTKWriter:
         """
 
         # Check if directory for file exits.
-        file_directory = os.path.dirname(filepath)
-        if not os.path.isdir(file_directory):
+        file_directory = _os.path.dirname(filepath)
+        if not _os.path.isdir(file_directory):
             raise ValueError(f"Directory {file_directory} does not exist!".format())
 
         # Initialize VTK writer.
-        writer = vtk.vtkXMLUnstructuredGridWriter()
+        writer = _vtk.vtkXMLUnstructuredGridWriter()
 
         # Set the ascii flag.
         if not binary:
             writer.SetDataModeToAscii()
 
         # Check the file extension.
-        _filename, file_extension = os.path.splitext(filepath)
+        _filename, file_extension = _os.path.splitext(filepath)
         if not file_extension.lower() == ".vtu":
             warnings.warn(f'The extension should be "vtu", got {file_extension}!')
 

--- a/src/meshpy/four_c/beam_interaction_conditions.py
+++ b/src/meshpy/four_c/beam_interaction_conditions.py
@@ -22,10 +22,10 @@
 """This file contains a function to add the beam interaction conditions for
 4C."""
 
-import re
-from typing import Optional
+import re as _re
+from typing import Optional as _Optional
 
-import meshpy.core.conf as _conf_typing
+import meshpy.core.conf as _conf
 from meshpy.core.geometry_set import GeometrySet as _GeometrySet
 from meshpy.core.mesh import Mesh as _Mesh
 from meshpy.four_c.boundary_condition import BoundaryCondition as _BoundaryCondition
@@ -33,8 +33,8 @@ from meshpy.four_c.boundary_condition import BoundaryCondition as _BoundaryCondi
 
 def get_next_possible_id_for_boundary_condition(
     mesh: _Mesh,
-    bc_type: _conf_typing.BoundaryCondition,
-    geometry_type: _conf_typing.Geometry,
+    bc_type: _conf.BoundaryCondition,
+    geometry_type: _conf.Geometry,
     regex_search_string: str,
     *,
     group_idx: int = 1,
@@ -71,7 +71,7 @@ def get_next_possible_id_for_boundary_condition(
 
         # compare string of each condition with input and store existing ids
         for bc in found_conditions:
-            match = re.search(regex_search_string, bc.bc_string)
+            match = _re.search(regex_search_string, bc.bc_string)
             if match is None:
                 raise ValueError(
                     "The string provided "
@@ -89,9 +89,9 @@ def add_beam_interaction_condition(
     mesh: _Mesh,
     geometry_set_1: _GeometrySet,
     geometry_set_2: _GeometrySet,
-    bc_type: _conf_typing.BoundaryCondition,
+    bc_type: _conf.BoundaryCondition,
     *,
-    id: Optional[int] = None,
+    id: _Optional[int] = None,
 ) -> int:
     """Adds a pair of beam interaction boundary conditions to the given mesh
     and estimates automatically the id of them based on all previously added
@@ -113,14 +113,14 @@ def add_beam_interaction_condition(
             mesh,
             bc_type,
             geometry_set_1.geometry_type,
-            regex_search_string=re.escape(condition_string) + r"(\d+)",
+            regex_search_string=_re.escape(condition_string) + r"(\d+)",
         )
 
         id_2 = get_next_possible_id_for_boundary_condition(
             mesh,
             bc_type,
             geometry_set_2.geometry_type,
-            regex_search_string=re.escape(condition_string) + r"(\d+)",
+            regex_search_string=_re.escape(condition_string) + r"(\d+)",
         )
 
         if not id == id_2:

--- a/src/meshpy/four_c/beam_interaction_conditions.py
+++ b/src/meshpy/four_c/beam_interaction_conditions.py
@@ -25,17 +25,16 @@
 import re
 from typing import Optional
 
-import meshpy.core.conf as conf_typing
-from meshpy.core.conf import mpy
-from meshpy.core.geometry_set import GeometrySet
-from meshpy.core.mesh import Mesh
-from meshpy.four_c.boundary_condition import BoundaryCondition
+import meshpy.core.conf as _conf_typing
+from meshpy.core.geometry_set import GeometrySet as _GeometrySet
+from meshpy.core.mesh import Mesh as _Mesh
+from meshpy.four_c.boundary_condition import BoundaryCondition as _BoundaryCondition
 
 
 def get_next_possible_id_for_boundary_condition(
-    mesh: Mesh,
-    bc_type: conf_typing.BoundaryCondition,
-    geometry_type: conf_typing.Geometry,
+    mesh: _Mesh,
+    bc_type: _conf_typing.BoundaryCondition,
+    geometry_type: _conf_typing.Geometry,
     regex_search_string: str,
     *,
     group_idx: int = 1,
@@ -87,10 +86,10 @@ def get_next_possible_id_for_boundary_condition(
 
 
 def add_beam_interaction_condition(
-    mesh: Mesh,
-    geometry_set_1: GeometrySet,
-    geometry_set_2: GeometrySet,
-    bc_type: conf_typing.BoundaryCondition,
+    mesh: _Mesh,
+    geometry_set_1: _GeometrySet,
+    geometry_set_2: _GeometrySet,
+    bc_type: _conf_typing.BoundaryCondition,
     *,
     id: Optional[int] = None,
 ) -> int:
@@ -132,7 +131,7 @@ def add_beam_interaction_condition(
     # Creates the two conditions with the same ID.
     for geometry_set in [geometry_set_1, geometry_set_2]:
         mesh.add(
-            BoundaryCondition(
+            _BoundaryCondition(
                 geometry_set, bc_string=condition_string + str(id), bc_type=bc_type
             )
         )

--- a/src/meshpy/four_c/beam_potential.py
+++ b/src/meshpy/four_c/beam_potential.py
@@ -22,9 +22,9 @@
 """This file includes functions to ease the creation of input files using beam
 interaction potentials."""
 
-from meshpy.four_c.boundary_condition import BoundaryCondition
-from meshpy.four_c.header_functions import get_yes_no
-from meshpy.four_c.input_file import InputSection
+from meshpy.four_c.boundary_condition import BoundaryCondition as _BoundaryCondition
+from meshpy.four_c.header_functions import get_yes_no as _get_yes_no
+from meshpy.four_c.input_file import InputSection as _InputSection
 
 
 class BeamPotential:
@@ -149,7 +149,7 @@ class BeamPotential:
             NUM_INTEGRATION_SEGMENTS        {integration_segments}
             NUM_GAUSSPOINTS                 {gauss_points}
             POTENTIAL_REDUCTION_LENGTH      {potential_reduction_length}
-            AUTOMATIC_DIFFERENTIATION       {get_yes_no(automatic_differentiation)}"""
+            AUTOMATIC_DIFFERENTIATION       {_get_yes_no(automatic_differentiation)}"""
 
         if regularization_type is not None:
             settings += f"""
@@ -160,7 +160,7 @@ class BeamPotential:
             settings += f"\nCHOICE_MASTER_SLAVE             {choice_master_slave}"
 
         self.input_file.add(
-            InputSection(
+            _InputSection(
                 "BEAM POTENTIAL",
                 settings,
                 option_overwrite=option_overwrite,
@@ -204,16 +204,16 @@ class BeamPotential:
         """
 
         self.input_file.add(
-            InputSection(
+            _InputSection(
                 "BEAM POTENTIAL/RUNTIME VTK OUTPUT",
                 f"""
-            VTK_OUTPUT_BEAM_POTENTIAL           {get_yes_no(output_beam_potential)}
+            VTK_OUTPUT_BEAM_POTENTIAL           {_get_yes_no(output_beam_potential)}
             INTERVAL_STEPS                      {interval_steps}
-            EVERY_ITERATION                     {get_yes_no(every_iteration)}
-            FORCES                              {get_yes_no(forces)}
-            MOMENTS                             {get_yes_no(moments)}
-            WRITE_UIDS                          {get_yes_no(uids)}
-            WRITE_FORCE_MOMENT_PER_ELEMENTPAIR  {get_yes_no(per_ele_pair)}""",
+            EVERY_ITERATION                     {_get_yes_no(every_iteration)}
+            FORCES                              {_get_yes_no(forces)}
+            MOMENTS                             {_get_yes_no(moments)}
+            WRITE_UIDS                          {_get_yes_no(uids)}
+            WRITE_FORCE_MOMENT_PER_ELEMENTPAIR  {_get_yes_no(per_ele_pair)}""",
                 option_overwrite=option_overwrite,
             )
         )
@@ -235,7 +235,7 @@ class BeamPotential:
             if func != "none":
                 self.input_file.add(func)
 
-            bc = BoundaryCondition(
+            bc = _BoundaryCondition(
                 geometry_set,
                 f"POTLAW {i + 1} VAL {line_charge} FUNCT {{}}",
                 bc_type="DESIGN LINE BEAM POTENTIAL CHARGE CONDITIONS",

--- a/src/meshpy/four_c/beam_potential.py
+++ b/src/meshpy/four_c/beam_potential.py
@@ -46,15 +46,15 @@ class BeamPotential:
         ----
         input_file:
             Input file of current problem setup.
-        pot_law_prefactors: float, int, np.array, list
+        pot_law_prefactors: float, int, _np.array, list
             Prefactors of a potential law in form of a power law. Same number
             of prefactors and exponents/line charge densities/functions must be
             provided!
-        pot_law_exponent: float, int, np.array, list
+        pot_law_exponent: float, int, _np.array, list
             Exponents of a potential law in form of a power law. Same number
             of exponents and prefactors/line charge densities/functions must be
             provided!
-        pot_law_line_charge_density: float, int, np.array, list
+        pot_law_line_charge_density: float, int, _np.array, list
             Line charge densities of a potential law in form of a power law.
             Same number of line charge densities and prefactors/exponents/functions
             must be provided!

--- a/src/meshpy/four_c/boundary_condition.py
+++ b/src/meshpy/four_c/boundary_condition.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 """This module implements a class to handle boundary conditions in 4C."""
 
-import warnings
+import warnings as _warnings
 
 from meshpy.core.boundary_condition import (
     BoundaryConditionBase as _BoundaryConditionBase,

--- a/src/meshpy/four_c/boundary_condition.py
+++ b/src/meshpy/four_c/boundary_condition.py
@@ -23,13 +23,15 @@
 
 import warnings
 
-from meshpy.core.boundary_condition import BoundaryConditionBase
-from meshpy.core.conf import mpy
-from meshpy.core.geometry_set import GeometrySet
-from meshpy.utils.nodes import find_close_nodes
+from meshpy.core.boundary_condition import (
+    BoundaryConditionBase as _BoundaryConditionBase,
+)
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.geometry_set import GeometrySet as _GeometrySet
+from meshpy.utils.nodes import find_close_nodes as _find_close_nodes
 
 
-class BoundaryCondition(BoundaryConditionBase):
+class BoundaryCondition(_BoundaryConditionBase):
     """This object represents a Dirichlet, Neumann or beam-to-solid boundary
     condition."""
 
@@ -61,7 +63,7 @@ class BoundaryCondition(BoundaryConditionBase):
             conditions do contain nodes at the same spatial positions.
         """
 
-        BoundaryConditionBase.__init__(self, geometry_set, bc_type=bc_type, **kwargs)
+        _BoundaryConditionBase.__init__(self, geometry_set, bc_type=bc_type, **kwargs)
         self.bc_string = bc_string
         self.format_replacement = format_replacement
         self.double_nodes = double_nodes
@@ -93,15 +95,15 @@ class BoundaryCondition(BoundaryConditionBase):
             # In the case of solid imports this is a integer at initialization.
             return
 
-        if self.double_nodes is mpy.double_nodes.keep:
+        if self.double_nodes is _mpy.double_nodes.keep:
             return
 
         if (
-            self.bc_type == mpy.bc.neumann
-            and self.geometry_set.geometry_type == mpy.geo.point
+            self.bc_type == _mpy.bc.neumann
+            and self.geometry_set.geometry_type == _mpy.geo.point
         ):
             my_nodes = self.geometry_set.get_points()
-            partners = find_close_nodes(my_nodes)
+            partners = _find_close_nodes(my_nodes)
             # Create a list with nodes that will not be kept in the set.
             double_node_list = []
             for node_list in partners:
@@ -110,10 +112,10 @@ class BoundaryCondition(BoundaryConditionBase):
                         double_node_list.append(node)
             if (
                 len(double_node_list) > 0
-                and self.double_nodes is mpy.double_nodes.remove
+                and self.double_nodes is _mpy.double_nodes.remove
             ):
                 # Create the a new geometry set with the unique nodes.
-                self.geometry_set = GeometrySet(
+                self.geometry_set = _GeometrySet(
                     [node for node in my_nodes if (node not in double_node_list)]
                 )
             elif len(double_node_list) > 0:

--- a/src/meshpy/four_c/dbc_monitor.py
+++ b/src/meshpy/four_c/dbc_monitor.py
@@ -26,15 +26,17 @@ from typing import Optional
 
 import numpy as np
 
-from meshpy.core.conf import mpy
-from meshpy.core.geometry_set import GeometrySet
-from meshpy.four_c.boundary_condition import BoundaryCondition
-from meshpy.four_c.function import Function
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.geometry_set import GeometrySet as _GeometrySet
+from meshpy.four_c.boundary_condition import BoundaryCondition as _BoundaryCondition
+from meshpy.four_c.function import Function as _Function
 from meshpy.four_c.function_utility import (
-    create_linear_interpolation_function,
-    ensure_length_of_function_array,
+    create_linear_interpolation_function as _create_linear_interpolation_function,
 )
-from meshpy.four_c.input_file import InputFile
+from meshpy.four_c.function_utility import (
+    ensure_length_of_function_array as _ensure_length_of_function_array,
+)
+from meshpy.four_c.input_file import InputFile as _InputFile
 
 
 def linear_time_transformation(
@@ -146,9 +148,9 @@ def read_dbc_monitor_file(file_path):
 
 
 def add_point_neuman_condition_to_input_file(
-    input_file: InputFile,
+    input_file: _InputFile,
     nodes: list[int],
-    function_array: list[Function],
+    function_array: list[_Function],
     force: np.ndarray,
     *,
     n_dof: int = 3,
@@ -177,7 +179,7 @@ def add_point_neuman_condition_to_input_file(
             f"The forces vector must have dimensions [3x1] not [{force.size}x1]"
         )
 
-    function_array = ensure_length_of_function_array(function_array, 3)
+    function_array = _ensure_length_of_function_array(function_array, 3)
 
     # Add the function to the input file, if they are not previously added.
     for function in function_array:
@@ -185,31 +187,31 @@ def add_point_neuman_condition_to_input_file(
 
     # Create GeometrySet with nodes.
     mesh_nodes = [input_file.nodes[i_node] for i_node in nodes]
-    geo = GeometrySet(mesh_nodes)
+    geo = _GeometrySet(mesh_nodes)
 
     # Create the Boundary Condition.
     extra_dof_zero = " 0" * (n_dof - 3)
-    bc = BoundaryCondition(
+    bc = _BoundaryCondition(
         geo,
         (
             "NUMDOF {n_dof} ONOFF 1 1 1{edz} VAL {data[0]} {data[1]} {data[2]}"
             "{edz} FUNCT {{}} {{}} {{}}{edz}"
         ).format(n_dof=n_dof, data=force, edz=extra_dof_zero),
-        bc_type=mpy.bc.neumann,
+        bc_type=_mpy.bc.neumann,
         format_replacement=function_array,
     )
     input_file.add(bc)
 
 
 def dbc_monitor_to_input_all_values(
-    input_file: InputFile,
+    input_file: _InputFile,
     file_path: str,
     *,
     steps: list[int] = [],
     time_span: list[int] = [0, 1, 2],
     type: Optional[str] = "linear",
     flip_time_values: bool = False,
-    functions: list[Function] = [],
+    functions: list[_Function] = [],
     **kwargs,
 ):
     """Extracts all the force values of the monitored Dirichlet boundary
@@ -315,7 +317,7 @@ def dbc_monitor_to_input_all_values(
     if not type == "linear":
         for dim in range(force.shape[1]):
             # create a linear function with the force values per dimension
-            fun = create_linear_interpolation_function(
+            fun = _create_linear_interpolation_function(
                 time, force[:, dim], function_type="SYMBOLIC_FUNCTION_OF_TIME"
             )
 
@@ -338,11 +340,11 @@ def dbc_monitor_to_input_all_values(
 
 
 def dbc_monitor_to_input(
-    input_file: InputFile,
+    input_file: _InputFile,
     file_path: str,
     *,
     step: int = -1,
-    function: Function,
+    function: _Function,
     **kwargs,
 ):
     """Converts the last value of a Dirichlet boundary condition monitor log to

--- a/src/meshpy/four_c/dbc_monitor.py
+++ b/src/meshpy/four_c/dbc_monitor.py
@@ -22,9 +22,9 @@
 """This function converts the DBC monitor log files to Neumann input
 sections."""
 
-from typing import Optional
+from typing import Optional as _Optional
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.geometry_set import GeometrySet as _GeometrySet
@@ -47,9 +47,9 @@ def linear_time_transformation(
 
     Args
     ----
-    time: np.array
+    time: _np.array
         array with time values
-    values: np.array
+    values: _np.array
         corresponding values to time
     time_span: [list] with 2 or 3 entries:
         time_span[0:2] defines the time interval to which the initial time interval should be scaled.
@@ -62,12 +62,12 @@ def linear_time_transformation(
 
     # flip values if desired and adjust time
     if flip is True:
-        values = np.flipud(values)
-        time = np.flip(-time) + time[-1]
+        values = _np.flipud(values)
+        time = _np.flip(-time) + time[-1]
 
     # transform time to interval
-    min_t = np.min(time)
-    max_t = np.max(time)
+    min_t = _np.min(time)
+    max_t = _np.max(time)
 
     # scaling/transforming the time into the user defined time
     time = time_span[0] + (time - min_t) * (time_span[1] - time_span[0]) / (
@@ -77,21 +77,21 @@ def linear_time_transformation(
     # ensure that start time is valid
     if valid_start_and_end_point and time[0] > 0.0:
         # add starting time 0
-        time = np.append(0.0, time)
+        time = _np.append(0.0, time)
 
         # add first coordinate again at the beginning of the array
         if len(values.shape) == 1:
-            values = np.append(values[0], values)
+            values = _np.append(values[0], values)
         else:
-            values = np.append(values[0], values).reshape(
+            values = _np.append(values[0], values).reshape(
                 values.shape[0] + 1, values.shape[1]
             )
 
     # repeat last value at provided time point
     if valid_start_and_end_point and len(time_span) > 2:
         if time_span[2] > time_span[1]:
-            time = np.append(time, time_span[2])
-            values = np.append(values, values[-1]).reshape(
+            time = _np.append(time, time_span[2])
+            values = _np.append(values, values[-1]).reshape(
                 values.shape[0] + 1, values.shape[1]
             )
     if not valid_start_and_end_point and len(time_span) > 2:
@@ -141,8 +141,8 @@ def read_dbc_monitor_file(file_path):
     # Get the monitor data.
     data = []
     for line in lines[start_line:]:
-        data.append(np.fromstring(line, dtype=float, sep=" "))
-    data = np.array(data)
+        data.append(_np.fromstring(line, dtype=float, sep=" "))
+    data = _np.array(data)
 
     return nodes, data[:, 1], data[:, 4:7], data[:, 7:]
 
@@ -151,7 +151,7 @@ def add_point_neuman_condition_to_input_file(
     input_file: _InputFile,
     nodes: list[int],
     function_array: list[_Function],
-    force: np.ndarray,
+    force: _np.ndarray,
     *,
     n_dof: int = 3,
 ):
@@ -167,7 +167,7 @@ def add_point_neuman_condition_to_input_file(
         list containing the ids of the nodes for the condition
     function_array: [function]
         list with functions
-    force: [np.ndarray]
+    force: [_np.ndarray]
         values to scale the function array with
     n_dof: int
         Number of DOFs per node.
@@ -209,7 +209,7 @@ def dbc_monitor_to_input_all_values(
     *,
     steps: list[int] = [],
     time_span: list[int] = [0, 1, 2],
-    type: Optional[str] = "linear",
+    type: _Optional[str] = "linear",
     flip_time_values: bool = False,
     functions: list[_Function] = [],
     **kwargs,
@@ -299,12 +299,12 @@ def dbc_monitor_to_input_all_values(
         )
 
         # remove first element since it is duplicated zero
-        np.delete(time2, 0)
-        np.delete(force2, 0)
+        _np.delete(time2, 0)
+        _np.delete(force2, 0)
 
         # add the respective force
-        time = np.concatenate((time1, time2[1:]))
-        force = np.concatenate((force1, force2[1:]), axis=0)
+        time = _np.concatenate((time1, time2[1:]))
+        force = _np.concatenate((force1, force2[1:]), axis=0)
 
     else:
         raise ValueError(
@@ -328,7 +328,7 @@ def dbc_monitor_to_input_all_values(
             functions.append(fun)
 
         # now set forces to 1 since the force values are already extracted in the function's values
-        force = np.zeros_like(force) + 1.0
+        force = _np.zeros_like(force) + 1.0
 
     elif len(functions) != 3:
         raise ValueError("Please provide functions with ")

--- a/src/meshpy/four_c/element_beam.py
+++ b/src/meshpy/four_c/element_beam.py
@@ -21,9 +21,9 @@
 # THE SOFTWARE.
 """This file implements beam elements for 4C."""
 
-import warnings
+import warnings as _warnings
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.element_beam import Beam as _Beam
@@ -114,7 +114,7 @@ class Beam3kClass(_Beam):
 
         # Show warning when not using rotvec.
         if not rotvec:
-            warnings.warn(
+            _warnings.warn(
                 "Use rotvec=False with caution, especially when applying the boundary conditions "
                 "and couplings."
             )
@@ -182,7 +182,7 @@ class Beam3eb(_Beam):
             )
         direction = self.nodes[1].coordinates - self.nodes[0].coordinates
         t1 = self.nodes[0].rotation * [1, 0, 0]
-        if np.linalg.norm(direction / np.linalg.norm(direction) - t1) >= _mpy.eps_pos:
+        if _np.linalg.norm(direction / _np.linalg.norm(direction) - t1) >= _mpy.eps_pos:
             raise ValueError(
                 "The rotations do not match the direction of the Euler Bernoulli beam!"
             )

--- a/src/meshpy/four_c/element_beam.py
+++ b/src/meshpy/four_c/element_beam.py
@@ -25,22 +25,22 @@ import warnings
 
 import numpy as np
 
-from meshpy.core.conf import mpy
-from meshpy.core.element_beam import Beam
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.element_beam import Beam as _Beam
+from meshpy.four_c.material import MaterialEulerBernoulli as _MaterialEulerBernoulli
+from meshpy.four_c.material import MaterialKirchhoff as _MaterialKirchhoff
+from meshpy.four_c.material import MaterialReissner as _MaterialReissner
 from meshpy.four_c.material import (
-    MaterialEulerBernoulli,
-    MaterialKirchhoff,
-    MaterialReissner,
-    MaterialReissnerElastoplastic,
+    MaterialReissnerElastoplastic as _MaterialReissnerElastoplastic,
 )
 
 
-class Beam3rHerm2Line3(Beam):
+class Beam3rHerm2Line3(_Beam):
     """Represents a BEAM3R HERM2LINE3 element."""
 
     nodes_create = [-1, 0, 1]
-    beam_type = mpy.beam.reissner
-    valid_material = [MaterialReissner, MaterialReissnerElastoplastic]
+    beam_type = _mpy.beam.reissner
+    valid_material = [_MaterialReissner, _MaterialReissnerElastoplastic]
 
     coupling_fix_string = "NUMDOF 9 ONOFF 1 1 1 1 1 1 0 0 0"
     coupling_joint_string = "NUMDOF 9 ONOFF 1 1 1 0 0 0 0 0 0"
@@ -64,13 +64,13 @@ class Beam3rHerm2Line3(Beam):
         )
 
 
-class Beam3rLine2Line2(Beam):
+class Beam3rLine2Line2(_Beam):
     """Represents a Reissner beam with linear shapefunctions in the rotations
     as well as the displacements."""
 
     nodes_create = [-1, 1]
-    beam_type = mpy.beam.reissner
-    valid_material = [MaterialReissner]
+    beam_type = _mpy.beam.reissner
+    valid_material = [_MaterialReissner]
 
     coupling_fix_string = "NUMDOF 6 ONOFF 1 1 1 1 1 1"
     coupling_joint_string = "NUMDOF 6 ONOFF 1 1 1 0 0 0"
@@ -94,18 +94,18 @@ class Beam3rLine2Line2(Beam):
         )
 
 
-class Beam3kClass(Beam):
+class Beam3kClass(_Beam):
     """Represents a Kirchhoff beam element."""
 
     nodes_create = [-1, 0, 1]
-    beam_type = mpy.beam.kirchhoff
-    valid_material = [MaterialKirchhoff]
+    beam_type = _mpy.beam.kirchhoff
+    valid_material = [_MaterialKirchhoff]
 
     coupling_fix_string = "NUMDOF 7 ONOFF 1 1 1 1 1 1 0"
     coupling_joint_string = "NUMDOF 7 ONOFF 1 1 1 0 0 0 0"
 
     def __init__(self, *, weak=True, rotvec=True, is_fad=True, **kwargs):
-        Beam.__init__(self, **kwargs)
+        _Beam.__init__(self, **kwargs)
 
         # Set the parameters for this beam.
         self.weak = weak
@@ -163,12 +163,12 @@ def Beam3k(**kwargs_class):
     return create_class
 
 
-class Beam3eb(Beam):
+class Beam3eb(_Beam):
     """Represents a Euler Bernoulli beam element."""
 
     nodes_create = [-1, 1]
-    beam_type = mpy.beam.euler_bernoulli
-    valid_material = [MaterialEulerBernoulli]
+    beam_type = _mpy.beam.euler_bernoulli
+    valid_material = [_MaterialEulerBernoulli]
 
     def _get_dat(self):
         """Return the line for the input file."""
@@ -182,7 +182,7 @@ class Beam3eb(Beam):
             )
         direction = self.nodes[1].coordinates - self.nodes[0].coordinates
         t1 = self.nodes[0].rotation * [1, 0, 0]
-        if np.linalg.norm(direction / np.linalg.norm(direction) - t1) >= mpy.eps_pos:
+        if np.linalg.norm(direction / np.linalg.norm(direction) - t1) >= _mpy.eps_pos:
             raise ValueError(
                 "The rotations do not match the direction of the Euler Bernoulli beam!"
             )

--- a/src/meshpy/four_c/element_volume.py
+++ b/src/meshpy/four_c/element_volume.py
@@ -21,15 +21,15 @@
 # THE SOFTWARE.
 """This file implements volume elements for 4C."""
 
-from meshpy.core.element_volume import VolumeElement
+from meshpy.core.element_volume import VolumeElement as _VolumeElement
 
 
-class SolidRigidSphere(VolumeElement):
+class SolidRigidSphere(_VolumeElement):
     """A rigid sphere solid element."""
 
     def __init__(self, **kwargs):
         """Initialize solid sphere object."""
-        VolumeElement.__init__(self, **kwargs)
+        _VolumeElement.__init__(self, **kwargs)
 
         # Set radius of sphere from input file.
         arg_name = self.dat_post_nodes.split()[0]

--- a/src/meshpy/four_c/function.py
+++ b/src/meshpy/four_c/function.py
@@ -22,10 +22,10 @@
 """This module implements a basic class to manage functions in the 4C input
 file."""
 
-from meshpy.core.base_mesh_item import BaseMeshItemFull
+from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
 
 
-class Function(BaseMeshItemFull):
+class Function(_BaseMeshItemFull):
     """Holds information for a function."""
 
     def __init__(self, data):

--- a/src/meshpy/four_c/function_utility.py
+++ b/src/meshpy/four_c/function_utility.py
@@ -22,9 +22,9 @@
 """This module implements utility functions to create 4C space time
 function."""
 
-from typing import List
+from typing import List as _List
 
-import numpy as np
+import numpy as _np
 
 from meshpy.four_c.function import Function as _Function
 
@@ -52,11 +52,11 @@ def create_linear_interpolation_string(
 
     t = t.copy()
     f = values.copy()
-    t_max = np.max(t)
-    t = np.insert(t, 0, -1000.0, axis=0)
-    t = np.append(t, [t_max + 1000.0])
-    f = np.insert(f, 0, f[0], axis=0)
-    f = np.append(f, f[-1])
+    t_max = _np.max(t)
+    t = _np.insert(t, 0, -1000.0, axis=0)
+    t = _np.append(t, [t_max + 1000.0])
+    f = _np.insert(f, 0, f[0], axis=0)
+    f = _np.append(f, f[-1])
     times = " ".join(map(str, t))
     values = " ".join(map(str, f))
     return (
@@ -81,7 +81,7 @@ def create_linear_interpolation_function(
     return _Function(f"{function_type} var\n" + variable_string)
 
 
-def ensure_length_of_function_array(function_array: List, length: int = 3):
+def ensure_length_of_function_array(function_array: _List, length: int = 3):
     """Performs size check of a function array and appends the function array
     to the given length, if a list with only one item is provided.
 

--- a/src/meshpy/four_c/function_utility.py
+++ b/src/meshpy/four_c/function_utility.py
@@ -26,7 +26,7 @@ from typing import List
 
 import numpy as np
 
-from meshpy.four_c.function import Function
+from meshpy.four_c.function import Function as _Function
 
 
 def create_linear_interpolation_string(
@@ -78,7 +78,7 @@ def create_linear_interpolation_function(
     """
 
     variable_string = create_linear_interpolation_string(t, values, variable_name="var")
-    return Function(f"{function_type} var\n" + variable_string)
+    return _Function(f"{function_type} var\n" + variable_string)
 
 
 def ensure_length_of_function_array(function_array: List, length: int = 3):

--- a/src/meshpy/four_c/header_functions.py
+++ b/src/meshpy/four_c/header_functions.py
@@ -24,8 +24,9 @@ an input file."""
 
 from typing import List, Optional, Union
 
-from meshpy.core.conf import mpy
-from meshpy.four_c.input_file import InputFile, InputSection
+from meshpy.core.conf import mpy as _mpy
+from meshpy.four_c.input_file import InputFile as _InputFile
+from meshpy.four_c.input_file import InputSection as _InputSection
 
 
 def get_yes_no(bool_var):
@@ -109,7 +110,7 @@ def set_runtime_output(
 
     # Set the basic runtime output options.
     input_file.add(
-        InputSection(
+        _InputSection(
             "IO/RUNTIME VTK OUTPUT",
             f"""
         OUTPUT_DATA_FORMAT        binary
@@ -121,7 +122,7 @@ def set_runtime_output(
 
     # Set the structure runtime output options.
     input_file.add(
-        InputSection(
+        _InputSection(
             "IO/RUNTIME VTK OUTPUT/STRUCTURE",
             f"""
         OUTPUT_STRUCTURE                {get_yes_no(output_solid)}
@@ -136,7 +137,7 @@ def set_runtime_output(
 
     # Set the beam runtime output options.
     input_file.add(
-        InputSection(
+        _InputSection(
             "IO/RUNTIME VTK OUTPUT/BEAMS",
             f"""
         OUTPUT_BEAMS                    yes
@@ -152,7 +153,7 @@ def set_runtime_output(
     if btsvmt_output:
         # Set the beam to solid volume mesh tying runtime output options.
         input_file.add(
-            InputSection(
+            _InputSection(
                 ("BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING/RUNTIME VTK OUTPUT"),
                 """
             WRITE_OUTPUT                          yes
@@ -169,7 +170,7 @@ def set_runtime_output(
     if btss_output:
         # Set the beam to solid surface coupling runtime output options.
         input_file.add(
-            InputSection(
+            _InputSection(
                 "BEAM INTERACTION/BEAM TO SOLID SURFACE/RUNTIME VTK OUTPUT",
                 """
             WRITE_OUTPUT                          yes
@@ -240,12 +241,12 @@ def set_beam_to_solid_meshtying(
 
     # Set the beam contact options.
     input_file.add(
-        InputSection(
+        _InputSection(
             "BEAM INTERACTION", "REPARTITIONSTRATEGY Everydt", option_overwrite=True
         )
     )
     input_file.add(
-        InputSection("BEAM CONTACT", "MODELEVALUATOR Standard", option_overwrite=True)
+        _InputSection("BEAM CONTACT", "MODELEVALUATOR Standard", option_overwrite=True)
     )
 
     set_binning_strategy_section(
@@ -255,10 +256,10 @@ def set_beam_to_solid_meshtying(
     )
 
     # Add the beam to solid volume mesh tying options.
-    if interaction_type == mpy.beam_to_solid.volume_meshtying:
-        bts = InputSection("BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING")
-    elif interaction_type == mpy.beam_to_solid.surface_meshtying:
-        bts = InputSection("BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING")
+    if interaction_type == _mpy.beam_to_solid.volume_meshtying:
+        bts = _InputSection("BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING")
+    elif interaction_type == _mpy.beam_to_solid.surface_meshtying:
+        bts = _InputSection("BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING")
         if coupling_type is not None:
             bts.add(f"COUPLING_TYPE {coupling_type}")
     else:
@@ -372,7 +373,7 @@ def set_header_static(
 
     # Set the parameters for a static analysis.
     input_file.add(
-        InputSection(
+        _InputSection(
             "PROBLEM TYPE",
             """
         PROBLEMTYPE Structure
@@ -382,7 +383,7 @@ def set_header_static(
         )
     )
     input_file.add(
-        InputSection(
+        _InputSection(
             "IO",
             f"""
         OUTPUT_BIN     {get_yes_no(write_bin)}
@@ -413,7 +414,7 @@ def set_header_static(
         total_time = time_step * n_steps
 
     input_file.add(
-        InputSection(
+        _InputSection(
             "STRUCTURAL DYNAMIC",
             f"""
         LINEAR_SOLVER     1
@@ -433,7 +434,7 @@ def set_header_static(
         )
     )
     input_file.add(
-        InputSection(
+        _InputSection(
             "SOLVER 1",
             """
         NAME              Structure_Solver
@@ -492,7 +493,7 @@ def set_header_static(
         """
 
     input_file.add(
-        InputSection(
+        _InputSection(
             "STRUCT NOX/Printing",
             """
         Error                           = Yes
@@ -515,7 +516,7 @@ def set_header_static(
 
 
 def set_binning_strategy_section(
-    input_file: InputFile,
+    input_file: _InputFile,
     binning_bounding_box: Union[List[int], None] = None,
     binning_cutoff_radius: Union[float, None] = None,
     *,
@@ -542,7 +543,7 @@ def set_binning_strategy_section(
         )
 
         input_file.add(
-            InputSection(
+            _InputSection(
                 "BINNING STRATEGY",
                 f"""
             BIN_SIZE_LOWER_BOUND    {binning_cutoff_radius}
@@ -560,7 +561,7 @@ def set_binning_strategy_section(
 
 
 def set_beam_interaction_section(
-    inputfile: InputFile,
+    inputfile: _InputFile,
     *,
     repartition_strategy: str = "everydt",
     search_strategy: str = "bounding_volume_hierarchy",
@@ -584,7 +585,7 @@ def set_beam_interaction_section(
     """
 
     inputfile.add(
-        InputSection(
+        _InputSection(
             "BEAM INTERACTION",
             f"""
         REPARTITIONSTRATEGY                   {repartition_strategy}
@@ -596,7 +597,7 @@ def set_beam_interaction_section(
 
 
 def set_beam_contact_runtime_output(
-    inputfile: InputFile,
+    inputfile: _InputFile,
     *,
     every_iteration: bool = False,
     option_overwrite: bool = False,
@@ -613,7 +614,7 @@ def set_beam_contact_runtime_output(
     """
 
     inputfile.add(
-        InputSection(
+        _InputSection(
             "BEAM CONTACT/RUNTIME VTK OUTPUT",
             f"""
             VTK_OUTPUT_BEAM_CONTACT               yes
@@ -628,7 +629,7 @@ def set_beam_contact_runtime_output(
 
 
 def set_beam_contact_section(
-    input_file: InputFile,
+    input_file: _InputFile,
     *,
     interaction_strategy: str = "penalty",
     btb_penalty: float = 0,
@@ -694,14 +695,14 @@ def set_beam_contact_section(
         raise ValueError("Please provide lower and upper value of BEAMS_PARSHIFTANGLE.")
 
     input_file.add(
-        InputSection(
+        _InputSection(
             "BEAM INTERACTION/BEAM TO BEAM CONTACT",
             f"""STRATEGY   {interaction_strategy}""",
             option_overwrite=option_overwrite,
         )
     )
     input_file.add(
-        InputSection(
+        _InputSection(
             "BEAM CONTACT",
             f"""MODELEVALUATOR                  Standard
         BEAMS_STRATEGY                  Penalty

--- a/src/meshpy/four_c/header_functions.py
+++ b/src/meshpy/four_c/header_functions.py
@@ -22,7 +22,9 @@
 """This module defines functions that can be used to add header information to
 an input file."""
 
-from typing import List, Optional, Union
+from typing import List as _List
+from typing import Optional as _Optional
+from typing import Union as _Union
 
 from meshpy.core.conf import mpy as _mpy
 from meshpy.four_c.input_file import InputFile as _InputFile
@@ -517,8 +519,8 @@ def set_header_static(
 
 def set_binning_strategy_section(
     input_file: _InputFile,
-    binning_bounding_box: Union[List[int], None] = None,
-    binning_cutoff_radius: Union[float, None] = None,
+    binning_bounding_box: _Union[_List[int], None] = None,
+    binning_cutoff_radius: _Union[float, None] = None,
     *,
     option_overwrite: bool = False,
 ):

--- a/src/meshpy/four_c/input_file.py
+++ b/src/meshpy/four_c/input_file.py
@@ -29,27 +29,31 @@ import shutil
 import subprocess  # nosec B404
 import sys
 
-from meshpy.core.base_mesh_item import BaseMeshItemFull, BaseMeshItemString
+from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
+from meshpy.core.base_mesh_item import BaseMeshItemString as _BaseMeshItemString
 from meshpy.core.boundary_condition import (
-    BoundaryConditionBase,
-    BoundaryConditionContainer,
+    BoundaryConditionBase as _BoundaryConditionBase,
 )
-from meshpy.core.conf import mpy
-from meshpy.core.element import Element
-from meshpy.core.geometry_set import GeometrySetContainer, GeometrySetNodes
-from meshpy.core.mesh import Mesh
-from meshpy.core.node import Node
-from meshpy.core.nurbs_patch import NURBSPatch
-from meshpy.utils.environment import cubitpy_is_available
+from meshpy.core.boundary_condition import (
+    BoundaryConditionContainer as _BoundaryConditionContainer,
+)
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.element import Element as _Element
+from meshpy.core.geometry_set import GeometrySetContainer as _GeometrySetContainer
+from meshpy.core.geometry_set import GeometrySetNodes as _GeometrySetNodes
+from meshpy.core.mesh import Mesh as _Mesh
+from meshpy.core.node import Node as _Node
+from meshpy.core.nurbs_patch import NURBSPatch as _NURBSPatch
+from meshpy.utils.environment import cubitpy_is_available as _cubitpy_is_available
 
-if cubitpy_is_available():
+if _cubitpy_is_available():
     import cubitpy
 
 
 def get_section_string(section_name):
     """Return the string for a section in the dat file."""
     return (
-        "".join(["-" for _i in range(mpy.dat_len_section - len(section_name))])
+        "".join(["-" for _i in range(_mpy.dat_len_section - len(section_name))])
         + section_name
     )
 
@@ -238,69 +242,69 @@ class InputSectionMultiKey(InputSection):
         self.data[len(self.data)] = option
 
 
-class InputFile(Mesh):
+class InputFile(_Mesh):
     """An item that represents a complete 4C input file."""
 
     # Define the names of sections and boundary conditions in the input file.
     geometry_set_names = {
-        mpy.geo.point: "DNODE-NODE TOPOLOGY",
-        mpy.geo.line: "DLINE-NODE TOPOLOGY",
-        mpy.geo.surface: "DSURF-NODE TOPOLOGY",
-        mpy.geo.volume: "DVOL-NODE TOPOLOGY",
+        _mpy.geo.point: "DNODE-NODE TOPOLOGY",
+        _mpy.geo.line: "DLINE-NODE TOPOLOGY",
+        _mpy.geo.surface: "DSURF-NODE TOPOLOGY",
+        _mpy.geo.volume: "DVOL-NODE TOPOLOGY",
     }
     boundary_condition_names = {
-        (mpy.bc.dirichlet, mpy.geo.point): "DESIGN POINT DIRICH CONDITIONS",
-        (mpy.bc.dirichlet, mpy.geo.line): "DESIGN LINE DIRICH CONDITIONS",
-        (mpy.bc.dirichlet, mpy.geo.surface): "DESIGN SURF DIRICH CONDITIONS",
-        (mpy.bc.dirichlet, mpy.geo.volume): "DESIGN VOL DIRICH CONDITIONS",
-        (mpy.bc.locsys, mpy.geo.point): "DESIGN POINT LOCSYS CONDITIONS",
-        (mpy.bc.locsys, mpy.geo.line): "DESIGN LINE LOCSYS CONDITIONS",
-        (mpy.bc.locsys, mpy.geo.surface): "DESIGN SURF LOCSYS CONDITIONS",
-        (mpy.bc.locsys, mpy.geo.volume): "DESIGN VOL LOCSYS CONDITIONS",
-        (mpy.bc.neumann, mpy.geo.point): "DESIGN POINT NEUMANN CONDITIONS",
-        (mpy.bc.neumann, mpy.geo.line): "DESIGN LINE NEUMANN CONDITIONS",
-        (mpy.bc.neumann, mpy.geo.surface): "DESIGN SURF NEUMANN CONDITIONS",
-        (mpy.bc.neumann, mpy.geo.volume): "DESIGN VOL NEUMANN CONDITIONS",
+        (_mpy.bc.dirichlet, _mpy.geo.point): "DESIGN POINT DIRICH CONDITIONS",
+        (_mpy.bc.dirichlet, _mpy.geo.line): "DESIGN LINE DIRICH CONDITIONS",
+        (_mpy.bc.dirichlet, _mpy.geo.surface): "DESIGN SURF DIRICH CONDITIONS",
+        (_mpy.bc.dirichlet, _mpy.geo.volume): "DESIGN VOL DIRICH CONDITIONS",
+        (_mpy.bc.locsys, _mpy.geo.point): "DESIGN POINT LOCSYS CONDITIONS",
+        (_mpy.bc.locsys, _mpy.geo.line): "DESIGN LINE LOCSYS CONDITIONS",
+        (_mpy.bc.locsys, _mpy.geo.surface): "DESIGN SURF LOCSYS CONDITIONS",
+        (_mpy.bc.locsys, _mpy.geo.volume): "DESIGN VOL LOCSYS CONDITIONS",
+        (_mpy.bc.neumann, _mpy.geo.point): "DESIGN POINT NEUMANN CONDITIONS",
+        (_mpy.bc.neumann, _mpy.geo.line): "DESIGN LINE NEUMANN CONDITIONS",
+        (_mpy.bc.neumann, _mpy.geo.surface): "DESIGN SURF NEUMANN CONDITIONS",
+        (_mpy.bc.neumann, _mpy.geo.volume): "DESIGN VOL NEUMANN CONDITIONS",
         (
-            mpy.bc.moment_euler_bernoulli,
-            mpy.geo.point,
+            _mpy.bc.moment_euler_bernoulli,
+            _mpy.geo.point,
         ): "DESIGN POINT MOMENT EB CONDITIONS",
         (
-            mpy.bc.beam_to_solid_volume_meshtying,
-            mpy.geo.line,
+            _mpy.bc.beam_to_solid_volume_meshtying,
+            _mpy.geo.line,
         ): "BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING LINE",
         (
-            mpy.bc.beam_to_solid_volume_meshtying,
-            mpy.geo.volume,
+            _mpy.bc.beam_to_solid_volume_meshtying,
+            _mpy.geo.volume,
         ): "BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING VOLUME",
         (
-            mpy.bc.beam_to_solid_surface_meshtying,
-            mpy.geo.line,
+            _mpy.bc.beam_to_solid_surface_meshtying,
+            _mpy.geo.line,
         ): "BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING LINE",
         (
-            mpy.bc.beam_to_solid_surface_meshtying,
-            mpy.geo.surface,
+            _mpy.bc.beam_to_solid_surface_meshtying,
+            _mpy.geo.surface,
         ): "BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING SURFACE",
         (
-            mpy.bc.beam_to_solid_surface_contact,
-            mpy.geo.line,
+            _mpy.bc.beam_to_solid_surface_contact,
+            _mpy.geo.line,
         ): "BEAM INTERACTION/BEAM TO SOLID SURFACE CONTACT LINE",
         (
-            mpy.bc.beam_to_solid_surface_contact,
-            mpy.geo.surface,
+            _mpy.bc.beam_to_solid_surface_contact,
+            _mpy.geo.surface,
         ): "BEAM INTERACTION/BEAM TO SOLID SURFACE CONTACT SURFACE",
-        (mpy.bc.point_coupling, mpy.geo.point): "DESIGN POINT COUPLING CONDITIONS",
+        (_mpy.bc.point_coupling, _mpy.geo.point): "DESIGN POINT COUPLING CONDITIONS",
         (
-            mpy.bc.beam_to_beam_contact,
-            mpy.geo.line,
+            _mpy.bc.beam_to_beam_contact,
+            _mpy.geo.line,
         ): "BEAM INTERACTION/BEAM TO BEAM CONTACT CONDITIONS",
         (
-            mpy.bc.point_coupling_penalty,
-            mpy.geo.point,
+            _mpy.bc.point_coupling_penalty,
+            _mpy.geo.point,
         ): "DESIGN POINT PENALTY COUPLING CONDITIONS",
         (
             "DESIGN SURF MORTAR CONTACT CONDITIONS 3D",
-            mpy.geo.surface,
+            _mpy.geo.surface,
         ): "DESIGN SURF MORTAR CONTACT CONDITIONS 3D",
     }
 
@@ -344,8 +348,8 @@ class InputFile(Mesh):
         self.dat_nodes = []
         self.dat_elements = []
         self.dat_elements_fluid = []
-        self.dat_geometry_sets = GeometrySetContainer()
-        self.dat_boundary_conditions = BoundaryConditionContainer()
+        self.dat_geometry_sets = _GeometrySetContainer()
+        self.dat_boundary_conditions = _BoundaryConditionContainer()
 
         # Contents of NOX xml file.
         self.nox_xml = None
@@ -401,7 +405,7 @@ class InputFile(Mesh):
         # Add the lines to this input file.
         self._add_dat_lines(dat_lines)
 
-        if mpy.import_mesh_full:
+        if _mpy.import_mesh_full:
             # If the solid mesh is imported as objects, link the relevant data
             # after the import.
 
@@ -497,17 +501,17 @@ class InputFile(Mesh):
                         break
 
                 for item, comments in section_data_comment:
-                    if mpy.import_mesh_full:
+                    if _mpy.import_mesh_full:
                         self.boundary_conditions.append(
                             (bc_key, geometry_key),
-                            BoundaryConditionBase.from_dat(
+                            _BoundaryConditionBase.from_dat(
                                 bc_key, item, comments=comments
                             ),
                         )
                     else:
                         self.dat_boundary_conditions.append(
                             (bc_key, geometry_key),
-                            BaseMeshItemString(item, comments=comments),
+                            _BaseMeshItemString(item, comments=comments),
                         )
 
             def add_set(section_header, section_data_comment):
@@ -527,15 +531,15 @@ class InputFile(Mesh):
                             geometry_key = key
                             break
 
-                    if mpy.import_mesh_full:
+                    if _mpy.import_mesh_full:
                         self.geometry_sets[geometry_key].append(
-                            GeometrySetNodes.from_dat(
+                            _GeometrySetNodes.from_dat(
                                 geometry_key, dat_list, comments=comments
                             )
                         )
                     else:
                         self.dat_geometry_sets[geometry_key].append(
-                            BaseMeshItemString(dat_list, comments=comments)
+                            _BaseMeshItemString(dat_list, comments=comments)
                         )
 
                 if len(section_data_comment) > 0:
@@ -571,7 +575,7 @@ class InputFile(Mesh):
 
             def add_line(self_list, line):
                 """Add the line to self_list, and handle comments."""
-                self_list.append(BaseMeshItemString(line[0], comments=line[1]))
+                self_list.append(_BaseMeshItemString(line[0], comments=line[1]))
 
             # Check if the section contains mesh data that has to be added to
             # specific lists.
@@ -581,26 +585,26 @@ class InputFile(Mesh):
                     add_line(self.materials, line)
             elif section_name == "NODE COORDS":
                 for line in section_data_comment:
-                    if mpy.import_mesh_full:
-                        self.nodes.append(Node.from_dat(line))
+                    if _mpy.import_mesh_full:
+                        self.nodes.append(_Node.from_dat(line))
                     else:
                         add_line(self.dat_nodes, line)
             elif section_name == "STRUCTURE ELEMENTS":
                 for line in section_data_comment:
-                    if mpy.import_mesh_full:
-                        self.elements.append(Element.from_dat(line))
+                    if _mpy.import_mesh_full:
+                        self.elements.append(_Element.from_dat(line))
                     else:
                         add_line(self.dat_elements, line)
             elif section_name == "FLUID ELEMENTS":
                 for line in section_data_comment:
-                    if mpy.import_mesh_full:
+                    if _mpy.import_mesh_full:
                         raise NotImplementedError(
                             "Fluid elements in combination with mpy.import_mesh_full == True is "
                             "not yet implemented!"
                         )
                     add_line(self.dat_elements_fluid, line)
             elif section_name.startswith("FUNCT"):
-                self.functions.append(BaseMeshItemFull(section_data))
+                self.functions.append(_BaseMeshItemFull(section_data))
             elif section_name in self.boundary_condition_names.values():
                 add_bc(section_name, section_data_comment)
             elif section_name.endswith("TOPOLOGY"):
@@ -700,7 +704,7 @@ class InputFile(Mesh):
         """
 
         # Perform some checks on the mesh.
-        if mpy.check_overlapping_elements:
+        if _mpy.check_overlapping_elements:
             self.check_overlapping_elements()
 
         # List that will contain all input lines.
@@ -709,7 +713,7 @@ class InputFile(Mesh):
         # Add header to the input file.
         end_text = None
 
-        lines.extend(["// " + line for line in mpy.input_file_meshpy_header])
+        lines.extend(["// " + line for line in _mpy.input_file_meshpy_header])
         if header:
             header_text, end_text = self._get_header(add_script_to_header)
             lines.append(header_text)
@@ -762,7 +766,7 @@ class InputFile(Mesh):
                 # As a NURBS patch can be defined with more elements, an offset is applied to the
                 # rest of the items
                 item.i_global = i + 1
-                if isinstance(item, NURBSPatch):
+                if isinstance(item, _NURBSPatch):
                     item.n_nurbs_patch = i_nurbs_patch + 1
                     offset = item.get_number_elements()
                     i += offset
@@ -784,7 +788,7 @@ class InputFile(Mesh):
             # Get the maximum material index in materials imported from a string
             max_material_id = 0
             for material in material_list:
-                if isinstance(material, BaseMeshItemString):
+                if isinstance(material, _BaseMeshItemString):
                     for dat_line in material.get_dat_lines():
                         if dat_line.startswith("MAT "):
                             max_material_id = max(
@@ -794,7 +798,7 @@ class InputFile(Mesh):
             # Set the material id in all MeshPy materials
             i_material = max_material_id + 1
             for material in material_list:
-                if not isinstance(material, BaseMeshItemString):
+                if not isinstance(material, _BaseMeshItemString):
                     material.i_global = i_material
                     i_material += 1
 
@@ -806,10 +810,10 @@ class InputFile(Mesh):
         all_nodes = self.dat_nodes + self.nodes
         all_elements_structure = self.dat_elements + self.elements
         all_elements = self.dat_elements_fluid + all_elements_structure
-        all_geometry_sets = GeometrySetContainer()
+        all_geometry_sets = _GeometrySetContainer()
         all_geometry_sets.extend(self.dat_geometry_sets)
         all_geometry_sets.extend(mesh_sets)
-        all_boundary_conditions = BoundaryConditionContainer()
+        all_boundary_conditions = _BoundaryConditionContainer()
         all_boundary_conditions.extend(self.dat_boundary_conditions)
         all_boundary_conditions.extend(self.boundary_conditions)
 
@@ -859,14 +863,14 @@ class InputFile(Mesh):
         # depending on the type of the connected beam element.
         def get_number_of_coupling_conditions(key):
             """Return the number of coupling conditions in the mesh."""
-            if (key, mpy.geo.point) in all_boundary_conditions.keys():
-                return len(all_boundary_conditions[key, mpy.geo.point])
+            if (key, _mpy.geo.point) in all_boundary_conditions.keys():
+                return len(all_boundary_conditions[key, _mpy.geo.point])
             else:
                 return 0
 
         if (
-            get_number_of_coupling_conditions(mpy.bc.point_coupling)
-            + get_number_of_coupling_conditions(mpy.bc.point_coupling_penalty)
+            get_number_of_coupling_conditions(_mpy.bc.point_coupling)
+            + get_number_of_coupling_conditions(_mpy.bc.point_coupling_penalty)
             > 0
         ):
             self.set_node_links()
@@ -973,7 +977,7 @@ class InputFile(Mesh):
             f"// git date:   {meshpy_git_date}\n"
         )
 
-        if cubitpy_is_available():
+        if _cubitpy_is_available():
             # Get git information about cubitpy.
             cubitpy_git_sha, cubitpy_git_date = get_git_data(
                 os.path.dirname(cubitpy.__file__)
@@ -987,7 +991,7 @@ class InputFile(Mesh):
                     f"// git date:   {cubitpy_git_date}\n"
                 )
 
-        string_line = "// " + "".join(["-" for _i in range(mpy.dat_len_section - 3)])
+        string_line = "// " + "".join(["-" for _i in range(_mpy.dat_len_section - 3)])
 
         # If needed, append the contents of the script.
         if add_script:

--- a/src/meshpy/four_c/input_file.py
+++ b/src/meshpy/four_c/input_file.py
@@ -22,12 +22,12 @@
 """This module defines the classes that are used to create an input file for
 4C."""
 
-import datetime
-import os
-import re
-import shutil
-import subprocess  # nosec B404
-import sys
+import datetime as _datetime
+import os as _os
+import re as _re
+import shutil as _shutil
+import subprocess as _subprocess  # nosec B404
+import sys as _sys
 
 from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
 from meshpy.core.base_mesh_item import BaseMeshItemString as _BaseMeshItemString
@@ -47,7 +47,7 @@ from meshpy.core.nurbs_patch import NURBSPatch as _NURBSPatch
 from meshpy.utils.environment import cubitpy_is_available as _cubitpy_is_available
 
 if _cubitpy_is_available():
-    import cubitpy
+    import cubitpy as _cubitpy
 
 
 def get_section_string(section_name):
@@ -469,7 +469,7 @@ class InputFile(_Mesh):
         else:
             # Extract the name of the section.
             name = section_line.strip()
-            start = re.search(r"[^-]", name).start()
+            start = _re.search(r"[^-]", name).start()
             section_name = name[start:]
 
             def group_input_comments(section_data):
@@ -664,14 +664,14 @@ class InputFile(_Mesh):
             if nox_xml_file is None:
                 # Get the name of the xml file.
                 self._nox_xml_file = (
-                    os.path.splitext(os.path.basename(file_path))[0] + ".xml"
+                    _os.path.splitext(_os.path.basename(file_path))[0] + ".xml"
                 )
             else:
                 self._nox_xml_file = nox_xml_file
 
             # Write the xml file to the disc.
             with open(
-                os.path.join(os.path.dirname(file_path), self._nox_xml_file), "w"
+                _os.path.join(_os.path.dirname(file_path), self._nox_xml_file), "w"
             ) as xml_file:
                 xml_file.write(self.nox_xml)
 
@@ -957,8 +957,8 @@ class InputFile(_Mesh):
         headers.append(model_header)
 
         # Get information about the script.
-        script_path = os.path.realpath(sys.argv[0])
-        script_git_sha, script_git_date = get_git_data(os.path.dirname(script_path))
+        script_path = _os.path.realpath(_sys.argv[0])
+        script_git_sha, script_git_date = get_git_data(_os.path.dirname(script_path))
         script_header = "// Script used to create input file:\n"
         script_header += f"// path:       {script_path}\n"
         if script_git_sha is not None:
@@ -969,7 +969,7 @@ class InputFile(_Mesh):
 
         # Header containing meshpy information.
         meshpy_git_sha, meshpy_git_date = get_git_data(
-            os.path.dirname(os.path.realpath(__file__))
+            _os.path.dirname(_os.path.realpath(__file__))
         )
         headers.append(
             "// Input file created with meshpy\n"
@@ -980,7 +980,7 @@ class InputFile(_Mesh):
         if _cubitpy_is_available():
             # Get git information about cubitpy.
             cubitpy_git_sha, cubitpy_git_date = get_git_data(
-                os.path.dirname(cubitpy.__file__)
+                _os.path.dirname(cubitpy.__file__)
             )
 
             if cubitpy_git_sha is not None:

--- a/src/meshpy/four_c/locsys_condition.py
+++ b/src/meshpy/four_c/locsys_condition.py
@@ -21,7 +21,9 @@
 # THE SOFTWARE.
 """This file contains the wrapper for the LocSys condition for 4c."""
 
-from typing import List, Optional, Union
+from typing import List as _List
+from typing import Optional as _Optional
+from typing import Union as _Union
 
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.geometry_set import GeometrySet as _GeometrySet
@@ -45,7 +47,7 @@ class LocSysCondition(_BoundaryCondition):
         geometry_set: _GeometrySet,
         rotation: _Rotation,
         *,
-        function_array: Optional[List[Union[_Function, int]]] = None,
+        function_array: _Optional[_List[_Union[_Function, int]]] = None,
         update_node_position: bool = False,
         use_consistent_node_normal: bool = False,
         **kwargs,
@@ -55,7 +57,7 @@ class LocSysCondition(_BoundaryCondition):
         Args:
             geometry_set: Geometry that this boundary condition acts on
             rotation: Object that represents the rotation of the coordinate system
-            function_array: List containing functions
+            function_array: _List containing functions
             update_node_position: Flag to enable the updated node position
             use_consistent_node_normal: Flag to use a consistent node normal
         """

--- a/src/meshpy/four_c/locsys_condition.py
+++ b/src/meshpy/four_c/locsys_condition.py
@@ -23,15 +23,17 @@
 
 from typing import List, Optional, Union
 
-from meshpy.core.conf import mpy
-from meshpy.core.geometry_set import GeometrySet
-from meshpy.core.rotation import Rotation
-from meshpy.four_c.boundary_condition import BoundaryCondition
-from meshpy.four_c.function import Function
-from meshpy.four_c.function_utility import ensure_length_of_function_array
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.geometry_set import GeometrySet as _GeometrySet
+from meshpy.core.rotation import Rotation as _Rotation
+from meshpy.four_c.boundary_condition import BoundaryCondition as _BoundaryCondition
+from meshpy.four_c.function import Function as _Function
+from meshpy.four_c.function_utility import (
+    ensure_length_of_function_array as _ensure_length_of_function_array,
+)
 
 
-class LocSysCondition(BoundaryCondition):
+class LocSysCondition(_BoundaryCondition):
     """This object represents a locsys condition in 4C.
 
     It allows to rotate the local coordinate system used to apply
@@ -40,10 +42,10 @@ class LocSysCondition(BoundaryCondition):
 
     def __init__(
         self,
-        geometry_set: GeometrySet,
-        rotation: Rotation,
+        geometry_set: _GeometrySet,
+        rotation: _Rotation,
         *,
-        function_array: Optional[List[Union[Function, int]]] = None,
+        function_array: Optional[List[Union[_Function, int]]] = None,
         update_node_position: bool = False,
         use_consistent_node_normal: bool = False,
         **kwargs,
@@ -62,7 +64,7 @@ class LocSysCondition(BoundaryCondition):
         if function_array is None:
             function_array = [0, 0, 0]
         else:
-            function_array = ensure_length_of_function_array(function_array, 3)
+            function_array = _ensure_length_of_function_array(function_array, 3)
 
         condition_string = (
             "ROTANGLE {} {} {} ".format(*rotation.get_rotation_vector())
@@ -72,8 +74,8 @@ class LocSysCondition(BoundaryCondition):
 
         # Append the condition string with consistent normal type for line and surface geometry
         if (
-            geometry_set.geometry_type is mpy.geo.line
-            or geometry_set.geometry_type is mpy.geo.surface
+            geometry_set.geometry_type is _mpy.geo.line
+            or geometry_set.geometry_type is _mpy.geo.surface
         ):
             condition_string = (
                 condition_string
@@ -87,7 +89,7 @@ class LocSysCondition(BoundaryCondition):
         super().__init__(
             geometry_set,
             bc_string=condition_string,
-            bc_type=mpy.bc.locsys,
+            bc_type=_mpy.bc.locsys,
             format_replacement=function_array,
             **kwargs,
         )

--- a/src/meshpy/four_c/material.py
+++ b/src/meshpy/four_c/material.py
@@ -21,10 +21,11 @@
 # THE SOFTWARE.
 """This file implements materials for 4C beams and solids."""
 
-from meshpy.core.material import Material, MaterialBeam
+from meshpy.core.material import Material as _Material
+from meshpy.core.material import MaterialBeam as _MaterialBeam
 
 
-class MaterialReissner(MaterialBeam):
+class MaterialReissner(_MaterialBeam):
     """Holds material definition for Reissner beams."""
 
     def __init__(self, shear_correction=1, **kwargs):
@@ -111,7 +112,7 @@ class MaterialReissnerElastoplastic(MaterialReissner):
         )
 
 
-class MaterialKirchhoff(MaterialBeam):
+class MaterialKirchhoff(_MaterialBeam):
     """Holds material definition for Kirchhoff beams."""
 
     def __init__(self, is_fad=False, **kwargs):
@@ -163,7 +164,7 @@ class MaterialKirchhoff(MaterialBeam):
         return string
 
 
-class MaterialEulerBernoulli(MaterialBeam):
+class MaterialEulerBernoulli(_MaterialBeam):
     """Holds material definition for Euler Bernoulli beams."""
 
     def __init__(self, **kwargs):
@@ -196,7 +197,7 @@ class MaterialEulerBernoulli(MaterialBeam):
         )
 
 
-class MaterialString(Material):
+class MaterialString(_Material):
     """Holds material definition that is defined by a string."""
 
     def __init__(self, material_string, **kwargs):
@@ -209,7 +210,7 @@ class MaterialString(Material):
         return string.format(self.i_global, self.material_string)
 
 
-class MaterialSolid(Material):
+class MaterialSolid(_Material):
     """Base class for a material for solids."""
 
     def __init__(

--- a/src/meshpy/four_c/run_four_c.py
+++ b/src/meshpy/four_c/run_four_c.py
@@ -27,7 +27,7 @@ import subprocess  # nosec B404
 import sys
 from pathlib import Path
 
-from meshpy.utils.environment import get_env_variable
+from meshpy.utils.environment import get_env_variable as _get_env_variable
 
 
 def run_four_c(
@@ -81,11 +81,11 @@ def run_four_c(
 
     # Fist get all needed parameters
     if four_c_exe is None:
-        four_c_exe = get_env_variable("MESHPY_FOUR_C_EXE")
+        four_c_exe = _get_env_variable("MESHPY_FOUR_C_EXE")
     if mpi_command is None:
-        mpi_command = get_env_variable("MESHPY_MPI_COMMAND", default="mpirun")
+        mpi_command = _get_env_variable("MESHPY_MPI_COMMAND", default="mpirun")
     if n_proc is None:
-        n_proc = get_env_variable("MESHPY_MPI_NUM_PROC", default="1")
+        n_proc = _get_env_variable("MESHPY_MPI_NUM_PROC", default="1")
 
     # Setup paths and actual command to run
     os.makedirs(output_dir, exist_ok=True)

--- a/src/meshpy/four_c/run_four_c.py
+++ b/src/meshpy/four_c/run_four_c.py
@@ -21,11 +21,11 @@
 # THE SOFTWARE.
 """Provide a function that allows to run 4C."""
 
-import os
-import shutil
-import subprocess  # nosec B404
-import sys
-from pathlib import Path
+import os as _os
+import shutil as _shutil
+import subprocess as _subprocess  # nosec B404
+import sys as _sys
+from pathlib import Path as _Path
 
 from meshpy.utils.environment import get_env_variable as _get_env_variable
 
@@ -88,9 +88,9 @@ def run_four_c(
         n_proc = _get_env_variable("MESHPY_MPI_NUM_PROC", default="1")
 
     # Setup paths and actual command to run
-    os.makedirs(output_dir, exist_ok=True)
-    log_file = os.path.join(output_dir, output_name + ".log")
-    error_file = os.path.join(output_dir, output_name + ".err")
+    _os.makedirs(output_dir, exist_ok=True)
+    log_file = _os.path.join(output_dir, output_name + ".log")
+    error_file = _os.path.join(output_dir, output_name + ".err")
     command = mpi_command.split(" ") + [
         "-np",
         str(n_proc),
@@ -109,22 +109,22 @@ def run_four_c(
 
     # Actually run the command
     with open(log_file, "w") as stdout_file, open(error_file, "w") as stderr_file:
-        process = subprocess.Popen(
+        process = _subprocess.Popen(
             command,  # nosec B603
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stdout=_subprocess.PIPE,
+            stderr=_subprocess.PIPE,
             cwd=output_dir,
             text=True,
         )
 
         for stdout_line in process.stdout:
             if log_to_console:
-                sys.stdout.write(stdout_line)
+                _sys.stdout.write(stdout_line)
             stdout_file.write(stdout_line)
 
         for stderr_line in process.stderr:
             if log_to_console:
-                sys.stderr.write(stderr_line)
+                _sys.stderr.write(stderr_line)
             stderr_file.write(stderr_line)
 
         process.stdout.close()
@@ -146,7 +146,7 @@ def clean_simulation_directory(sim_dir, *, ask_before_clean=False):
     """
 
     # Check if simulation directory exists.
-    if os.path.exists(sim_dir):
+    if _os.path.exists(sim_dir):
         if ask_before_clean:
             print(f'Path "{sim_dir}" already exists')
         while True:
@@ -155,17 +155,17 @@ def clean_simulation_directory(sim_dir, *, ask_before_clean=False):
             else:
                 answer = "y"
             if answer.lower() == "y":
-                for filename in os.listdir(sim_dir):
-                    file_path = os.path.join(sim_dir, filename)
+                for filename in _os.listdir(sim_dir):
+                    file_path = _os.path.join(sim_dir, filename)
                     try:
-                        if os.path.isfile(file_path) or os.path.islink(file_path):
-                            os.unlink(file_path)
-                        elif os.path.isdir(file_path):
-                            shutil.rmtree(file_path)
+                        if _os.path.isfile(file_path) or _os.path.islink(file_path):
+                            _os.unlink(file_path)
+                        elif _os.path.isdir(file_path):
+                            _shutil.rmtree(file_path)
                     except Exception as e:
                         raise ValueError(f"Failed to delete {file_path}. Reason: {e}")
                 return
             elif answer.lower() == "n":
                 raise ValueError("Directory is not deleted!")
     else:
-        Path(sim_dir).mkdir(parents=True, exist_ok=True)
+        _Path(sim_dir).mkdir(parents=True, exist_ok=True)

--- a/src/meshpy/four_c/solid_shell_thickness_direction.py
+++ b/src/meshpy/four_c/solid_shell_thickness_direction.py
@@ -22,10 +22,10 @@
 """This function allows to reorder the connectivity of solid shell elements
 such that the solid shell direction is correctly represented."""
 
-from typing import List
+from typing import List as _List
 
-import numpy as np
-import pyvista as pv
+import numpy as _np
+import pyvista as _pv
 
 from meshpy.core.element import Element as _Element
 from meshpy.core.element_volume import VolumeElement as _VolumeElement
@@ -35,7 +35,7 @@ from meshpy.utils.nodes import get_nodal_coordinates as _get_nodal_coordinates
 
 def shape_functions_hex8(xi1, xi2, xi3):
     """Return the shape functions for a hex8 element."""
-    shape_functions = np.zeros(8)
+    shape_functions = _np.zeros(8)
     one_over_eight = 0.125
     shape_functions[0] = one_over_eight * (1 - xi1) * (1 - xi2) * (1 - xi3)
     shape_functions[1] = one_over_eight * (1 + xi1) * (1 - xi2) * (1 - xi3)
@@ -50,7 +50,7 @@ def shape_functions_hex8(xi1, xi2, xi3):
 
 def shape_functions_derivative_hex8(xi1, xi2, xi3):
     """Return the derivative of the shape functions for a hex8 element."""
-    derivatives = np.zeros((3, 8))
+    derivatives = _np.zeros((3, 8))
     one_over_eight = 0.125
 
     # Derivatives with respect to xi1
@@ -97,8 +97,8 @@ def get_hex8_element_center_and_jacobian_mapping(element):
     N = shape_functions_hex8(0, 0, 0)
     dN = shape_functions_derivative_hex8(0, 0, 0)
 
-    reference_position_center = np.dot(N, nodal_coordinates)
-    jacobian_center = np.dot(dN, nodal_coordinates)
+    reference_position_center = _np.dot(N, nodal_coordinates)
+    jacobian_center = _np.dot(dN, nodal_coordinates)
 
     return reference_position_center, jacobian_center
 
@@ -114,9 +114,9 @@ def get_reordering_index_thickness(jacobian, *, identify_threshold=None):
 
     # The direction with the smallest parameter derivative is the thickness direction
     parameter_derivative_norms = [
-        np.linalg.norm(parameter_direction) for parameter_direction in jacobian
+        _np.linalg.norm(parameter_direction) for parameter_direction in jacobian
     ]
-    thickness_direction = np.argmin(parameter_derivative_norms)
+    thickness_direction = _np.argmin(parameter_derivative_norms)
 
     if identify_threshold is not None:
         # Check that the minimal parameter direction is at least a given factor
@@ -128,7 +128,7 @@ def get_reordering_index_thickness(jacobian, *, identify_threshold=None):
             for i in range(3)
             if not i == thickness_direction
         ]
-        if np.min(relative_difference) < 1.5:
+        if _np.min(relative_difference) < 1.5:
             raise ValueError("Could not uniquely identify the thickness direction.")
 
     return thickness_direction
@@ -143,9 +143,9 @@ def get_reordering_index_director_projection(
 
     projections = []
     for parameter_director in jacobian:
-        parameter_director = parameter_director / np.linalg.norm(parameter_director)
-        projections.append(np.abs(np.dot(director, parameter_director)))
-    thickness_direction = np.argmax(projections)
+        parameter_director = parameter_director / _np.linalg.norm(parameter_director)
+        projections.append(_np.abs(_np.dot(director, parameter_director)))
+    thickness_direction = _np.argmax(projections)
 
     if identify_threshold is not None:
         # Check that the maximal dot product is at least a given factor larger than
@@ -155,14 +155,14 @@ def get_reordering_index_director_projection(
         relative_difference = [
             projections[i] / max_norm for i in range(3) if not i == thickness_direction
         ]
-        if np.max(relative_difference) > 1.0 / identify_threshold:
+        if _np.max(relative_difference) > 1.0 / identify_threshold:
             raise ValueError("Could not uniquely identify the thickness direction.")
 
     return thickness_direction
 
 
 def set_solid_shell_thickness_direction(
-    elements: List[_Element],
+    elements: _List[_Element],
     *,
     selection_type="thickness",
     director=None,
@@ -254,7 +254,7 @@ def get_visualization_third_parameter_direction_hex8(mesh):
     for hex8 elements."""
 
     vtk_solid = mesh.get_vtk_representation()[1].grid
-    pv_solid = pv.UnstructuredGrid(vtk_solid)
+    pv_solid = _pv.UnstructuredGrid(vtk_solid)
 
     cell_thickness_direction = []
     for element in mesh.elements:
@@ -289,7 +289,7 @@ def visualize_third_parameter_direction_hex8(mesh):
         orient="thickness_direction", scale="thickness_direction", factor=5
     )
 
-    plotter = pv.Plotter()
+    plotter = _pv.Plotter()
     plotter.renderer.add_axes()
     plotter.add_mesh(grid, color="white", show_edges=True, opacity=0.5)
     plotter.add_mesh(thickness_direction, color="red")

--- a/src/meshpy/four_c/solid_shell_thickness_direction.py
+++ b/src/meshpy/four_c/solid_shell_thickness_direction.py
@@ -27,9 +27,10 @@ from typing import List
 import numpy as np
 import pyvista as pv
 
-from meshpy.core.element import Element
-from meshpy.core.element_volume import VolumeElement, VolumeHEX8
-from meshpy.utils.nodes import get_nodal_coordinates
+from meshpy.core.element import Element as _Element
+from meshpy.core.element_volume import VolumeElement as _VolumeElement
+from meshpy.core.element_volume import VolumeHEX8 as _VolumeHEX8
+from meshpy.utils.nodes import get_nodal_coordinates as _get_nodal_coordinates
 
 
 def shape_functions_hex8(xi1, xi2, xi3):
@@ -89,7 +90,7 @@ def get_hex8_element_center_and_jacobian_mapping(element):
     """Return the center of a hex8 element and the Jacobian mapping for that
     point."""
 
-    nodal_coordinates = get_nodal_coordinates(element.nodes)
+    nodal_coordinates = _get_nodal_coordinates(element.nodes)
     if not len(nodal_coordinates) == 8:
         raise ValueError(f"Expected 8 nodes, got {len(nodal_coordinates)}")
 
@@ -161,7 +162,7 @@ def get_reordering_index_director_projection(
 
 
 def set_solid_shell_thickness_direction(
-    elements: List[Element],
+    elements: List[_Element],
     *,
     selection_type="thickness",
     director=None,
@@ -173,7 +174,7 @@ def set_solid_shell_thickness_direction(
 
     Args:
     ----
-    elements: List[Element]
+    elements:
         A list containing all elements that should be checked
     selection_type:
         The type of algorithm that shall be used to select the thickness direction
@@ -196,7 +197,7 @@ def set_solid_shell_thickness_direction(
         raise ValueError("Expected a non empty element list")
 
     for element in elements:
-        is_hex8 = isinstance(element, VolumeHEX8)
+        is_hex8 = isinstance(element, _VolumeHEX8)
         if is_hex8:
             is_solid_shell = "SOLIDSH8" in element.dat_pre_nodes  # type: ignore[attr-defined]
 
@@ -257,10 +258,10 @@ def get_visualization_third_parameter_direction_hex8(mesh):
 
     cell_thickness_direction = []
     for element in mesh.elements:
-        if isinstance(element, VolumeHEX8):
+        if isinstance(element, _VolumeHEX8):
             _, jacobian_center = get_hex8_element_center_and_jacobian_mapping(element)
             cell_thickness_direction.append(jacobian_center[2])
-        elif isinstance(element, VolumeElement):
+        elif isinstance(element, _VolumeElement):
             cell_thickness_direction.append([0, 0, 0])
 
     if not len(cell_thickness_direction) == pv_solid.number_of_cells:

--- a/src/meshpy/geometric_search/find_close_points.py
+++ b/src/meshpy/geometric_search/find_close_points.py
@@ -22,7 +22,8 @@
 """Find unique points in a point cloud, i.e., points that are within a certain
 tolerance of each other will be considered as unique."""
 
-from enum import Enum, auto
+from enum import Enum as _Enum
+from enum import auto as _auto
 
 from meshpy.geometric_search.geometric_search_cython import (
     cython_available as _cython_available,
@@ -32,20 +33,24 @@ from meshpy.geometric_search.geometric_search_scipy import (
 )
 
 if _cython_available:
-    from .geometric_search_cython import find_close_points_brute_force_cython
+    from .geometric_search_cython import (
+        find_close_points_brute_force_cython as _find_close_points_brute_force_cython,
+    )
 
 from .geometric_search_arborx import arborx_available
 
 if arborx_available:
-    from .geometric_search_arborx import find_close_points_arborx
+    from .geometric_search_arborx import (
+        find_close_points_arborx as _find_close_points_arborx,
+    )
 
 
-class FindClosePointAlgorithm(Enum):
+class FindClosePointAlgorithm(_Enum):
     """Enum for different find_close_point algorithms."""
 
-    kd_tree_scipy = auto()
-    brute_force_cython = auto()
-    boundary_volume_hierarchy_arborx = auto()
+    kd_tree_scipy = _auto()
+    brute_force_cython = _auto()
+    boundary_volume_hierarchy_arborx = _auto()
 
 
 def point_partners_to_unique_indices(point_partners):
@@ -114,7 +119,7 @@ def find_close_points(point_coordinates, *, algorithm=None, tol=1e-8, **kwargs):
 
     Args
     ----
-    point_coordinates: np.array(n_points x n_dim)
+    point_coordinates: _np.array(n_points x n_dim)
         Point coordinates that are checked for partners. The number of spatial dimensions
         does not have to be equal to 3.
     algorithm: FindClosePointAlgorithm
@@ -156,11 +161,11 @@ def find_close_points(point_coordinates, *, algorithm=None, tol=1e-8, **kwargs):
             point_coordinates, tol, **kwargs
         )
     elif algorithm is FindClosePointAlgorithm.brute_force_cython:
-        has_partner, n_partner = find_close_points_brute_force_cython(
+        has_partner, n_partner = _find_close_points_brute_force_cython(
             point_coordinates, tol, **kwargs
         )
     elif algorithm is FindClosePointAlgorithm.boundary_volume_hierarchy_arborx:
-        has_partner, n_partner = find_close_points_arborx(
+        has_partner, n_partner = _find_close_points_arborx(
             point_coordinates, tol, **kwargs
         )
     else:

--- a/src/meshpy/geometric_search/find_close_points.py
+++ b/src/meshpy/geometric_search/find_close_points.py
@@ -24,10 +24,14 @@ tolerance of each other will be considered as unique."""
 
 from enum import Enum, auto
 
-from meshpy.geometric_search.geometric_search_cython import cython_available
-from meshpy.geometric_search.geometric_search_scipy import find_close_points_scipy
+from meshpy.geometric_search.geometric_search_cython import (
+    cython_available as _cython_available,
+)
+from meshpy.geometric_search.geometric_search_scipy import (
+    find_close_points_scipy as _find_close_points_scipy,
+)
 
-if cython_available:
+if _cython_available:
     from .geometric_search_cython import find_close_points_brute_force_cython
 
 from .geometric_search_arborx import arborx_available
@@ -135,7 +139,7 @@ def find_close_points(point_coordinates, *, algorithm=None, tol=1e-8, **kwargs):
 
     if algorithm is None:
         # Decide which algorithm to use
-        if n_points < 200 and cython_available:
+        if n_points < 200 and _cython_available:
             # For around 200 points the brute force cython algorithm is the fastest one
             algorithm = FindClosePointAlgorithm.brute_force_cython
         elif arborx_available:
@@ -148,7 +152,7 @@ def find_close_points(point_coordinates, *, algorithm=None, tol=1e-8, **kwargs):
 
     # Get list of closest pairs
     if algorithm is FindClosePointAlgorithm.kd_tree_scipy:
-        has_partner, n_partner = find_close_points_scipy(
+        has_partner, n_partner = _find_close_points_scipy(
             point_coordinates, tol, **kwargs
         )
     elif algorithm is FindClosePointAlgorithm.brute_force_cython:

--- a/src/meshpy/geometric_search/geometric_search_arborx.py
+++ b/src/meshpy/geometric_search/geometric_search_arborx.py
@@ -22,15 +22,15 @@
 """This file defines the interface to the ArborX geometric search
 functionality."""
 
-import os
-import sys
+import os as _os
+import sys as _sys
 
 # Set path so ArborX binary will be found
-sys.path.append(os.path.dirname(__file__))
+_sys.path.append(_os.path.dirname(__file__))
 
 # Import the ArborX wrapper
 try:
-    import geometric_search_arborx_lib
+    import geometric_search_arborx_lib as _geometric_search_arborx_lib
 
     arborx_available = True
 except ImportError:
@@ -42,12 +42,12 @@ class KokkosScopeGuardWrapper:
 
     def __init__(self):
         """Call initialize when this object is created."""
-        geometric_search_arborx_lib.kokkos_initialize()
+        _geometric_search_arborx_lib.kokkos_initialize()
 
     def __del__(self):
         """Finalize Kokkos after this object goes out of scope, i.e., at the
         end of this modules lifetime."""
-        geometric_search_arborx_lib.kokkos_finalize()
+        _geometric_search_arborx_lib.kokkos_finalize()
 
 
 if arborx_available:
@@ -58,6 +58,6 @@ if arborx_available:
 def find_close_points_arborx(point_coordinates, tol):
     """Call the ArborX implementation of find close_points."""
     if arborx_available:
-        return geometric_search_arborx_lib.find_close_points(point_coordinates, tol)
+        return _geometric_search_arborx_lib.find_close_points(point_coordinates, tol)
     else:
         raise ModuleNotFoundError("ArborX functionality is not available")

--- a/src/meshpy/geometric_search/geometric_search_cython.py
+++ b/src/meshpy/geometric_search/geometric_search_cython.py
@@ -22,16 +22,16 @@
 """This file defines the interface to the Cython geometric search
 functionality."""
 
-import os
-import sys
-import warnings
+import os as _os
+import sys as _sys
+import warnings as _warnings
 
 # Set path so the Cython binary will be found
-sys.path.append(os.path.dirname(__file__))
+_sys.path.append(_os.path.dirname(__file__))
 
 # Try to import the Cython module
 try:
-    import geometric_search_cython_lib
+    import geometric_search_cython_lib as _geometric_search_cython_lib
 
     cython_available = True
 except ImportError:
@@ -45,11 +45,11 @@ def find_close_points_brute_force_cython(
     if cython_available:
         n_points = len(point_coordinates)
         if n_points > n_points_performance_warning:
-            warnings.warn(
+            _warnings.warn(
                 "The function find_close_points is called with the brute force algorithm "
                 + f"with {n_points} points, for performance reasons other algorithms should be used!"
             )
-        return geometric_search_cython_lib.find_close_points(point_coordinates, tol)
+        return _geometric_search_cython_lib.find_close_points(point_coordinates, tol)
     else:
         raise ModuleNotFoundError(
             "Cython geometric search functionality is not available"

--- a/src/meshpy/geometric_search/geometric_search_scipy.py
+++ b/src/meshpy/geometric_search/geometric_search_scipy.py
@@ -22,7 +22,7 @@
 """This file defines the interface to the Scipy spatial geometric search
 functionality."""
 
-from scipy.spatial import KDTree
+from scipy.spatial import KDTree as _KDTree
 
 
 def pairs_to_partner_list(pairs, n_points):
@@ -58,6 +58,6 @@ def pairs_to_partner_list(pairs, n_points):
 def find_close_points_scipy(point_coordinates, tol):
     """Call the Scipy implementation of find close_points."""
 
-    kd_tree = KDTree(point_coordinates)
+    kd_tree = _KDTree(point_coordinates)
     pairs = kd_tree.query_pairs(r=tol, output_type="ndarray")
     return pairs_to_partner_list(pairs, len(point_coordinates))

--- a/src/meshpy/mesh_creation_functions/beam_basic_geometry.py
+++ b/src/meshpy/mesh_creation_functions/beam_basic_geometry.py
@@ -21,9 +21,9 @@
 # THE SOFTWARE.
 """This file has functions to create basic geometry items with meshpy."""
 
-import warnings
+import warnings as _warnings
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.mesh import Mesh as _Mesh
@@ -47,7 +47,7 @@ def create_beam_mesh_line(
         Class of beam that will be used for this line.
     material: Material
         Material for this line.
-    start_point, end_point: np.array, list
+    start_point, end_point: _np.array, list
         3D-coordinates for the start and end point of the line.
 
     **kwargs (for all of them look into create_beam_mesh_function)
@@ -77,17 +77,17 @@ def create_beam_mesh_line(
     """
 
     # Get geometrical values for this line.
-    start_point = np.asarray(start_point)
-    end_point = np.asarray(end_point)
+    start_point = _np.asarray(start_point)
+    end_point = _np.asarray(end_point)
     direction = end_point - start_point
-    line_length = np.linalg.norm(direction)
+    line_length = _np.linalg.norm(direction)
     t1 = direction / line_length
 
     # Check if the z or y axis are larger projected onto the direction.
     # The tolerance is used here to ensure that round-off changes in the last digits of
     # the floating point values don't switch the case. This increases the robustness in
     # testing.
-    if abs(np.dot(t1, [0, 0, 1])) < abs(np.dot(t1, [0, 1, 0])) - _mpy.eps_quaternion:
+    if abs(_np.dot(t1, [0, 0, 1])) < abs(_np.dot(t1, [0, 1, 0])) - _mpy.eps_quaternion:
         t2 = [0, 0, 1]
     else:
         t2 = [0, 1, 0]
@@ -136,7 +136,7 @@ def create_beam_mesh_arc_segment_via_rotation(
         Class of beam that will be used for this line.
     material: Material
         Material for this segment.
-    center: np.array, list
+    center: _np.array, list
         Center of the arc.
     axis_rotation: Rotation
         This rotation defines the spatial orientation of the arc.
@@ -198,11 +198,11 @@ def create_beam_mesh_arc_segment_via_axis(
         Class of beam that will be used for this line.
     material: Material
         Material for this segment.
-    axis: np.array, list
+    axis: _np.array, list
         Rotation axis of the arc.
-    axis_point: np.array, list
+    axis_point: _np.array, list
         Point lying on the rotation axis. Does not have to be the center of the arc.
-    start_point: np.array, list
+    start_point: _np.array, list
         Start point of the arc.
     angle: float
         The central angle of this segment in radians.
@@ -232,22 +232,22 @@ def create_beam_mesh_arc_segment_via_axis(
 
     # Shortest distance from the given point to the axis of rotation gives
     # the "center" of the arc
-    axis = np.asarray(axis)
-    axis_point = np.asarray(axis_point)
-    start_point = np.asarray(start_point)
+    axis = _np.asarray(axis)
+    axis_point = _np.asarray(axis_point)
+    start_point = _np.asarray(start_point)
 
-    axis = axis / np.linalg.norm(axis)
+    axis = axis / _np.linalg.norm(axis)
     diff = start_point - axis_point
-    distance = diff - np.dot(np.dot(diff, axis), axis)
-    radius = np.linalg.norm(distance)
+    distance = diff - _np.dot(_np.dot(diff, axis), axis)
+    radius = _np.linalg.norm(distance)
     center = start_point - distance
 
     # Get the rotation at the start
     if start_node is None:
-        tangent = np.cross(axis, distance)
-        tangent /= np.linalg.norm(tangent)
+        tangent = _np.cross(axis, distance)
+        tangent /= _np.linalg.norm(tangent)
         start_rotation = _Rotation.from_rotation_matrix(
-            np.transpose(np.array([tangent, -distance / radius, axis]))
+            _np.transpose(_np.array([tangent, -distance / radius, axis]))
         )
     else:
         start_rotation = _get_single_node(start_node).rotation
@@ -293,7 +293,7 @@ def create_beam_mesh_arc_segment_2d(
         Class of beam that will be used for this line.
     material: Material
         Material for this segment.
-    center: np.array, list
+    center: _np.array, list
         Center of the arc. If the z component is not 0, an error will be
         thrown.
     radius: float
@@ -322,15 +322,15 @@ def create_beam_mesh_arc_segment_2d(
     """
 
     # The center point has to be on the x-y plane.
-    if np.abs(center[2]) > _mpy.eps_pos:
+    if _np.abs(center[2]) > _mpy.eps_pos:
         raise ValueError("The z-value of center has to be 0!")
 
     # Check if the beam is in clockwise or counter clockwise direction.
     angle = phi_end - phi_start
-    axis = np.array([0, 0, 1])
+    axis = _np.array([0, 0, 1])
     start_point = center + radius * (_Rotation(axis, phi_start) * [1, 0, 0])
 
-    counter_clockwise = np.sign(angle) == 1
+    counter_clockwise = _np.sign(angle) == 1
     if not counter_clockwise:
         # If the beam is not in counter clockwise direction, we have to flip
         # the rotation axis.
@@ -343,7 +343,7 @@ def create_beam_mesh_arc_segment_2d(
         axis,
         center,
         start_point,
-        np.abs(angle),
+        _np.abs(angle),
         **kwargs,
     )
 
@@ -362,7 +362,7 @@ def create_beam_mesh_line_at_node(
         Class of beam that will be used for this line.
     material: Material
         Material for this segment.
-    start_node: np.array, list
+    start_node: _np.array, list
         Point where the arc will continue.
     length: float
         Length of the line.
@@ -418,7 +418,7 @@ def create_beam_mesh_arc_at_node(
         Class of beam that will be used for this line.
     material: Material
         Material for this segment.
-    start_node: np.array, list
+    start_node: _np.array, list
         Point where the arc will continue.
     arc_axis_normal: 3d-vector
         Rotation axis for the created arc.
@@ -446,21 +446,21 @@ def create_beam_mesh_arc_at_node(
     """
 
     # If the angle is negative, the normal is switched
-    arc_axis_normal = np.asarray(arc_axis_normal)
+    arc_axis_normal = _np.asarray(arc_axis_normal)
     if angle < 0:
         arc_axis_normal = -1.0 * arc_axis_normal
 
     # The normal has to be perpendicular to the start point tangent
     start_node = _get_single_node(start_node, check_cosserat_node=True)
     tangent = start_node.rotation * [1, 0, 0]
-    if np.abs(np.dot(tangent, arc_axis_normal)) > _mpy.eps_pos:
+    if _np.abs(_np.dot(tangent, arc_axis_normal)) > _mpy.eps_pos:
         raise ValueError(
             "The normal has to be perpendicular to the tangent in the start node!"
         )
 
     # Get the center of the arc
-    center_direction = np.cross(tangent, arc_axis_normal)
-    center_direction *= 1.0 / np.linalg.norm(center_direction)
+    center_direction = _np.cross(tangent, arc_axis_normal)
+    center_direction *= 1.0 / _np.linalg.norm(center_direction)
     center = start_node.coordinates - center_direction * radius
 
     return create_beam_mesh_arc_segment_via_axis(
@@ -470,7 +470,7 @@ def create_beam_mesh_arc_at_node(
         arc_axis_normal,
         center,
         start_node.coordinates,
-        np.abs(angle),
+        _np.abs(angle),
         start_node=start_node,
         **kwargs,
     )
@@ -503,12 +503,12 @@ def create_beam_mesh_helix(
         Class of beam that will be used for this line.
     material: Material
         Material for this segment.
-    axis_vector: np.array, list
+    axis_vector: _np.array, list
         Vector for the orientation of the helical center axis.
-    axis_point: np.array, list
+    axis_point: _np.array, list
         Point lying on the helical center axis. Does not need to align with
         bottom plane of helix.
-    start_point: np.array, list
+    start_point: _np.array, list
         Start point of the helix. Defines the radius.
     helix_angle: float
         Angle of the helix (synonyms in literature: twist angle or pitch
@@ -544,37 +544,37 @@ def create_beam_mesh_helix(
             " must be provided!"
         )
 
-    if helix_angle is not None and np.isclose(np.sin(helix_angle), 0.0):
+    if helix_angle is not None and _np.isclose(_np.sin(helix_angle), 0.0):
         raise ValueError(
             "Helix angle of helix is 0 degrees! "
             + "Change angle for feasible helix geometry!"
         )
 
-    if height_helix is not None and np.isclose(height_helix, 0.0):
+    if height_helix is not None and _np.isclose(height_helix, 0.0):
         raise ValueError(
             "Height of helix is 0! Change height for feasible helix geometry!"
         )
 
     # determine radius of helix
-    axis_vector = np.asarray(axis_vector)
-    axis_point = np.asarray(axis_point)
-    start_point = np.asarray(start_point)
+    axis_vector = _np.asarray(axis_vector)
+    axis_point = _np.asarray(axis_point)
+    start_point = _np.asarray(start_point)
 
-    axis_vector = axis_vector / np.linalg.norm(axis_vector)
-    origin = axis_point + np.dot(
-        np.dot(start_point - axis_point, axis_vector), axis_vector
+    axis_vector = axis_vector / _np.linalg.norm(axis_vector)
+    origin = axis_point + _np.dot(
+        _np.dot(start_point - axis_point, axis_vector), axis_vector
     )
     start_point_origin_vec = start_point - origin
-    radius = np.linalg.norm(start_point_origin_vec)
+    radius = _np.linalg.norm(start_point_origin_vec)
 
     # create temporary mesh to not alter original mesh
     mesh_temp = _Mesh()
 
-    # return line if radius of helix is 0, helix angle is np.pi/2 or turns is 0
+    # return line if radius of helix is 0, helix angle is pi/2 or turns is 0
     if (
-        np.isclose(radius, 0)
-        or (helix_angle is not None and np.isclose(np.cos(helix_angle), 0.0))
-        or (turns is not None and np.isclose(turns, 0.0))
+        _np.isclose(radius, 0)
+        or (helix_angle is not None and _np.isclose(_np.cos(helix_angle), 0.0))
+        or (turns is not None and _np.isclose(turns, 0.0))
     ):
         if height_helix is None:
             raise ValueError(
@@ -591,8 +591,8 @@ def create_beam_mesh_helix(
             )
 
         if helix_angle is not None and height_helix is not None:
-            end_point = start_point + height_helix * axis_vector * np.sign(
-                np.sin(helix_angle)
+            end_point = start_point + height_helix * axis_vector * _np.sign(
+                _np.sin(helix_angle)
             )
         elif height_helix is not None and turns is not None:
             end_point = start_point + height_helix * axis_vector
@@ -613,31 +613,31 @@ def create_beam_mesh_helix(
 
     # generate simple helix
     if helix_angle and height_helix:
-        end_point = np.array(
+        end_point = _np.array(
             [
                 radius,
-                np.sign(np.sin(helix_angle)) * height_helix / np.tan(helix_angle),
-                np.sign(np.sin(helix_angle)) * height_helix,
+                _np.sign(_np.sin(helix_angle)) * height_helix / _np.tan(helix_angle),
+                _np.sign(_np.sin(helix_angle)) * height_helix,
             ]
         )
     elif helix_angle and turns:
-        end_point = np.array(
+        end_point = _np.array(
             [
                 radius,
-                np.sign(np.cos(helix_angle)) * 2 * np.pi * radius * turns,
-                np.sign(np.cos(helix_angle))
+                _np.sign(_np.cos(helix_angle)) * 2 * _np.pi * radius * turns,
+                _np.sign(_np.cos(helix_angle))
                 * 2
-                * np.pi
+                * _np.pi
                 * radius
-                * np.abs(turns)
-                * np.tan(helix_angle),
+                * _np.abs(turns)
+                * _np.tan(helix_angle),
             ]
         )
     elif height_helix and turns:
-        end_point = np.array(
+        end_point = _np.array(
             [
                 radius,
-                2 * np.pi * radius * turns,
+                2 * _np.pi * radius * turns,
                 height_helix,
             ]
         )
@@ -656,7 +656,7 @@ def create_beam_mesh_helix(
     # rotate and translate simple helix to align with necessary axis and starting point
     mesh_temp.rotate(
         _Rotation.from_basis(start_point_origin_vec, axis_vector)
-        * _Rotation([1, 0, 0], -np.pi * 0.5)
+        * _Rotation([1, 0, 0], -_np.pi * 0.5)
     )
     mesh_temp.translate(-mesh_temp.nodes[0].coordinates + start_point)
 

--- a/src/meshpy/mesh_creation_functions/beam_basic_geometry.py
+++ b/src/meshpy/mesh_creation_functions/beam_basic_geometry.py
@@ -25,11 +25,13 @@ import warnings
 
 import numpy as np
 
-from meshpy.core.conf import mpy
-from meshpy.core.mesh import Mesh
-from meshpy.core.rotation import Rotation
-from meshpy.mesh_creation_functions.beam_generic import create_beam_mesh_function
-from meshpy.utils.nodes import get_single_node
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.mesh import Mesh as _Mesh
+from meshpy.core.rotation import Rotation as _Rotation
+from meshpy.mesh_creation_functions.beam_generic import (
+    create_beam_mesh_function as _create_beam_mesh_function,
+)
+from meshpy.utils.nodes import get_single_node as _get_single_node
 
 
 def create_beam_mesh_line(
@@ -85,11 +87,11 @@ def create_beam_mesh_line(
     # The tolerance is used here to ensure that round-off changes in the last digits of
     # the floating point values don't switch the case. This increases the robustness in
     # testing.
-    if abs(np.dot(t1, [0, 0, 1])) < abs(np.dot(t1, [0, 1, 0])) - mpy.eps_quaternion:
+    if abs(np.dot(t1, [0, 0, 1])) < abs(np.dot(t1, [0, 1, 0])) - _mpy.eps_quaternion:
         t2 = [0, 0, 1]
     else:
         t2 = [0, 1, 0]
-    rotation = Rotation.from_basis(t1, t2)
+    rotation = _Rotation.from_basis(t1, t2)
 
     def get_beam_geometry(parameter_a, parameter_b):
         """Return a function for the position along the beams axis."""
@@ -104,7 +106,7 @@ def create_beam_mesh_line(
         return beam_function
 
     # Create the beam in the mesh
-    return create_beam_mesh_function(
+    return _create_beam_mesh_function(
         mesh,
         beam_object=beam_object,
         material=material,
@@ -244,11 +246,11 @@ def create_beam_mesh_arc_segment_via_axis(
     if start_node is None:
         tangent = np.cross(axis, distance)
         tangent /= np.linalg.norm(tangent)
-        start_rotation = Rotation.from_rotation_matrix(
+        start_rotation = _Rotation.from_rotation_matrix(
             np.transpose(np.array([tangent, -distance / radius, axis]))
         )
     else:
-        start_rotation = get_single_node(start_node).rotation
+        start_rotation = _get_single_node(start_node).rotation
 
     def get_beam_geometry(alpha, beta):
         """Return a function for the position and rotation along the beam
@@ -258,7 +260,7 @@ def create_beam_mesh_arc_segment_via_axis(
             """Return a point and the triad on the beams axis for a given
             parameter coordinate xi."""
             phi = 0.5 * (xi + 1) * (beta - alpha) + alpha
-            arc_rotation = Rotation(axis, phi)
+            arc_rotation = _Rotation(axis, phi)
             rot = arc_rotation * start_rotation
             pos = center + arc_rotation * distance
             return (pos, rot)
@@ -266,7 +268,7 @@ def create_beam_mesh_arc_segment_via_axis(
         return beam_function
 
     # Create the beam in the mesh
-    return create_beam_mesh_function(
+    return _create_beam_mesh_function(
         mesh,
         beam_object=beam_object,
         material=material,
@@ -320,13 +322,13 @@ def create_beam_mesh_arc_segment_2d(
     """
 
     # The center point has to be on the x-y plane.
-    if np.abs(center[2]) > mpy.eps_pos:
+    if np.abs(center[2]) > _mpy.eps_pos:
         raise ValueError("The z-value of center has to be 0!")
 
     # Check if the beam is in clockwise or counter clockwise direction.
     angle = phi_end - phi_start
     axis = np.array([0, 0, 1])
-    start_point = center + radius * (Rotation(axis, phi_start) * [1, 0, 0])
+    start_point = center + radius * (_Rotation(axis, phi_start) * [1, 0, 0])
 
     counter_clockwise = np.sign(angle) == 1
     if not counter_clockwise:
@@ -386,7 +388,7 @@ def create_beam_mesh_line_at_node(
         raise ValueError("Length has to be positive!")
 
     # Create the line starting from the given node
-    start_node = get_single_node(start_node, check_cosserat_node=True)
+    start_node = _get_single_node(start_node, check_cosserat_node=True)
     tangent = start_node.rotation * [1, 0, 0]
     start_position = start_node.coordinates
     end_position = start_position + tangent * length
@@ -449,9 +451,9 @@ def create_beam_mesh_arc_at_node(
         arc_axis_normal = -1.0 * arc_axis_normal
 
     # The normal has to be perpendicular to the start point tangent
-    start_node = get_single_node(start_node, check_cosserat_node=True)
+    start_node = _get_single_node(start_node, check_cosserat_node=True)
     tangent = start_node.rotation * [1, 0, 0]
-    if np.abs(np.dot(tangent, arc_axis_normal)) > mpy.eps_pos:
+    if np.abs(np.dot(tangent, arc_axis_normal)) > _mpy.eps_pos:
         raise ValueError(
             "The normal has to be perpendicular to the tangent in the start node!"
         )
@@ -566,7 +568,7 @@ def create_beam_mesh_helix(
     radius = np.linalg.norm(start_point_origin_vec)
 
     # create temporary mesh to not alter original mesh
-    mesh_temp = Mesh()
+    mesh_temp = _Mesh()
 
     # return line if radius of helix is 0, helix angle is np.pi/2 or turns is 0
     if (
@@ -653,8 +655,8 @@ def create_beam_mesh_helix(
 
     # rotate and translate simple helix to align with necessary axis and starting point
     mesh_temp.rotate(
-        Rotation.from_basis(start_point_origin_vec, axis_vector)
-        * Rotation([1, 0, 0], -np.pi * 0.5)
+        _Rotation.from_basis(start_point_origin_vec, axis_vector)
+        * _Rotation([1, 0, 0], -np.pi * 0.5)
     )
     mesh_temp.translate(-mesh_temp.nodes[0].coordinates + start_point)
 

--- a/src/meshpy/mesh_creation_functions/beam_curve.py
+++ b/src/meshpy/mesh_creation_functions/beam_curve.py
@@ -27,9 +27,12 @@ import scipy.integrate as integrate
 import scipy.optimize as optimize
 from autograd import jacobian
 
-from meshpy.core.conf import mpy
-from meshpy.core.rotation import Rotation, smallest_rotation
-from meshpy.mesh_creation_functions.beam_generic import create_beam_mesh_function
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.rotation import Rotation as _Rotation
+from meshpy.core.rotation import smallest_rotation as _smallest_rotation
+from meshpy.mesh_creation_functions.beam_generic import (
+    create_beam_mesh_function as _create_beam_mesh_function,
+)
 
 
 def create_beam_mesh_curve(
@@ -180,7 +183,7 @@ def create_beam_mesh_curve(
                     t2_temp = [0, 0, 1]
                 else:
                     t2_temp = [0, 1, 0]
-                self.last_triad = Rotation.from_basis(r_prime, t2_temp)
+                self.last_triad = _Rotation.from_basis(r_prime, t2_temp)
 
         def _reset_start_values(self):
             """Reset the stored start values for the next Newton iteration."""
@@ -196,7 +199,7 @@ def create_beam_mesh_curve(
 
             # In case the interval is not continuous with the last one, we reset the start
             # values for the Newton iteration here
-            if length_a < self.S_start_newton - mpy.eps_pos:
+            if length_a < self.S_start_newton - _mpy.eps_pos:
                 self._reset_start_values()
 
             # Length of the beam element in physical space.
@@ -232,11 +235,11 @@ def create_beam_mesh_curve(
                     if is_3d_curve:
                         # Create the next triad via the smallest rotation mapping based
                         # on the last triad.
-                        rot = smallest_rotation(self.last_triad, r_prime)
+                        rot = _smallest_rotation(self.last_triad, r_prime)
                         self.last_triad = rot.copy()
                     else:
                         # The rotation simplifies in the 2d case.
-                        rot = Rotation([0, 0, 1], np.arctan2(r_prime[1], r_prime[0]))
+                        rot = _Rotation([0, 0, 1], np.arctan2(r_prime[1], r_prime[0]))
 
                 # Set start values for the next iteration
                 self.t_start_newton = t
@@ -252,7 +255,7 @@ def create_beam_mesh_curve(
     length = S(interval[1])
 
     # Create the beam in the mesh
-    created_sets = create_beam_mesh_function(
+    created_sets = _create_beam_mesh_function(
         mesh,
         beam_object=beam_object,
         material=material,

--- a/src/meshpy/mesh_creation_functions/beam_curve.py
+++ b/src/meshpy/mesh_creation_functions/beam_curve.py
@@ -21,11 +21,11 @@
 # THE SOFTWARE.
 """This file has functions to create a beam from a parametric curve."""
 
-import autograd.numpy as npAD
-import numpy as np
-import scipy.integrate as integrate
-import scipy.optimize as optimize
-from autograd import jacobian
+import autograd.numpy as _npAD
+import numpy as _np
+import scipy.integrate as _integrate
+import scipy.optimize as _optimize
+from autograd import jacobian as _jacobian
 
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.rotation import Rotation as _Rotation
@@ -112,9 +112,9 @@ def create_beam_mesh_curve(
         is_rot_funct = True
 
     # Check that the position is an np.array
-    if not isinstance(function(float(interval[0])), np.ndarray):
+    if not isinstance(function(float(interval[0])), _np.ndarray):
         raise TypeError(
-            "Function must be of type np.ndarray, got {}!".format(
+            "Function must be of type _np.ndarray, got {}!".format(
                 type(function(float(interval[0])))
             )
         )
@@ -122,7 +122,7 @@ def create_beam_mesh_curve(
     # Get the derivative of the position function and the increment along
     # the curve.
     if function_derivative is None:
-        rp = jacobian(function)
+        rp = _jacobian(function)
     else:
         rp = function_derivative
 
@@ -137,7 +137,7 @@ def create_beam_mesh_curve(
 
     def ds(t):
         """Increment along the curve."""
-        return npAD.linalg.norm(rp(t))
+        return _npAD.linalg.norm(rp(t))
 
     def S(t, start_t=None, start_S=None):
         """Function that integrates the length until a parameter value.
@@ -153,7 +153,7 @@ def create_beam_mesh_curve(
             sS = start_S
         else:
             raise ValueError("Input parameters are wrong!")
-        return integrate.quad(ds, st, t)[0] + sS
+        return _integrate.quad(ds, st, t)[0] + sS
 
     def get_t_along_curve(arc_length, t0, **kwargs):
         """Calculate the parameter t where the length along the curve is
@@ -161,7 +161,7 @@ def create_beam_mesh_curve(
 
         t0 is the start point for the Newton iteration.
         """
-        t_root = optimize.newton(lambda t: S(t, **kwargs) - arc_length, t0, fprime=ds)
+        t_root = _optimize.newton(lambda t: S(t, **kwargs) - arc_length, t0, fprime=ds)
         return t_root
 
     class BeamFunctions:
@@ -179,7 +179,7 @@ def create_beam_mesh_curve(
 
             if is_3d_curve:
                 r_prime = rp(float(interval[0]))
-                if abs(np.dot(r_prime, [0, 0, 1])) < abs(np.dot(r_prime, [0, 1, 0])):
+                if abs(_np.dot(r_prime, [0, 0, 1])) < abs(_np.dot(r_prime, [0, 1, 0])):
                     t2_temp = [0, 0, 1]
                 else:
                     t2_temp = [0, 1, 0]
@@ -224,7 +224,7 @@ def create_beam_mesh_curve(
                 if is_3d_curve:
                     pos = function(t)
                 else:
-                    pos = np.zeros(3)
+                    pos = _np.zeros(3)
                     pos[:2] = function(t)
 
                 # Rotation at xi.
@@ -239,7 +239,7 @@ def create_beam_mesh_curve(
                         self.last_triad = rot.copy()
                     else:
                         # The rotation simplifies in the 2d case.
-                        rot = _Rotation([0, 0, 1], np.arctan2(r_prime[1], r_prime[0]))
+                        rot = _Rotation([0, 0, 1], _np.arctan2(r_prime[1], r_prime[0]))
 
                 # Set start values for the next iteration
                 self.t_start_newton = t

--- a/src/meshpy/mesh_creation_functions/beam_fibers_in_rectangle.py
+++ b/src/meshpy/mesh_creation_functions/beam_fibers_in_rectangle.py
@@ -26,7 +26,7 @@ This can for example be used to create fiber reinforced composite
 plates.
 """
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.geometry_set import GeometryName as _GeometryName
 from meshpy.core.geometry_set import GeometrySet as _GeometrySet
@@ -67,8 +67,8 @@ def _intersect_line_with_rectangle(
     """
 
     # Convert the input values to np.arrays.
-    start_line = np.asarray(start_line)
-    direction_line = np.asarray(direction_line)
+    start_line = _np.asarray(start_line)
+    direction_line = _np.asarray(direction_line)
 
     # Set definition for the boundary lines of the rectangle. The director is
     # chosen in a way, that the values [0, 1] for the line parameters alpha are
@@ -82,18 +82,18 @@ def _intersect_line_with_rectangle(
     ]
     # Convert to numpy arrays.
     boundary_lines = [
-        [np.array(item) for item in boundary] for boundary in boundary_lines
+        [_np.array(item) for item in boundary] for boundary in boundary_lines
     ]
 
     # Loop over the boundaries.
     alpha_list = []
     for start_boundary, direction_boundary in boundary_lines:
         # Set up the linear system to solve the intersection problem.
-        A = np.transpose(np.array([direction_line, -direction_boundary]))
+        A = _np.transpose(_np.array([direction_line, -direction_boundary]))
 
         # Check if the system is solvable.
-        if np.abs(np.linalg.det(A)) > 1e-10:
-            alpha = np.linalg.solve(A, start_boundary - start_line)
+        if _np.abs(_np.linalg.det(A)) > 1e-10:
+            alpha = _np.linalg.solve(A, start_boundary - start_line)
             if 0 <= alpha[1] and alpha[1] <= 1:
                 alpha_list.append(alpha[0])
 
@@ -154,7 +154,7 @@ def create_fibers_in_rectangle(
     """
 
     if reference_point is None:
-        reference_point = 0.5 * np.array([length, width])
+        reference_point = 0.5 * _np.array([length, width])
     else:
         if (
             reference_point[0] < 0.0
@@ -170,17 +170,17 @@ def create_fibers_in_rectangle(
         raise ValueError("fiber_element_length_min must be positive!")
 
     # Get the fiber angle in rad.
-    fiber_angle = angle * np.pi / 180.0
-    sin = np.sin(fiber_angle)
-    cos = np.cos(fiber_angle)
+    fiber_angle = angle * _np.pi / 180.0
+    sin = _np.sin(fiber_angle)
+    cos = _np.cos(fiber_angle)
 
     # Direction and normal vector of the fibers.
-    fiber_direction = np.array([cos, sin])
-    fiber_normal = np.array([-sin, cos])
+    fiber_direction = _np.array([cos, sin])
+    fiber_normal = _np.array([-sin, cos])
 
     # Get an upper bound of the number of fibers in this layer.
-    diagonal = np.sqrt(length**2 + width**2)
-    fiber_n_max = int(np.ceil(diagonal / fiber_normal_distance)) + 1
+    diagonal = _np.sqrt(length**2 + width**2)
+    fiber_n_max = int(_np.ceil(diagonal / fiber_normal_distance)) + 1
 
     # Go in both directions from the start point.
     for direction_sign, n_start in [[-1, 1], [1, 0]]:
@@ -198,20 +198,20 @@ def create_fibers_in_rectangle(
 
             if projection_found:
                 # Calculate the length of the line.
-                fiber_length = np.linalg.norm(end - start)
+                fiber_length = _np.linalg.norm(end - start)
 
                 # Create the beams if the length is not smaller than the fiber
                 # distance.
                 if fiber_length >= fiber_element_length_min:
                     # Calculate the number of elements in this fiber.
-                    fiber_nel = int(np.round(fiber_length / fiber_element_length))
-                    fiber_nel = np.max([fiber_nel, 1])
+                    fiber_nel = int(_np.round(fiber_length / fiber_element_length))
+                    fiber_nel = _np.max([fiber_nel, 1])
                     _create_beam_mesh_line(
                         mesh,
                         beam_object,
                         material,
-                        np.append(start, 0.0),
-                        np.append(end, 0.0),
+                        _np.append(start, 0.0),
+                        _np.append(end, 0.0),
                         n_el=fiber_nel,
                     )
             else:

--- a/src/meshpy/mesh_creation_functions/beam_fibers_in_rectangle.py
+++ b/src/meshpy/mesh_creation_functions/beam_fibers_in_rectangle.py
@@ -28,9 +28,12 @@ plates.
 
 import numpy as np
 
-from meshpy.core.geometry_set import GeometryName, GeometrySet
-from meshpy.mesh_creation_functions.beam_basic_geometry import create_beam_mesh_line
-from meshpy.utils.nodes import check_node_by_coordinate
+from meshpy.core.geometry_set import GeometryName as _GeometryName
+from meshpy.core.geometry_set import GeometrySet as _GeometrySet
+from meshpy.mesh_creation_functions.beam_basic_geometry import (
+    create_beam_mesh_line as _create_beam_mesh_line,
+)
+from meshpy.utils.nodes import check_node_by_coordinate as _check_node_by_coordinate
 
 
 def _intersect_line_with_rectangle(
@@ -203,7 +206,7 @@ def create_fibers_in_rectangle(
                     # Calculate the number of elements in this fiber.
                     fiber_nel = int(np.round(fiber_length / fiber_element_length))
                     fiber_nel = np.max([fiber_nel, 1])
-                    create_beam_mesh_line(
+                    _create_beam_mesh_line(
                         mesh,
                         beam_object,
                         material,
@@ -215,18 +218,18 @@ def create_fibers_in_rectangle(
                 # The current search position is already outside of the rectangle, no need to continue.
                 break
 
-    return_set = GeometryName()
-    return_set["north"] = GeometrySet(
-        mesh.get_nodes_by_function(check_node_by_coordinate, 1, width),
+    return_set = _GeometryName()
+    return_set["north"] = _GeometrySet(
+        mesh.get_nodes_by_function(_check_node_by_coordinate, 1, width),
     )
-    return_set["east"] = GeometrySet(
-        mesh.get_nodes_by_function(check_node_by_coordinate, 0, length),
+    return_set["east"] = _GeometrySet(
+        mesh.get_nodes_by_function(_check_node_by_coordinate, 0, length),
     )
-    return_set["south"] = GeometrySet(
-        mesh.get_nodes_by_function(check_node_by_coordinate, 1, 0)
+    return_set["south"] = _GeometrySet(
+        mesh.get_nodes_by_function(_check_node_by_coordinate, 1, 0)
     )
-    return_set["west"] = GeometrySet(
-        mesh.get_nodes_by_function(check_node_by_coordinate, 0, 0)
+    return_set["west"] = _GeometrySet(
+        mesh.get_nodes_by_function(_check_node_by_coordinate, 0, 0)
     )
-    return_set["all"] = GeometrySet(mesh.elements)
+    return_set["all"] = _GeometrySet(mesh.elements)
     return return_set

--- a/src/meshpy/mesh_creation_functions/beam_generic.py
+++ b/src/meshpy/mesh_creation_functions/beam_generic.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 """Generic function used to create all beams within meshpy."""
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.geometry_set import GeometryName as _GeometryName
@@ -142,7 +142,7 @@ def create_beam_mesh_function(
     else:
         # Check that the given positions are in ascending order and start with 1 and end with 0
         for index, value, name in zip([0, -1], [0, 1], ["First", "Last"]):
-            if not np.isclose(
+            if not _np.isclose(
                 value,
                 node_positions_of_elements[index],
                 atol=1e-12,
@@ -160,7 +160,7 @@ def create_beam_mesh_function(
             )
         interval_node_positions_of_elements = interval[0] + (
             interval[1] - interval[0]
-        ) * np.asarray(node_positions_of_elements)
+        ) * _np.asarray(node_positions_of_elements)
 
     # Make sure the material is in the mesh.
     mesh.add_material(material)
@@ -197,7 +197,7 @@ def create_beam_mesh_function(
             # Evaluate the relative rotation
             # First check if the first basis vector is the same
             relative_basis_1 = rotation_node.inv() * rotation_function * [1, 0, 0]
-            if np.linalg.norm(relative_basis_1 - [1, 0, 0]) < _mpy.eps_quaternion:
+            if _np.linalg.norm(relative_basis_1 - [1, 0, 0]) < _mpy.eps_quaternion:
                 # Calculate the relative rotation
                 return rotation_function.inv() * rotation_node
             else:

--- a/src/meshpy/mesh_creation_functions/beam_generic.py
+++ b/src/meshpy/mesh_creation_functions/beam_generic.py
@@ -23,9 +23,10 @@
 
 import numpy as np
 
-from meshpy.core.conf import mpy
-from meshpy.core.geometry_set import GeometryName, GeometrySet
-from meshpy.utils.nodes import get_single_node
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.geometry_set import GeometryName as _GeometryName
+from meshpy.core.geometry_set import GeometrySet as _GeometrySet
+from meshpy.utils.nodes import get_single_node as _get_single_node
 
 
 def create_beam_mesh_function(
@@ -187,7 +188,7 @@ def create_beam_mesh_function(
 
         if rotation_node == rotation_function:
             return None
-        elif not mpy.allow_beam_rotation:
+        elif not _mpy.allow_beam_rotation:
             # The settings do not allow for a rotation of the beam
             raise ValueError(
                 "Given nodal rotation does not match with given rotation function!"
@@ -196,7 +197,7 @@ def create_beam_mesh_function(
             # Evaluate the relative rotation
             # First check if the first basis vector is the same
             relative_basis_1 = rotation_node.inv() * rotation_function * [1, 0, 0]
-            if np.linalg.norm(relative_basis_1 - [1, 0, 0]) < mpy.eps_quaternion:
+            if np.linalg.norm(relative_basis_1 - [1, 0, 0]) < _mpy.eps_quaternion:
                 # Calculate the relative rotation
                 return rotation_function.inv() * rotation_node
             else:
@@ -211,7 +212,7 @@ def create_beam_mesh_function(
 
     # If a start node is given, set this as the first node for this beam.
     if start_node is not None:
-        start_node = get_single_node(start_node, check_cosserat_node=True)
+        start_node = _get_single_node(start_node, check_cosserat_node=True)
         nodes = [start_node]
         check_given_node(start_node)
         _, start_rotation = function_over_whole_interval(-1.0)
@@ -222,7 +223,7 @@ def create_beam_mesh_function(
     if end_node is True:
         close_beam = True
     elif end_node is not None:
-        end_node = get_single_node(end_node, check_cosserat_node=True)
+        end_node = _get_single_node(end_node, check_cosserat_node=True)
         check_given_node(end_node)
         _, end_rotation = function_over_whole_interval(1.0)
         relative_twist_end = get_relative_twist(end_node.rotation, end_rotation)
@@ -306,10 +307,10 @@ def create_beam_mesh_function(
     end_node.is_end_node = True
 
     # Create geometry sets that will be returned.
-    return_set = GeometryName()
-    return_set["start"] = GeometrySet(nodes[0])
-    return_set["end"] = GeometrySet(end_node)
-    return_set["line"] = GeometrySet(elements)
+    return_set = _GeometryName()
+    return_set["start"] = _GeometrySet(nodes[0])
+    return_set["end"] = _GeometrySet(end_node)
+    return_set["line"] = _GeometrySet(elements)
     if add_sets:
         mesh.add(return_set)
     return return_set

--- a/src/meshpy/mesh_creation_functions/beam_honeycomb.py
+++ b/src/meshpy/mesh_creation_functions/beam_honeycomb.py
@@ -23,11 +23,14 @@
 
 import numpy as np
 
-from meshpy.core.geometry_set import GeometryName, GeometrySet
-from meshpy.core.mesh import Mesh
-from meshpy.core.rotation import Rotation
-from meshpy.mesh_creation_functions.beam_basic_geometry import create_beam_mesh_line
-from meshpy.utils.nodes import get_min_max_nodes
+from meshpy.core.geometry_set import GeometryName as _GeometryName
+from meshpy.core.geometry_set import GeometrySet as _GeometrySet
+from meshpy.core.mesh import Mesh as _Mesh
+from meshpy.core.rotation import Rotation as _Rotation
+from meshpy.mesh_creation_functions.beam_basic_geometry import (
+    create_beam_mesh_line as _create_beam_mesh_line,
+)
+from meshpy.utils.nodes import get_min_max_nodes as _get_min_max_nodes
 
 
 def create_beam_mesh_honeycomb_flat(
@@ -84,7 +87,7 @@ def create_beam_mesh_honeycomb_flat(
 
     def add_line(pointa, pointb):
         """Shortcut to add line."""
-        return create_beam_mesh_line(
+        return _create_beam_mesh_line(
             mesh_honeycomb, beam_object, material, pointa, pointb, n_el=n_el
         )
 
@@ -98,7 +101,7 @@ def create_beam_mesh_honeycomb_flat(
     zig_zag_y = ny * a * sin30 * 0.5
 
     # Create the honeycomb structure
-    mesh_honeycomb = Mesh()
+    mesh_honeycomb = _Mesh()
     origin = np.array([0, a * 0.5 * sin30, 0])
     for i_height in range(n_height + 1):
         # Start point for this zig-zag line.
@@ -144,15 +147,15 @@ def create_beam_mesh_honeycomb_flat(
         mesh_honeycomb.couple_nodes(nodes=honeycomb_nodes)
 
     # Get min and max nodes of the honeycomb.
-    min_max_nodes = get_min_max_nodes(honeycomb_nodes)
+    min_max_nodes = _get_min_max_nodes(honeycomb_nodes)
 
     # Return the geometry set.
-    return_set = GeometryName()
+    return_set = _GeometryName()
     return_set["north"] = min_max_nodes["y_max"]
     return_set["east"] = min_max_nodes["x_max"]
     return_set["south"] = min_max_nodes["y_min"]
     return_set["west"] = min_max_nodes["x_min"]
-    return_set["all"] = GeometrySet(mesh_honeycomb.elements)
+    return_set["all"] = _GeometrySet(mesh_honeycomb.elements)
 
     mesh.add(mesh_honeycomb)
     if add_sets:
@@ -215,7 +218,7 @@ def create_beam_mesh_honeycomb(
         width = diameter * np.pi / n_circumference
         closed_width = False
         closed_height = closed_top
-        rotation = Rotation([0, 0, 1], np.pi / 2) * Rotation([1, 0, 0], np.pi / 2)
+        rotation = _Rotation([0, 0, 1], np.pi / 2) * _Rotation([1, 0, 0], np.pi / 2)
         n_height = n_axis
         n_width = n_circumference
     else:
@@ -229,14 +232,14 @@ def create_beam_mesh_honeycomb(
         width = 2 * r * np.cos(np.pi / 6)
         closed_width = closed_top
         closed_height = False
-        rotation = Rotation([0, 1, 0], -0.5 * np.pi)
+        rotation = _Rotation([0, 1, 0], -0.5 * np.pi)
         n_height = n_circumference - 1
         n_width = n_axis
 
     # Create the flat mesh, do not create couplings, as they will be added
     # later in this function, where also the diameter nodes will be
     # connected.
-    mesh_temp = Mesh()
+    mesh_temp = _Mesh()
     honeycomb_sets = create_beam_mesh_honeycomb_flat(
         mesh_temp,
         beam_object,
@@ -260,7 +263,7 @@ def create_beam_mesh_honeycomb(
     mesh_temp.couple_nodes(nodes=honeycomb_nodes)
 
     # Return the geometry set'
-    return_set = GeometryName()
+    return_set = _GeometryName()
     return_set["all"] = honeycomb_sets["all"]
     if vertical:
         return_set["top"] = honeycomb_sets["north"]

--- a/src/meshpy/mesh_creation_functions/beam_honeycomb.py
+++ b/src/meshpy/mesh_creation_functions/beam_honeycomb.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 """This file has functions to create a honeycomb beam mesh."""
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.geometry_set import GeometryName as _GeometryName
 from meshpy.core.geometry_set import GeometrySet as _GeometrySet
@@ -92,17 +92,17 @@ def create_beam_mesh_honeycomb_flat(
         )
 
     # Geometrical shortcuts.
-    sin30 = np.sin(np.pi / 6)
-    cos30 = np.sin(2 * np.pi / 6)
+    sin30 = _np.sin(_np.pi / 6)
+    cos30 = _np.sin(2 * _np.pi / 6)
     a = width * 0.5 / cos30
-    nx = np.array([1.0, 0.0, 0.0])
-    ny = np.array([0.0, 1.0, 0.0])
+    nx = _np.array([1.0, 0.0, 0.0])
+    ny = _np.array([0.0, 1.0, 0.0])
     zig_zag_x = nx * width * 0.5
     zig_zag_y = ny * a * sin30 * 0.5
 
     # Create the honeycomb structure
     mesh_honeycomb = _Mesh()
-    origin = np.array([0, a * 0.5 * sin30, 0])
+    origin = _np.array([0, a * 0.5 * sin30, 0])
     for i_height in range(n_height + 1):
         # Start point for this zig-zag line.
         base_row = origin + (2 * zig_zag_y + a * ny) * i_height
@@ -215,10 +215,10 @@ def create_beam_mesh_honeycomb(
 
     # Calculate the input values for the flat honeycomb mesh.
     if vertical:
-        width = diameter * np.pi / n_circumference
+        width = diameter * _np.pi / n_circumference
         closed_width = False
         closed_height = closed_top
-        rotation = _Rotation([0, 0, 1], np.pi / 2) * _Rotation([1, 0, 0], np.pi / 2)
+        rotation = _Rotation([0, 0, 1], _np.pi / 2) * _Rotation([1, 0, 0], _np.pi / 2)
         n_height = n_axis
         n_width = n_circumference
     else:
@@ -227,12 +227,12 @@ def create_beam_mesh_honeycomb(
                 "There has to be an even number of elements along the diameter in horizontal mode. "
                 "Given: {}!".format(n_circumference)
             )
-        H = diameter * np.pi / n_circumference
-        r = H / (1 + np.sin(np.pi / 6))
-        width = 2 * r * np.cos(np.pi / 6)
+        H = diameter * _np.pi / n_circumference
+        r = H / (1 + _np.sin(_np.pi / 6))
+        width = 2 * r * _np.cos(_np.pi / 6)
         closed_width = closed_top
         closed_height = False
-        rotation = _Rotation([0, 1, 0], -0.5 * np.pi)
+        rotation = _Rotation([0, 1, 0], -0.5 * _np.pi)
         n_height = n_circumference - 1
         n_width = n_axis
 

--- a/src/meshpy/mesh_creation_functions/beam_nurbs.py
+++ b/src/meshpy/mesh_creation_functions/beam_nurbs.py
@@ -23,8 +23,10 @@
 
 import numpy as np
 
-from meshpy.core.conf import mpy
-from meshpy.mesh_creation_functions.beam_curve import create_beam_mesh_curve
+from meshpy.core.conf import mpy as _mpy
+from meshpy.mesh_creation_functions.beam_curve import (
+    create_beam_mesh_curve as _create_beam_mesh_curve,
+)
 
 
 def get_nurbs_curve_function_and_jacobian_for_integration(curve, tol=None):
@@ -57,7 +59,7 @@ def get_nurbs_curve_function_and_jacobian_for_integration(curve, tol=None):
     """
 
     if tol is None:
-        tol = mpy.eps_pos
+        tol = _mpy.eps_pos
 
     knot_vector = curve.knot_vectors[0]
     curve_start = np.min(knot_vector)
@@ -148,7 +150,7 @@ def create_beam_mesh_from_nurbs(
     ) = get_nurbs_curve_function_and_jacobian_for_integration(curve, tol=tol)
 
     # Create the beams
-    return create_beam_mesh_curve(
+    return _create_beam_mesh_curve(
         mesh,
         beam_object,
         material,

--- a/src/meshpy/mesh_creation_functions/beam_nurbs.py
+++ b/src/meshpy/mesh_creation_functions/beam_nurbs.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 """Create a beam filament from a NURBS curve represented with splinepy."""
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.conf import mpy as _mpy
 from meshpy.mesh_creation_functions.beam_curve import (
@@ -62,8 +62,8 @@ def get_nurbs_curve_function_and_jacobian_for_integration(curve, tol=None):
         tol = _mpy.eps_pos
 
     knot_vector = curve.knot_vectors[0]
-    curve_start = np.min(knot_vector)
-    curve_end = np.max(knot_vector)
+    curve_start = _np.min(knot_vector)
+    curve_end = _np.max(knot_vector)
 
     def eval_r(t):
         """Evaluate the position along the curve."""
@@ -79,10 +79,10 @@ def get_nurbs_curve_function_and_jacobian_for_integration(curve, tol=None):
 
         if curve_start <= t <= curve_end:
             return eval_r(t)
-        elif t < curve_start and np.abs(t - curve_start) < tol:
+        elif t < curve_start and _np.abs(t - curve_start) < tol:
             diff = t - curve_start
             return eval_r(curve_start) + diff * eval_rp(curve_start)
-        elif t > curve_end and np.abs(t - curve_end) < tol:
+        elif t > curve_end and _np.abs(t - curve_end) < tol:
             diff = t - curve_end
             return eval_r(curve_end) + diff * eval_rp(curve_end)
         raise ValueError(

--- a/src/meshpy/mesh_creation_functions/beam_stent.py
+++ b/src/meshpy/mesh_creation_functions/beam_stent.py
@@ -23,14 +23,17 @@
 
 import numpy as np
 
-from meshpy.core.geometry_set import GeometryName, GeometrySet
-from meshpy.core.mesh import Mesh
-from meshpy.core.rotation import Rotation
+from meshpy.core.geometry_set import GeometryName as _GeometryName
+from meshpy.core.geometry_set import GeometrySet as _GeometrySet
+from meshpy.core.mesh import Mesh as _Mesh
+from meshpy.core.rotation import Rotation as _Rotation
 from meshpy.mesh_creation_functions.beam_basic_geometry import (
-    create_beam_mesh_arc_segment_via_rotation,
-    create_beam_mesh_line,
+    create_beam_mesh_arc_segment_via_rotation as _create_beam_mesh_arc_segment_via_rotation,
 )
-from meshpy.utils.nodes import get_min_max_nodes
+from meshpy.mesh_creation_functions.beam_basic_geometry import (
+    create_beam_mesh_line as _create_beam_mesh_line,
+)
+from meshpy.utils.nodes import get_min_max_nodes as _get_min_max_nodes
 
 
 def create_stent_cell(
@@ -80,17 +83,17 @@ def create_stent_cell(
         A mesh with this structure
     """
 
-    mesh = Mesh()
+    mesh = _Mesh()
 
     def add_line(pointa, pointb, n_el_line):
         """Shortcut to add line."""
-        return create_beam_mesh_line(
+        return _create_beam_mesh_line(
             mesh, beam_object, material, pointa, pointb, n_el=n_el_line
         )
 
     def add_segment(center, axis_rotation, radius, angle, n_el_segment):
         """Shortcut to add arc segment."""
-        return create_beam_mesh_arc_segment_via_rotation(
+        return _create_beam_mesh_arc_segment_via_rotation(
             mesh,
             beam_object,
             material,
@@ -115,12 +118,12 @@ def create_stent_cell(
         )
         S1_angle = np.pi / 2 + np.arcsin((d - radius) / radius)
         S1_center1 = CM + MO + neck_point
-        S1_axis_rotation1 = Rotation([0, 0, 1], 2 * np.pi - S1_angle - alpha)
+        S1_axis_rotation1 = _Rotation([0, 0, 1], 2 * np.pi - S1_angle - alpha)
         add_segment(S1_center1, S1_axis_rotation1, radius, S1_angle, n_el)
         add_line([-bottom_width, 0, 0], mesh.nodes[-1].coordinates, 2 * n_el)
 
         S1_center2 = 2 * neck_point - S1_center1
-        S1_axis_rotation2 = Rotation([0, 0, 1], np.pi - alpha - S1_angle)
+        S1_axis_rotation2 = _Rotation([0, 0, 1], np.pi - alpha - S1_angle)
 
         add_segment(S1_center2, S1_axis_rotation2, radius, S1_angle, n_el)
         add_line(
@@ -132,7 +135,7 @@ def create_stent_cell(
             alpha / 2
         )
         S3_center = [-width, height * 0.5, 0] + S3_radius * np.array([0, 1, 0])
-        S3_axis_rotation = Rotation()
+        S3_axis_rotation = _Rotation()
         S3_angle = np.pi - alpha
         add_segment(S3_center, S3_axis_rotation, S3_radius, S3_angle, n_el)
         add_line(mesh.nodes[-1].coordinates, [-bottom_width, height, 0], 2 * n_el)
@@ -141,7 +144,7 @@ def create_stent_cell(
         S2_radius = (height * 0.5 / np.tan(alpha) + top_width) * np.tan(alpha * 0.5)
         S2_center = [0, height * 0.5, 0] - S2_radius * np.array([0, 1, 0])
         S2_angle = np.pi - alpha
-        S2_axis_rotation = Rotation([0, 0, 1], np.pi)
+        S2_axis_rotation = _Rotation([0, 0, 1], np.pi)
         add_segment(S2_center, S2_axis_rotation, S2_radius, S2_angle, 2 * n_el)
         add_line(mesh.nodes[-1].coordinates, [-top_width, 0, 0], 2 * n_el)
 
@@ -177,7 +180,7 @@ def create_stent_column(
         A mesh with this structure.
     """
 
-    mesh_column = Mesh()
+    mesh_column = _Mesh()
     for i in range(n_height):
         S1 = True
         S2 = True
@@ -242,7 +245,7 @@ def create_beam_mesh_stent_flat(
         A mesh with this structure
     """
 
-    mesh_flat = Mesh()
+    mesh_flat = _Mesh()
     width = width_flat / n_column / 2
     height = height_flat / n_height
     column_mesh = create_stent_column(
@@ -255,7 +258,7 @@ def create_beam_mesh_stent_flat(
 
     for i in range(n_column // 2):
         for j in range(n_height - 1):
-            create_beam_mesh_line(
+            _create_beam_mesh_line(
                 mesh_flat,
                 beam_object,
                 material,
@@ -263,7 +266,7 @@ def create_beam_mesh_stent_flat(
                 [4 * i * width, (j + 1) * height, 0],
                 n_el=2 * n_el,
             )
-        create_beam_mesh_line(
+        _create_beam_mesh_line(
             mesh_flat,
             beam_object,
             material,
@@ -331,8 +334,8 @@ def create_beam_mesh_stent(
     mesh_stent = create_beam_mesh_stent_flat(
         beam_object, material, width_flat, height_flat, n_height, n_column, **kwargs
     )
-    mesh_stent.rotate(Rotation([1, 0, 0], np.pi / 2))
-    mesh_stent.rotate(Rotation([0, 0, 1], np.pi / 2))
+    mesh_stent.rotate(_Rotation([1, 0, 0], np.pi / 2))
+    mesh_stent.rotate(_Rotation([0, 0, 1], np.pi / 2))
     mesh_stent.translate([diameter / 2, 0, 0])
     mesh_stent.wrap_around_cylinder()
 
@@ -343,13 +346,13 @@ def create_beam_mesh_stent(
     mesh_stent.couple_nodes(nodes=stent_nodes)
 
     # Get min and max nodes of the honeycomb.
-    min_max_nodes = get_min_max_nodes(stent_nodes)
+    min_max_nodes = _get_min_max_nodes(stent_nodes)
 
     # Return the geometry set.
-    return_set = GeometryName()
+    return_set = _GeometryName()
     return_set["top"] = min_max_nodes["z_max"]
     return_set["bottom"] = min_max_nodes["z_min"]
-    return_set["all"] = GeometrySet(mesh_stent.elements)
+    return_set["all"] = _GeometrySet(mesh_stent.elements)
 
     mesh.add_mesh(mesh_stent)
 

--- a/src/meshpy/mesh_creation_functions/beam_stent.py
+++ b/src/meshpy/mesh_creation_functions/beam_stent.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 """This file has functions to create a stent according to Auricchio 2012."""
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.geometry_set import GeometryName as _GeometryName
 from meshpy.core.geometry_set import GeometrySet as _GeometrySet
@@ -44,7 +44,7 @@ def create_stent_cell(
     fac_bottom=0.6,
     fac_neck=0.55,
     fac_radius=0.36,
-    alpha=0.46 * np.pi,
+    alpha=0.46 * _np.pi,
     S1=True,
     S2=True,
     S3=True,
@@ -110,20 +110,20 @@ def create_stent_cell(
     radius = width * fac_radius
 
     if S1:
-        neck_point = np.array([-neck_width, height * 0.5, 0])
-        d = (height * 0.5 / np.tan(alpha) + bottom_width - neck_width) / np.sin(alpha)
-        CM = np.array([-np.sin(alpha), -np.cos(alpha), 0]) * (d - radius)
-        MO = np.array([np.cos(alpha), -np.sin(alpha), 0]) * np.sqrt(
+        neck_point = _np.array([-neck_width, height * 0.5, 0])
+        d = (height * 0.5 / _np.tan(alpha) + bottom_width - neck_width) / _np.sin(alpha)
+        CM = _np.array([-_np.sin(alpha), -_np.cos(alpha), 0]) * (d - radius)
+        MO = _np.array([_np.cos(alpha), -_np.sin(alpha), 0]) * _np.sqrt(
             radius**2 - (d - radius) ** 2
         )
-        S1_angle = np.pi / 2 + np.arcsin((d - radius) / radius)
+        S1_angle = _np.pi / 2 + _np.arcsin((d - radius) / radius)
         S1_center1 = CM + MO + neck_point
-        S1_axis_rotation1 = _Rotation([0, 0, 1], 2 * np.pi - S1_angle - alpha)
+        S1_axis_rotation1 = _Rotation([0, 0, 1], 2 * _np.pi - S1_angle - alpha)
         add_segment(S1_center1, S1_axis_rotation1, radius, S1_angle, n_el)
         add_line([-bottom_width, 0, 0], mesh.nodes[-1].coordinates, 2 * n_el)
 
         S1_center2 = 2 * neck_point - S1_center1
-        S1_axis_rotation2 = _Rotation([0, 0, 1], np.pi - alpha - S1_angle)
+        S1_axis_rotation2 = _Rotation([0, 0, 1], _np.pi - alpha - S1_angle)
 
         add_segment(S1_center2, S1_axis_rotation2, radius, S1_angle, n_el)
         add_line(
@@ -131,20 +131,20 @@ def create_stent_cell(
         )
 
     if S3:
-        S3_radius = (width - bottom_width + height * 0.5 / np.tan(alpha)) * np.tan(
+        S3_radius = (width - bottom_width + height * 0.5 / _np.tan(alpha)) * _np.tan(
             alpha / 2
         )
-        S3_center = [-width, height * 0.5, 0] + S3_radius * np.array([0, 1, 0])
+        S3_center = [-width, height * 0.5, 0] + S3_radius * _np.array([0, 1, 0])
         S3_axis_rotation = _Rotation()
-        S3_angle = np.pi - alpha
+        S3_angle = _np.pi - alpha
         add_segment(S3_center, S3_axis_rotation, S3_radius, S3_angle, n_el)
         add_line(mesh.nodes[-1].coordinates, [-bottom_width, height, 0], 2 * n_el)
 
     if S2:
-        S2_radius = (height * 0.5 / np.tan(alpha) + top_width) * np.tan(alpha * 0.5)
-        S2_center = [0, height * 0.5, 0] - S2_radius * np.array([0, 1, 0])
-        S2_angle = np.pi - alpha
-        S2_axis_rotation = _Rotation([0, 0, 1], np.pi)
+        S2_radius = (height * 0.5 / _np.tan(alpha) + top_width) * _np.tan(alpha * 0.5)
+        S2_center = [0, height * 0.5, 0] - S2_radius * _np.array([0, 1, 0])
+        S2_angle = _np.pi - alpha
+        S2_axis_rotation = _Rotation([0, 0, 1], _np.pi)
         add_segment(S2_center, S2_axis_rotation, S2_radius, S2_angle, 2 * n_el)
         add_line(mesh.nodes[-1].coordinates, [-top_width, 0, 0], 2 * n_el)
 
@@ -327,15 +327,15 @@ def create_beam_mesh_stent(
 
     # Set the Parameter for other functions
     height_flat = length
-    width_flat = np.pi * diameter
+    width_flat = _np.pi * diameter
     n_height = n_axis
     n_column = n_circumference
 
     mesh_stent = create_beam_mesh_stent_flat(
         beam_object, material, width_flat, height_flat, n_height, n_column, **kwargs
     )
-    mesh_stent.rotate(_Rotation([1, 0, 0], np.pi / 2))
-    mesh_stent.rotate(_Rotation([0, 0, 1], np.pi / 2))
+    mesh_stent.rotate(_Rotation([1, 0, 0], _np.pi / 2))
+    mesh_stent.rotate(_Rotation([0, 0, 1], _np.pi / 2))
     mesh_stent.translate([diameter / 2, 0, 0])
     mesh_stent.wrap_around_cylinder()
 

--- a/src/meshpy/mesh_creation_functions/beam_wire.py
+++ b/src/meshpy/mesh_creation_functions/beam_wire.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 """Create a steel wire."""
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.geometry_set import GeometryName as _GeometryName
 from meshpy.core.geometry_set import GeometrySet as _GeometrySet
@@ -89,10 +89,10 @@ def create_wire_fibers(
 
     # Create the filaments in the layers.
     for i_angle in range(6):
-        angle = i_angle * np.pi / 3.0
-        direction_radial = np.array([np.cos(angle), np.sin(angle)])
-        angle = i_angle * np.pi / 3.0 + 2.0 * np.pi / 3.0
-        direction_tangential = np.array([np.cos(angle), np.sin(angle)])
+        angle = i_angle * _np.pi / 3.0
+        direction_radial = _np.array([_np.cos(angle), _np.sin(angle)])
+        angle = i_angle * _np.pi / 3.0 + 2.0 * _np.pi / 3.0
+        direction_tangential = _np.array([_np.cos(angle), _np.sin(angle)])
         for i_layer in range(layers):
             for i_tangent in range(i_layer + 1):
                 pos = (

--- a/src/meshpy/mesh_creation_functions/beam_wire.py
+++ b/src/meshpy/mesh_creation_functions/beam_wire.py
@@ -23,9 +23,12 @@
 
 import numpy as np
 
-from meshpy.core.geometry_set import GeometryName, GeometrySet
-from meshpy.mesh_creation_functions.beam_basic_geometry import create_beam_mesh_line
-from meshpy.utils.nodes import check_node_by_coordinate
+from meshpy.core.geometry_set import GeometryName as _GeometryName
+from meshpy.core.geometry_set import GeometrySet as _GeometrySet
+from meshpy.mesh_creation_functions.beam_basic_geometry import (
+    create_beam_mesh_line as _create_beam_mesh_line,
+)
+from meshpy.utils.nodes import check_node_by_coordinate as _check_node_by_coordinate
 
 
 def create_wire_fibers(
@@ -72,7 +75,7 @@ def create_wire_fibers(
     def create_line(pos_yz):
         """Create a line starting at the yz-plane with the 2D coordinates
         pos_yz."""
-        create_beam_mesh_line(
+        _create_beam_mesh_line(
             mesh,
             beam_object,
             material,
@@ -103,10 +106,10 @@ def create_wire_fibers(
                 create_line(pos)
 
     # Create the sets to return.
-    return_set = GeometryName()
-    start_nodes = mesh.get_nodes_by_function(check_node_by_coordinate, 0, 0.0)
-    end_nodes = mesh.get_nodes_by_function(check_node_by_coordinate, 0, length)
-    return_set["start"] = GeometrySet(start_nodes)
-    return_set["end"] = GeometrySet(end_nodes)
-    return_set["all"] = GeometrySet(mesh.elements)
+    return_set = _GeometryName()
+    start_nodes = mesh.get_nodes_by_function(_check_node_by_coordinate, 0, 0.0)
+    end_nodes = mesh.get_nodes_by_function(_check_node_by_coordinate, 0, length)
+    return_set["start"] = _GeometrySet(start_nodes)
+    return_set["end"] = _GeometrySet(end_nodes)
+    return_set["all"] = _GeometrySet(mesh.elements)
     return return_set

--- a/src/meshpy/mesh_creation_functions/nurbs_generic.py
+++ b/src/meshpy/mesh_creation_functions/nurbs_generic.py
@@ -23,10 +23,12 @@
 
 import numpy as np
 
-from meshpy.core.conf import mpy
-from meshpy.core.geometry_set import GeometryName, GeometrySetNodes
-from meshpy.core.node import ControlPoint
-from meshpy.core.nurbs_patch import NURBSSurface, NURBSVolume
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.geometry_set import GeometryName as _GeometryName
+from meshpy.core.geometry_set import GeometrySetNodes as _GeometrySetNodes
+from meshpy.core.node import ControlPoint as _ControlPoint
+from meshpy.core.nurbs_patch import NURBSSurface as _NURBSSurface
+from meshpy.core.nurbs_patch import NURBSVolume as _NURBSVolume
 
 
 def add_geomdl_nurbs_to_mesh(
@@ -92,9 +94,9 @@ def add_geomdl_nurbs_to_mesh(
     manifold_dim = len(geomdl_obj.knotvector)
 
     if manifold_dim == 2:
-        nurbs_object = NURBSSurface
+        nurbs_object = _NURBSSurface
     elif manifold_dim == 3:
-        nurbs_object = NURBSVolume
+        nurbs_object = _NURBSVolume
     else:
         raise NotImplementedError(
             "Error, not implemented for a NURBS {}!".format(type(geomdl_obj))
@@ -135,7 +137,7 @@ def create_control_points_surface(geomdl_obj):
                 geomdl_obj.ctrlpts2d[dir_u][dir_v][2] / weight,
             ]
 
-            control_points.append(ControlPoint(coord, weight))
+            control_points.append(_ControlPoint(coord, weight))
 
     return control_points
 
@@ -164,7 +166,7 @@ def create_control_points_volume(geomdl_obj):
                     geomdl_obj.ctrlptsw[cp_id][2] / weight,
                 ]
 
-                control_points.append(ControlPoint(coord, weight))
+                control_points.append(_ControlPoint(coord, weight))
 
     return control_points
 
@@ -195,59 +197,59 @@ def create_geometry_sets(element):
 
         if nurbs_dimension == 2:
             # Vertex 1 is positioned on u = 0, v = 0
-            return_set["vertex_u_min_v_min"] = GeometrySetNodes(
-                mpy.geo.point, nodes=element.nodes[0]
+            return_set["vertex_u_min_v_min"] = _GeometrySetNodes(
+                _mpy.geo.point, nodes=element.nodes[0]
             )
 
             # Vertex 2 is positioned on u = 1, v = 0
-            return_set["vertex_u_max_v_min"] = GeometrySetNodes(
-                mpy.geo.point, nodes=element.nodes[num_cps_uvw[0] - 1]
+            return_set["vertex_u_max_v_min"] = _GeometrySetNodes(
+                _mpy.geo.point, nodes=element.nodes[num_cps_uvw[0] - 1]
             )
 
             # Vertex 3 is positioned on u = 0, v = 1
-            return_set["vertex_u_min_v_max"] = GeometrySetNodes(
-                mpy.geo.point,
+            return_set["vertex_u_min_v_max"] = _GeometrySetNodes(
+                _mpy.geo.point,
                 nodes=element.nodes[num_cps_uvw[0] * (num_cps_uvw[1] - 1)],
             )
 
             # Vertex 4 is positioned on u = 1, v = 1
-            return_set["vertex_u_max_v_max"] = GeometrySetNodes(
-                mpy.geo.point, nodes=element.nodes[num_cps_uvw[0] * num_cps_uvw[1] - 1]
+            return_set["vertex_u_max_v_max"] = _GeometrySetNodes(
+                _mpy.geo.point, nodes=element.nodes[num_cps_uvw[0] * num_cps_uvw[1] - 1]
             )
 
         elif nurbs_dimension == 3:
             # Vertex 1 is positioned on u = 0, v = 0, w =
-            return_set["vertex_u_min_v_min_w_min"] = GeometrySetNodes(
-                mpy.geo.point, nodes=element.nodes[0]
+            return_set["vertex_u_min_v_min_w_min"] = _GeometrySetNodes(
+                _mpy.geo.point, nodes=element.nodes[0]
             )
 
             # Vertex 2 is positioned on u = 1, v = 0, w = 0
-            return_set["vertex_u_max_v_min_w_min"] = GeometrySetNodes(
-                mpy.geo.point, nodes=element.nodes[num_cps_uvw[0] - 1]
+            return_set["vertex_u_max_v_min_w_min"] = _GeometrySetNodes(
+                _mpy.geo.point, nodes=element.nodes[num_cps_uvw[0] - 1]
             )
 
             # Vertex 3 is positioned on u = 0, v = 1, w = 0
-            return_set["vertex_u_min_v_max_w_min"] = GeometrySetNodes(
-                mpy.geo.point,
+            return_set["vertex_u_min_v_max_w_min"] = _GeometrySetNodes(
+                _mpy.geo.point,
                 nodes=element.nodes[num_cps_uvw[0] * (num_cps_uvw[1] - 1)],
             )
 
             # Vertex 4 is positioned on u = 1, v = 1, w = 0
-            return_set["vertex_u_max_v_max_w_min"] = GeometrySetNodes(
-                mpy.geo.point, nodes=element.nodes[num_cps_uvw[0] * num_cps_uvw[1] - 1]
+            return_set["vertex_u_max_v_max_w_min"] = _GeometrySetNodes(
+                _mpy.geo.point, nodes=element.nodes[num_cps_uvw[0] * num_cps_uvw[1] - 1]
             )
 
             # Vertex 5 is positioned on u = 0, v = 0, w = 1
-            return_set["vertex_u_min_v_min_w_max"] = GeometrySetNodes(
-                mpy.geo.point,
+            return_set["vertex_u_min_v_min_w_max"] = _GeometrySetNodes(
+                _mpy.geo.point,
                 nodes=element.nodes[
                     num_cps_uvw[0] * num_cps_uvw[1] * (num_cps_uvw[2] - 1)
                 ],
             )
 
             # Vertex 6 is positioned on u = 1, v = 0, w = 1
-            return_set["vertex_u_max_v_min_w_max"] = GeometrySetNodes(
-                mpy.geo.point,
+            return_set["vertex_u_max_v_min_w_max"] = _GeometrySetNodes(
+                _mpy.geo.point,
                 nodes=element.nodes[
                     num_cps_uvw[0] * num_cps_uvw[1] * (num_cps_uvw[2] - 1)
                     + (num_cps_uvw[0] - 1)
@@ -255,8 +257,8 @@ def create_geometry_sets(element):
             )
 
             # Vertex 7 is positioned on u = 0, v = 1, w = 1
-            return_set["vertex_u_min_v_max_w_max"] = GeometrySetNodes(
-                mpy.geo.point,
+            return_set["vertex_u_min_v_max_w_max"] = _GeometrySetNodes(
+                _mpy.geo.point,
                 nodes=element.nodes[
                     num_cps_uvw[0] * num_cps_uvw[1] * (num_cps_uvw[2] - 1)
                     + num_cps_uvw[0] * (num_cps_uvw[1] - 1)
@@ -264,8 +266,8 @@ def create_geometry_sets(element):
             )
 
             # Vertex 8 is positioned on u = 1, v = 1, w = 1
-            return_set["vertex_u_max_v_max_w_max"] = GeometrySetNodes(
-                mpy.geo.point,
+            return_set["vertex_u_max_v_max_w_max"] = _GeometrySetNodes(
+                _mpy.geo.point,
                 nodes=element.nodes[
                     num_cps_uvw[0] * num_cps_uvw[1] * num_cps_uvw[2] - 1
                 ],
@@ -306,8 +308,8 @@ def create_geometry_sets(element):
                             + i_along_dir * factor_dir
                         )
                     set_name = f"line_{name_dir[i_dir]}_{name_other_dir[index]}"
-                    return_set[set_name] = GeometrySetNodes(
-                        mpy.geo.line,
+                    return_set[set_name] = _GeometrySetNodes(
+                        _mpy.geo.line,
                         nodes=[element.nodes[i_node] for i_node in cp_indices],
                     )
 
@@ -398,41 +400,41 @@ def create_geometry_sets(element):
                 control_points_line_8.append(element.nodes[cpgid_l8])
 
             # Create geometric sets for lines
-            return_set["line_v_min_w_min"] = GeometrySetNodes(
-                mpy.geo.line, nodes=control_points_line_1
+            return_set["line_v_min_w_min"] = _GeometrySetNodes(
+                _mpy.geo.line, nodes=control_points_line_1
             )
-            return_set["line_u_max_w_min"] = GeometrySetNodes(
-                mpy.geo.line, nodes=control_points_line_2
+            return_set["line_u_max_w_min"] = _GeometrySetNodes(
+                _mpy.geo.line, nodes=control_points_line_2
             )
-            return_set["line_v_max_w_min"] = GeometrySetNodes(
-                mpy.geo.line, nodes=control_points_line_3
+            return_set["line_v_max_w_min"] = _GeometrySetNodes(
+                _mpy.geo.line, nodes=control_points_line_3
             )
-            return_set["line_u_min_w_min"] = GeometrySetNodes(
-                mpy.geo.line, nodes=control_points_line_4
+            return_set["line_u_min_w_min"] = _GeometrySetNodes(
+                _mpy.geo.line, nodes=control_points_line_4
             )
-            return_set["line_u_min_v_min"] = GeometrySetNodes(
-                mpy.geo.line, nodes=control_points_line_5
+            return_set["line_u_min_v_min"] = _GeometrySetNodes(
+                _mpy.geo.line, nodes=control_points_line_5
             )
-            return_set["line_u_max_v_min"] = GeometrySetNodes(
-                mpy.geo.line, nodes=control_points_line_6
+            return_set["line_u_max_v_min"] = _GeometrySetNodes(
+                _mpy.geo.line, nodes=control_points_line_6
             )
-            return_set["line_u_min_v_max"] = GeometrySetNodes(
-                mpy.geo.line, nodes=control_points_line_7
+            return_set["line_u_min_v_max"] = _GeometrySetNodes(
+                _mpy.geo.line, nodes=control_points_line_7
             )
-            return_set["line_u_max_v_max"] = GeometrySetNodes(
-                mpy.geo.line, nodes=control_points_line_8
+            return_set["line_u_max_v_max"] = _GeometrySetNodes(
+                _mpy.geo.line, nodes=control_points_line_8
             )
-            return_set["line_v_min_w_max"] = GeometrySetNodes(
-                mpy.geo.line, nodes=control_points_line_9
+            return_set["line_v_min_w_max"] = _GeometrySetNodes(
+                _mpy.geo.line, nodes=control_points_line_9
             )
-            return_set["line_u_max_w_max"] = GeometrySetNodes(
-                mpy.geo.line, nodes=control_points_line_10
+            return_set["line_u_max_w_max"] = _GeometrySetNodes(
+                _mpy.geo.line, nodes=control_points_line_10
             )
-            return_set["line_v_max_w_max"] = GeometrySetNodes(
-                mpy.geo.line, nodes=control_points_line_11
+            return_set["line_v_max_w_max"] = _GeometrySetNodes(
+                _mpy.geo.line, nodes=control_points_line_11
             )
-            return_set["line_u_min_w_max"] = GeometrySetNodes(
-                mpy.geo.line, nodes=control_points_line_12
+            return_set["line_u_min_w_max"] = _GeometrySetNodes(
+                _mpy.geo.line, nodes=control_points_line_12
             )
 
         else:
@@ -454,8 +456,8 @@ def create_geometry_sets(element):
             )
 
             # Create geometric sets for surfaces
-            return_set["surf"] = GeometrySetNodes(
-                mpy.geo.surface, nodes=control_points_surface_1
+            return_set["surf"] = _GeometrySetNodes(
+                _mpy.geo.surface, nodes=control_points_surface_1
             )
 
         elif nurbs_dimension == 3:
@@ -510,23 +512,23 @@ def create_geometry_sets(element):
                     )
 
             # Create geometric sets for surfaces
-            return_set["surf_w_min"] = GeometrySetNodes(
-                mpy.geo.surface, nodes=control_points_surface_1
+            return_set["surf_w_min"] = _GeometrySetNodes(
+                _mpy.geo.surface, nodes=control_points_surface_1
             )
-            return_set["surf_w_max"] = GeometrySetNodes(
-                mpy.geo.surface, nodes=control_points_surface_2
+            return_set["surf_w_max"] = _GeometrySetNodes(
+                _mpy.geo.surface, nodes=control_points_surface_2
             )
-            return_set["surf_v_min"] = GeometrySetNodes(
-                mpy.geo.surface, nodes=control_points_surface_3
+            return_set["surf_v_min"] = _GeometrySetNodes(
+                _mpy.geo.surface, nodes=control_points_surface_3
             )
-            return_set["surf_u_max"] = GeometrySetNodes(
-                mpy.geo.surface, nodes=control_points_surface_4
+            return_set["surf_u_max"] = _GeometrySetNodes(
+                _mpy.geo.surface, nodes=control_points_surface_4
             )
-            return_set["surf_v_max"] = GeometrySetNodes(
-                mpy.geo.surface, nodes=control_points_surface_5
+            return_set["surf_v_max"] = _GeometrySetNodes(
+                _mpy.geo.surface, nodes=control_points_surface_5
             )
-            return_set["surf_u_min"] = GeometrySetNodes(
-                mpy.geo.surface, nodes=control_points_surface_6
+            return_set["surf_u_min"] = _GeometrySetNodes(
+                _mpy.geo.surface, nodes=control_points_surface_6
             )
 
         else:
@@ -552,8 +554,8 @@ def create_geometry_sets(element):
             )
 
             # Create geometric sets for surfaces
-            return_set["vol"] = GeometrySetNodes(
-                mpy.geo.volume, nodes=control_points_volume_1
+            return_set["vol"] = _GeometrySetNodes(
+                _mpy.geo.volume, nodes=control_points_volume_1
             )
 
         else:
@@ -564,7 +566,7 @@ def create_geometry_sets(element):
             )
 
     # Create return set
-    return_set = GeometryName()
+    return_set = _GeometryName()
 
     # Get the number of control points on each parametric direction that define the patch
     num_cps_uvw = get_num_cps_uvw(element.knot_vectors)

--- a/src/meshpy/mesh_creation_functions/nurbs_generic.py
+++ b/src/meshpy/mesh_creation_functions/nurbs_generic.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 """Generic function used to create NURBS meshes within meshpy."""
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.geometry_set import GeometryName as _GeometryName
@@ -181,7 +181,7 @@ def create_geometry_sets(element):
     def get_num_cps_uvw(knot_vectors):
         """Obtain the number of control points on each parametric direction of
         a patch."""
-        num_cps_uvw = np.zeros(len(knot_vectors), dtype=int)
+        num_cps_uvw = _np.zeros(len(knot_vectors), dtype=int)
 
         for direction in range(len(knot_vectors)):
             knotvector_size_dir = len(element.knot_vectors[direction])

--- a/src/meshpy/mesh_creation_functions/nurbs_geometries.py
+++ b/src/meshpy/mesh_creation_functions/nurbs_geometries.py
@@ -21,9 +21,10 @@
 # THE SOFTWARE.
 """This file has functions to create NURBS geometries using Geomdl."""
 
-import numpy as np
-from geomdl import NURBS, operations
-from geomdl import compatibility as compat
+import numpy as _np
+from geomdl import NURBS as _NURBS
+from geomdl import compatibility as _compat
+from geomdl import operations as _operations
 
 
 def create_nurbs_hollow_cylinder_segment_2d(
@@ -56,13 +57,13 @@ def create_nurbs_hollow_cylinder_segment_2d(
         raise ValueError(
             "The external radius should be larger than the internal radius of a hollow cylinder."
         )
-    if (angle > np.pi) or (angle < 0):
+    if (angle > _np.pi) or (angle < 0):
         raise ValueError(
             "The following algorithm for creating a hollow cylinder section is only valid for 0 < angle <= pi."
         )
 
     # Create a NURBS surface instance
-    surf = NURBS.Surface()
+    surf = _NURBS.Surface()
 
     # Set degrees
     surf.degree_u = 2
@@ -80,7 +81,7 @@ def create_nurbs_hollow_cylinder_segment_2d(
 
     # Obtaining the control points that define the external arc of the hollow cylinder
     cp_ext1 = [radius_out, 0.0, 0.0]
-    cp_ext3 = [radius_out * np.cos(angle), radius_out * np.sin(angle), 0.0]
+    cp_ext3 = [radius_out * _np.cos(angle), radius_out * _np.sin(angle), 0.0]
     cp_ext2 = [
         radius_out,
         -(cp_ext3[0] / cp_ext3[1]) * (radius_out - cp_ext3[0]) + cp_ext3[1],
@@ -89,7 +90,7 @@ def create_nurbs_hollow_cylinder_segment_2d(
 
     # Obtaining the control points that define the internal arc of the hollow cylinder
     cp_int1 = [radius_in, 0.0, 0.0]
-    cp_int3 = [radius_in * np.cos(angle), radius_in * np.sin(angle), 0.0]
+    cp_int3 = [radius_in * _np.cos(angle), radius_in * _np.sin(angle), 0.0]
     cp_int2 = [
         radius_in,
         -(cp_int3[0] / cp_int3[1]) * (radius_in - cp_int3[0]) + cp_int3[1],
@@ -115,18 +116,18 @@ def create_nurbs_hollow_cylinder_segment_2d(
 
     weights = [
         1.0,
-        np.cos(angle / 2),
+        _np.cos(angle / 2),
         1.0,
         1.0,
-        np.cos(angle / 2),
+        _np.cos(angle / 2),
         1.0,
         1.0,
-        np.cos(angle / 2),
+        _np.cos(angle / 2),
         1.0,
     ]
 
-    t_ctrlptsw = compat.combine_ctrlpts_weights(ctrlpts, weights)
-    n_ctrlptsw = compat.flip_ctrlpts_u(t_ctrlptsw, p_size_u, p_size_v)
+    t_ctrlptsw = _compat.combine_ctrlpts_weights(ctrlpts, weights)
+    n_ctrlptsw = _compat.flip_ctrlpts_u(t_ctrlptsw, p_size_u, p_size_v)
 
     surf.ctrlpts_size_u = p_size_u
     surf.ctrlpts_size_v = p_size_v
@@ -162,7 +163,7 @@ def create_nurbs_flat_plate_2d(width, length, *, n_ele_u=1, n_ele_v=1):
     """
 
     # Create a NURBS surface instance
-    surf = NURBS.Surface()
+    surf = _NURBS.Surface()
 
     # Set degrees
     surf.degree_u = 2
@@ -186,8 +187,8 @@ def create_nurbs_flat_plate_2d(width, length, *, n_ele_u=1, n_ele_v=1):
 
     weights = [1.0] * 9
 
-    t_ctrlptsw = compat.combine_ctrlpts_weights(ctrlpts, weights)
-    n_ctrlptsw = compat.flip_ctrlpts_u(t_ctrlptsw, p_size_u, p_size_v)
+    t_ctrlptsw = _compat.combine_ctrlpts_weights(ctrlpts, weights)
+    n_ctrlptsw = _compat.flip_ctrlpts_u(t_ctrlptsw, p_size_u, p_size_v)
 
     surf.ctrlpts_size_u = p_size_u
     surf.ctrlpts_size_v = p_size_v
@@ -223,7 +224,7 @@ def create_nurbs_sphere_surface(radius, n_ele_u=1, n_ele_v=1):
     """
 
     # Create a NURBS surface instance
-    surf = NURBS.Surface()
+    surf = _NURBS.Surface()
 
     # Set degrees
     surf.degree_u = 2
@@ -235,79 +236,91 @@ def create_nurbs_sphere_surface(radius, n_ele_u=1, n_ele_v=1):
 
     dummy = 6.0 * (
         5.0 / 12.0
-        + 0.5 * np.sqrt(2.0 / 3.0)
-        - 0.25 / np.sqrt(3.0)
-        - 0.5 * np.sqrt(2.0 / 3.0) * np.sqrt(3.0) / 2.0
+        + 0.5 * _np.sqrt(2.0 / 3.0)
+        - 0.25 / _np.sqrt(3.0)
+        - 0.5 * _np.sqrt(2.0 / 3.0) * _np.sqrt(3.0) / 2.0
     )
 
     ctrlpts = [
         [
-            2.0 * radius / np.sqrt(6.0) * -np.sin(1.0 / 4.0 * np.pi),
-            -radius / np.sqrt(3.0),
-            2.0 * radius / np.sqrt(6.0) * np.cos(1.0 / 4.0 * np.pi),
+            2.0 * radius / _np.sqrt(6.0) * -_np.sin(1.0 / 4.0 * _np.pi),
+            -radius / _np.sqrt(3.0),
+            2.0 * radius / _np.sqrt(6.0) * _np.cos(1.0 / 4.0 * _np.pi),
         ],
         [
-            radius * np.sqrt(3.0) / (np.sqrt(2.0) * 2.0) * np.cos(1.0 / 4.0 * np.pi)
-            + radius * np.sqrt(3.0) / (np.sqrt(2.0) * 2.0) * -np.sin(1.0 / 4.0 * np.pi),
-            -np.sqrt(3.0) / 2 * radius,
-            radius * np.sqrt(3.0) / (np.sqrt(2.0) * 2.0) * np.cos(1.0 / 4.0 * np.pi)
-            + radius * np.sqrt(3.0) / (np.sqrt(2.0) * 2.0) * np.sin(1.0 / 4.0 * np.pi),
+            radius * _np.sqrt(3.0) / (_np.sqrt(2.0) * 2.0) * _np.cos(1.0 / 4.0 * _np.pi)
+            + radius
+            * _np.sqrt(3.0)
+            / (_np.sqrt(2.0) * 2.0)
+            * -_np.sin(1.0 / 4.0 * _np.pi),
+            -_np.sqrt(3.0) / 2 * radius,
+            radius * _np.sqrt(3.0) / (_np.sqrt(2.0) * 2.0) * _np.cos(1.0 / 4.0 * _np.pi)
+            + radius
+            * _np.sqrt(3.0)
+            / (_np.sqrt(2.0) * 2.0)
+            * _np.sin(1.0 / 4.0 * _np.pi),
         ],
         [
-            2.0 * radius / np.sqrt(6.0) * np.cos(1.0 / 4.0 * np.pi),
-            -radius / np.sqrt(3.0),
-            2.0 * radius / np.sqrt(6.0) * np.sin(1.0 / 4.0 * np.pi),
+            2.0 * radius / _np.sqrt(6.0) * _np.cos(1.0 / 4.0 * _np.pi),
+            -radius / _np.sqrt(3.0),
+            2.0 * radius / _np.sqrt(6.0) * _np.sin(1.0 / 4.0 * _np.pi),
         ],
         [
-            radius * np.sqrt(6.0) / 2.0 * -np.sin(1.0 / 4.0 * np.pi),
+            radius * _np.sqrt(6.0) / 2.0 * -_np.sin(1.0 / 4.0 * _np.pi),
             0.0,
-            radius * np.sqrt(6.0) / 2.0 * np.cos(1.0 / 4.0 * np.pi),
+            radius * _np.sqrt(6.0) / 2.0 * _np.cos(1.0 / 4.0 * _np.pi),
         ],
         [
-            radius * dummy * np.sqrt(2.0) / 2.0 * np.cos(1.0 / 4.0 * np.pi)
-            + radius * dummy * np.sqrt(2.0) / 2.0 * -np.sin(1.0 / 4.0 * np.pi),
+            radius * dummy * _np.sqrt(2.0) / 2.0 * _np.cos(1.0 / 4.0 * _np.pi)
+            + radius * dummy * _np.sqrt(2.0) / 2.0 * -_np.sin(1.0 / 4.0 * _np.pi),
             0.0,
-            radius * dummy * np.sqrt(2.0) / 2.0 * np.cos(1.0 / 4.0 * np.pi)
-            + radius * dummy * np.sqrt(2.0) / 2.0 * np.sin(1.0 / 4.0 * np.pi),
+            radius * dummy * _np.sqrt(2.0) / 2.0 * _np.cos(1.0 / 4.0 * _np.pi)
+            + radius * dummy * _np.sqrt(2.0) / 2.0 * _np.sin(1.0 / 4.0 * _np.pi),
         ],
         [
-            radius * np.sqrt(6.0) / 2.0 * np.cos(1.0 / 4.0 * np.pi),
+            radius * _np.sqrt(6.0) / 2.0 * _np.cos(1.0 / 4.0 * _np.pi),
             0.0,
-            radius * np.sqrt(6.0) / 2.0 * np.sin(1.0 / 4.0 * np.pi),
+            radius * _np.sqrt(6.0) / 2.0 * _np.sin(1.0 / 4.0 * _np.pi),
         ],
         [
-            2.0 * radius / np.sqrt(6.0) * -np.sin(1.0 / 4.0 * np.pi),
-            2.0 * radius / np.sqrt(6.0) * np.cos(1.0 / 4.0 * np.pi),
-            radius / np.sqrt(3.0),
+            2.0 * radius / _np.sqrt(6.0) * -_np.sin(1.0 / 4.0 * _np.pi),
+            2.0 * radius / _np.sqrt(6.0) * _np.cos(1.0 / 4.0 * _np.pi),
+            radius / _np.sqrt(3.0),
         ],
         [
-            radius * np.sqrt(3.0) / (np.sqrt(2.0) * 2.0) * np.cos(1.0 / 4.0 * np.pi)
-            + radius * np.sqrt(3.0) / (np.sqrt(2.0) * 2.0) * -np.sin(1.0 / 4.0 * np.pi),
-            np.sqrt(3.0) / 2 * radius,
-            radius * np.sqrt(3.0) / (np.sqrt(2.0) * 2.0) * np.cos(1.0 / 4.0 * np.pi)
-            + radius * np.sqrt(3.0) / (np.sqrt(2.0) * 2.0) * np.sin(1.0 / 4.0 * np.pi),
+            radius * _np.sqrt(3.0) / (_np.sqrt(2.0) * 2.0) * _np.cos(1.0 / 4.0 * _np.pi)
+            + radius
+            * _np.sqrt(3.0)
+            / (_np.sqrt(2.0) * 2.0)
+            * -_np.sin(1.0 / 4.0 * _np.pi),
+            _np.sqrt(3.0) / 2 * radius,
+            radius * _np.sqrt(3.0) / (_np.sqrt(2.0) * 2.0) * _np.cos(1.0 / 4.0 * _np.pi)
+            + radius
+            * _np.sqrt(3.0)
+            / (_np.sqrt(2.0) * 2.0)
+            * _np.sin(1.0 / 4.0 * _np.pi),
         ],
         [
-            2.0 * radius / np.sqrt(6.0) * np.cos(1.0 / 4.0 * np.pi),
-            radius / np.sqrt(3.0),
-            2.0 * radius / np.sqrt(6.0) * np.sin(1.0 / 4.0 * np.pi),
+            2.0 * radius / _np.sqrt(6.0) * _np.cos(1.0 / 4.0 * _np.pi),
+            radius / _np.sqrt(3.0),
+            2.0 * radius / _np.sqrt(6.0) * _np.sin(1.0 / 4.0 * _np.pi),
         ],
     ]
 
     weights = [
         1.0,
-        2.0 / np.sqrt(6.0),
+        2.0 / _np.sqrt(6.0),
         1.0,
-        2.0 / np.sqrt(6.0),
+        2.0 / _np.sqrt(6.0),
         2.0 / 3.0,
-        2.0 / np.sqrt(6.0),
+        2.0 / _np.sqrt(6.0),
         1.0,
-        2.0 / np.sqrt(6.0),
+        2.0 / _np.sqrt(6.0),
         1.0,
     ]
 
-    t_ctrlptsw = compat.combine_ctrlpts_weights(ctrlpts, weights)
-    n_ctrlptsw = compat.flip_ctrlpts_u(t_ctrlptsw, p_size_u, p_size_v)
+    t_ctrlptsw = _compat.combine_ctrlpts_weights(ctrlpts, weights)
+    n_ctrlptsw = _compat.flip_ctrlpts_u(t_ctrlptsw, p_size_u, p_size_v)
 
     surf.ctrlpts_size_u = p_size_u
     surf.ctrlpts_size_v = p_size_v
@@ -350,31 +363,31 @@ def create_nurbs_hemisphere_surface(radius, n_ele_uv=1):
 
     # Create a temporary section by rotating and translating the
     # first section of the hemisphere
-    temp_hemisphere = operations.rotate(hemisphere_1, 90, axis=1)
-    temp_hemisphere = operations.translate(
+    temp_hemisphere = _operations.rotate(hemisphere_1, 90, axis=1)
+    temp_hemisphere = _operations.translate(
         temp_hemisphere,
-        (0, 0, -2.0 * radius / np.sqrt(6.0) * np.sin(1.0 / 4.0 * np.pi) * 2),
+        (0, 0, -2.0 * radius / _np.sqrt(6.0) * _np.sin(1.0 / 4.0 * _np.pi) * 2),
     )
 
     # To create the hemisphere it is necessary to split the temporary
     # sphere section in two pieces. This split is done in u = 0.5. After
     # the split, the second surface is taken as it will be
     # adjacent to the first section of the sphere
-    cut_section_sphere = operations.split_surface_u(temp_hemisphere, param=0.5)
+    cut_section_sphere = _operations.split_surface_u(temp_hemisphere, param=0.5)
     hemisphere_2 = cut_section_sphere[1]
 
-    translation_component = radius * np.sin(1.0 / 4.0 * np.pi) * 2
+    translation_component = radius * _np.sin(1.0 / 4.0 * _np.pi) * 2
     # Create the third section. Rotate and translate it accordingly
-    hemisphere_3 = operations.rotate(hemisphere_2, 90, axis=2)
-    hemisphere_3 = operations.translate(hemisphere_3, (translation_component, 0, 0))
+    hemisphere_3 = _operations.rotate(hemisphere_2, 90, axis=2)
+    hemisphere_3 = _operations.translate(hemisphere_3, (translation_component, 0, 0))
 
     # Create the forth section. Rotate and translate it accordingly
-    hemisphere_4 = operations.rotate(hemisphere_3, 90, axis=2)
-    hemisphere_4 = operations.translate(hemisphere_4, (0, translation_component, 0))
+    hemisphere_4 = _operations.rotate(hemisphere_3, 90, axis=2)
+    hemisphere_4 = _operations.translate(hemisphere_4, (0, translation_component, 0))
 
     # Create the fifth section. Rotate and translate it accordingly
-    hemisphere_5 = operations.rotate(hemisphere_4, 90, axis=2)
-    hemisphere_5 = operations.translate(hemisphere_5, (-translation_component, 0, 0))
+    hemisphere_5 = _operations.rotate(hemisphere_4, 90, axis=2)
+    hemisphere_5 = _operations.translate(hemisphere_5, (-translation_component, 0, 0))
 
     patches = [hemisphere_1, hemisphere_2, hemisphere_3, hemisphere_4, hemisphere_5]
     for patch in patches:
@@ -412,10 +425,10 @@ def create_nurbs_torus_surface(radius_torus, radius_circle, *, n_ele_u=1, n_ele_
     """
 
     # Create four NURBS surface instances. These are the base patches of the torus.
-    surf_1 = NURBS.Surface()
-    surf_2 = NURBS.Surface()
-    surf_3 = NURBS.Surface()
-    surf_4 = NURBS.Surface()
+    surf_1 = _NURBS.Surface()
+    surf_2 = _NURBS.Surface()
+    surf_3 = _NURBS.Surface()
+    surf_4 = _NURBS.Surface()
     base_surfs = [surf_1, surf_2, surf_3, surf_4]
 
     # Define control points and set them to the surfaces
@@ -475,20 +488,20 @@ def create_nurbs_torus_surface(radius_torus, radius_circle, *, n_ele_u=1, n_ele_
 
     weights = [
         1.0,
-        np.sqrt(2) / 2,
+        _np.sqrt(2) / 2,
         1.0,
-        np.sqrt(2) / 2,
+        _np.sqrt(2) / 2,
         0.5,
-        np.sqrt(2) / 2,
+        _np.sqrt(2) / 2,
         1.0,
-        np.sqrt(2) / 2,
+        _np.sqrt(2) / 2,
         1.0,
     ]
 
-    t_ctrlptsw1 = compat.combine_ctrlpts_weights(ctrlpts_surf1, weights)
-    t_ctrlptsw2 = compat.combine_ctrlpts_weights(ctrlpts_surf2, weights)
-    t_ctrlptsw3 = compat.combine_ctrlpts_weights(ctrlpts_surf3, weights)
-    t_ctrlptsw4 = compat.combine_ctrlpts_weights(ctrlpts_surf4, weights)
+    t_ctrlptsw1 = _compat.combine_ctrlpts_weights(ctrlpts_surf1, weights)
+    t_ctrlptsw2 = _compat.combine_ctrlpts_weights(ctrlpts_surf2, weights)
+    t_ctrlptsw3 = _compat.combine_ctrlpts_weights(ctrlpts_surf3, weights)
+    t_ctrlptsw4 = _compat.combine_ctrlpts_weights(ctrlpts_surf4, weights)
 
     t_ctrlpts_surfs = [t_ctrlptsw1, t_ctrlptsw2, t_ctrlptsw3, t_ctrlptsw4]
 
@@ -546,20 +559,20 @@ def create_nurbs_torus_surface(radius_torus, radius_circle, *, n_ele_u=1, n_ele_
     for transform1, transform2, transform3, transform4 in zip(
         transform_surf1, transform_surf2, transform_surf3, transform_surf4
     ):
-        new_surf1 = operations.translate(surf_1, transform1[0])
-        new_surf1 = operations.rotate(new_surf1, transform1[1], axis=transform1[2])
+        new_surf1 = _operations.translate(surf_1, transform1[0])
+        new_surf1 = _operations.rotate(new_surf1, transform1[1], axis=transform1[2])
         surfaces_torus.append(new_surf1)
 
-        new_surf2 = operations.translate(surf_2, transform2[0])
-        new_surf2 = operations.rotate(new_surf2, transform2[1], axis=transform2[2])
+        new_surf2 = _operations.translate(surf_2, transform2[0])
+        new_surf2 = _operations.rotate(new_surf2, transform2[1], axis=transform2[2])
         surfaces_torus.append(new_surf2)
 
-        new_surf3 = operations.translate(surf_3, transform3[0])
-        new_surf3 = operations.rotate(new_surf3, transform3[1], axis=transform3[2])
+        new_surf3 = _operations.translate(surf_3, transform3[0])
+        new_surf3 = _operations.rotate(new_surf3, transform3[1], axis=transform3[2])
         surfaces_torus.append(new_surf3)
 
-        new_surf4 = operations.translate(surf_4, transform4[0])
-        new_surf4 = operations.rotate(new_surf4, transform4[1], axis=transform4[2])
+        new_surf4 = _operations.translate(surf_4, transform4[0])
+        new_surf4 = _operations.rotate(new_surf4, transform4[1], axis=transform4[2])
         surfaces_torus.append(new_surf4)
 
     return surfaces_torus
@@ -591,7 +604,7 @@ def create_nurbs_brick(width, length, height, *, n_ele_u=1, n_ele_v=1, n_ele_w=1
     """
 
     # Create a NURBS volume instance
-    vol = NURBS.Volume()
+    vol = _NURBS.Volume()
 
     # Set degrees
     vol.degree_u = 2
@@ -639,7 +652,7 @@ def create_nurbs_brick(width, length, height, *, n_ele_u=1, n_ele_v=1, n_ele_w=1
     vol.ctrlpts_size_v = cp_size_v
     vol.ctrlpts_size_w = cp_size_w
 
-    t_ctrlptsw = compat.combine_ctrlpts_weights(ctrlpts, weights)
+    t_ctrlptsw = _compat.combine_ctrlpts_weights(ctrlpts, weights)
 
     vol.set_ctrlpts(t_ctrlptsw, cp_size_u, cp_size_v, cp_size_w)
 
@@ -674,9 +687,9 @@ def do_uniform_knot_refinement_surface(surf, n_ele_u, n_ele_v):
     size_of_knotvector_v = 1 / n_ele_v
 
     for i in range(1, n_ele_u):
-        operations.insert_knot(surf, [size_of_knotvector_u * i, None], [1, 0])
+        _operations.insert_knot(surf, [size_of_knotvector_u * i, None], [1, 0])
     for j in range(1, n_ele_v):
-        operations.insert_knot(surf, [None, size_of_knotvector_v * j], [0, 1])
+        _operations.insert_knot(surf, [None, size_of_knotvector_v * j], [0, 1])
 
 
 def do_uniform_knot_refinement_volume(vol, n_ele_u, n_ele_v, n_ele_w):
@@ -704,8 +717,8 @@ def do_uniform_knot_refinement_volume(vol, n_ele_u, n_ele_v, n_ele_w):
     size_of_knotvector_w = 1 / n_ele_w
 
     for i in range(1, n_ele_u):
-        operations.insert_knot(vol, [size_of_knotvector_u * i, None, None], [1, 0, 0])
+        _operations.insert_knot(vol, [size_of_knotvector_u * i, None, None], [1, 0, 0])
     for j in range(1, n_ele_v):
-        operations.insert_knot(vol, [None, size_of_knotvector_v * j, None], [0, 1, 0])
+        _operations.insert_knot(vol, [None, size_of_knotvector_v * j, None], [0, 1, 0])
     for k in range(1, n_ele_w):
-        operations.insert_knot(vol, [None, None, size_of_knotvector_w * k], [0, 0, 1])
+        _operations.insert_knot(vol, [None, None, size_of_knotvector_w * k], [0, 0, 1])

--- a/src/meshpy/space_time/beam_to_space_time.py
+++ b/src/meshpy/space_time/beam_to_space_time.py
@@ -21,10 +21,16 @@
 # THE SOFTWARE.
 """Convert a MeshPy beam to a space time surface mesh."""
 
-from typing import Callable, Dict, List, Tuple, Type, Union, cast
+from typing import Callable as _Callable
+from typing import Dict as _Dict
+from typing import List as _List
+from typing import Tuple as _Tuple
+from typing import Type as _Type
+from typing import Union as _Union
+from typing import cast as _cast
 
-import numpy as np
-import vtk
+import numpy as _np
+import vtk as _vtk
 
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.coupling import Coupling as _Coupling
@@ -68,7 +74,7 @@ class NodeCosseratSpaceTime(_NodeCosserat):
             [
                 (
                     _mpy.dat_precision.format(component + 0)
-                    if np.abs(component) >= _mpy.eps_pos
+                    if _np.abs(component) >= _mpy.eps_pos
                     else "0"
                 )
                 for component in space_time_coordinates
@@ -116,7 +122,7 @@ class SpaceTimeElement(_VolumeElement):
 class SpaceTimeElementQuad4(SpaceTimeElement):
     """A space-time element with 4 nodes."""
 
-    vtk_cell_type = vtk.vtkQuad
+    vtk_cell_type = _vtk.vtkQuad
     vtk_topology = list(range(4))
     four_c_name = "QUAD4"
 
@@ -124,18 +130,18 @@ class SpaceTimeElementQuad4(SpaceTimeElement):
 class SpaceTimeElementQuad9(SpaceTimeElement):
     """A space-time element with 9 nodes."""
 
-    vtk_cell_type = vtk.vtkQuadraticQuad
+    vtk_cell_type = _vtk.vtkQuadraticQuad
     vtk_topology = list(range(9))
     four_c_name = "QUAD9"
 
 
 def beam_to_space_time(
-    mesh_space_or_generator: Union[_Mesh, Callable[[float], _Mesh]],
+    mesh_space_or_generator: _Union[_Mesh, _Callable[[float], _Mesh]],
     time_duration: float,
     number_of_elements_in_time: int,
     *,
     time_start: float = 0.0,
-) -> Tuple[_Mesh, _GeometryName]:
+) -> _Tuple[_Mesh, _GeometryName]:
     """Convert a MeshPy beam mesh to a surface space-time mesh.
 
     Args
@@ -178,8 +184,8 @@ def beam_to_space_time(
     # Calculate global mesh properties
     number_of_nodes_in_space = len(mesh_space_reference.nodes)
     number_of_elements_in_space = len(mesh_space_reference.elements)
-    space_time_element_type: Union[
-        Type[SpaceTimeElementQuad4], Type[SpaceTimeElementQuad9]
+    space_time_element_type: _Union[
+        _Type[SpaceTimeElementQuad4], _Type[SpaceTimeElementQuad9]
     ]
     if element_type == _Beam3rLine2Line2:
         number_of_copies_in_time = number_of_elements_in_time + 1
@@ -355,16 +361,16 @@ def mesh_to_data_arrays(mesh: _Mesh):
         )
 
     _, raw_unique_nodes = _get_coupled_nodes_to_master_map(mesh, assign_i_global=True)
-    unique_nodes = cast(List[NodeCosseratSpaceTime], raw_unique_nodes)
+    unique_nodes = _cast(_List[NodeCosseratSpaceTime], raw_unique_nodes)
 
     n_nodes = len(unique_nodes)
     n_elements = len(mesh.elements)
     n_nodes_per_element = len(mesh.elements[0].nodes)
 
     coordinates = _get_nodal_coordinates(unique_nodes)
-    time = np.zeros(n_nodes)
-    connectivity = np.zeros((n_elements, n_nodes_per_element), dtype=int)
-    element_rotation_vectors = np.zeros((n_elements, n_nodes_per_element, 3))
+    time = _np.zeros(n_nodes)
+    connectivity = _np.zeros((n_elements, n_nodes_per_element), dtype=int)
+    element_rotation_vectors = _np.zeros((n_elements, n_nodes_per_element, 3))
 
     for i_node, node in enumerate(unique_nodes):
         time[i_node] = node.time
@@ -377,10 +383,10 @@ def mesh_to_data_arrays(mesh: _Mesh):
             )
 
     geometry_sets = mesh.get_unique_geometry_sets()
-    node_sets: Dict[str, List] = {}
+    node_sets: _Dict[str, _List] = {}
     for value in geometry_sets.values():
         for geometry_set in value:
-            node_sets[str(len(node_sets) + 1)] = np.array(
+            node_sets[str(len(node_sets) + 1)] = _np.array(
                 [node.i_global for node in geometry_set.get_all_nodes()]
             )
 
@@ -398,7 +404,7 @@ def mesh_to_data_arrays(mesh: _Mesh):
         # The arc length is added as an "element" property, since the same
         # node can have a different arc length depending on the element
         # (similar to the rotation vectors).
-        arc_length = np.zeros((n_elements, n_nodes_per_element))
+        arc_length = _np.zeros((n_elements, n_nodes_per_element))
         for i_element, element in enumerate(mesh.elements):
             for i_node, node in enumerate(element.nodes):
                 connectivity[i_element, i_node] = node.i_global

--- a/src/meshpy/utils/environment.py
+++ b/src/meshpy/utils/environment.py
@@ -21,8 +21,8 @@
 # THE SOFTWARE.
 """Helper functions to interact with the MeshPy environment."""
 
-import importlib.util
-import os
+import os as _os
+from importlib.util import find_spec as _find_spec
 
 
 def cubitpy_is_available() -> bool:
@@ -32,19 +32,19 @@ def cubitpy_is_available() -> bool:
         True if CubitPy is installed, False otherwise
     """
 
-    if importlib.util.find_spec("cubitpy") is None:
+    if _find_spec("cubitpy") is None:
         return False
     return True
 
 
 def is_mybinder():
     """Check if the current environment is running on mybinder."""
-    return "BINDER_LAUNCH_HOST" in os.environ.keys()
+    return "BINDER_LAUNCH_HOST" in _os.environ.keys()
 
 
 def is_testing():
     """Check if the current environment is a pytest testing run."""
-    return "PYTEST_CURRENT_TEST" in os.environ
+    return "PYTEST_CURRENT_TEST" in _os.environ
 
 
 def get_env_variable(name, *, default="default_not_set"):
@@ -59,8 +59,8 @@ def get_env_variable(name, *, default="default_not_set"):
         not exist. If this is not set and the name is not in the env
         variables, then an error will be thrown.
     """
-    if name in os.environ.keys():
-        return os.environ[name]
+    if name in _os.environ.keys():
+        return _os.environ[name]
     elif default == "default_not_set":
         raise ValueError(f"Environment variable {name} is not set")
     return default

--- a/src/meshpy/utils/nodes.py
+++ b/src/meshpy/utils/nodes.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 """Helper functions to find, filter and interact with nodes."""
 
-import numpy as np
+import numpy as _np
 
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.geometry_set import GeometryName as _GeometryName
@@ -56,7 +56,7 @@ def find_close_nodes(nodes, **kwargs):
         to each other.
     """
 
-    coords = np.zeros([len(nodes), 3])
+    coords = _np.zeros([len(nodes), 3])
     for i, node in enumerate(nodes):
         coords[i, :] = node.coordinates
     partner_indices = _point_partners_to_partner_indices(
@@ -80,7 +80,7 @@ def check_node_by_coordinate(node, axis, value, eps=_mpy.eps_pos):
     eps: float
         Tolerance to check for equality.
     """
-    return np.abs(node.coordinates[axis] - value) < eps
+    return _np.abs(node.coordinates[axis] - value) < eps
 
 
 def get_min_max_coordinates(nodes):
@@ -92,12 +92,12 @@ def get_min_max_coordinates(nodes):
     min_max_coordinates:
         [min_x, min_y, min_z, max_x, max_y, max_z]
     """
-    coordinates = np.zeros([len(nodes), 3])
+    coordinates = _np.zeros([len(nodes), 3])
     for i, node in enumerate(nodes):
         coordinates[i, :] = node.coordinates
-    min_max = np.zeros(6)
-    min_max[:3] = np.min(coordinates, axis=0)
-    min_max[3:] = np.max(coordinates, axis=0)
+    min_max = _np.zeros(6)
+    min_max[:3] = _np.min(coordinates, axis=0)
+    min_max[3:] = _np.max(coordinates, axis=0)
     return min_max
 
 
@@ -160,10 +160,10 @@ def get_nodal_coordinates(nodes):
 
     Return
     ----
-    pos: np.array
+    pos: _np.array
         Numpy array with all the positions of the nodes.
     """
-    coordinates = np.zeros([len(nodes), 3])
+    coordinates = _np.zeros([len(nodes), 3])
     for i, node in enumerate(nodes):
         coordinates[i, :] = node.coordinates
     return coordinates
@@ -179,10 +179,10 @@ def get_nodal_quaternions(nodes):
 
     Return
     ----
-    pos: np.array
+    pos: _np.array
         Numpy array with all the positions of the nodes.
     """
-    quaternions = np.zeros([len(nodes), 4])
+    quaternions = _np.zeros([len(nodes), 4])
     for i, node in enumerate(nodes):
         if isinstance(node, _NodeCosserat):
             quaternions[i, :] = node.rotation.get_quaternion()
@@ -227,13 +227,13 @@ def get_min_max_nodes(nodes, *, middle_nodes=False):
     pos = get_nodal_coordinates(node_list)
     for i, direction in enumerate(["x", "y", "z"]):
         # Check if there is more than one value in dimension.
-        min_max = [np.min(pos[:, i]), np.max(pos[:, i])]
-        if np.abs(min_max[1] - min_max[0]) >= _mpy.eps_pos:
+        min_max = [_np.min(pos[:, i]), _np.max(pos[:, i])]
+        if _np.abs(min_max[1] - min_max[0]) >= _mpy.eps_pos:
             for j, text in enumerate(["min", "max"]):
                 # get all nodes with the min / max coordinate
                 min_max_nodes = []
                 for index, value in enumerate(
-                    np.abs(pos[:, i] - min_max[j]) < _mpy.eps_pos
+                    _np.abs(pos[:, i] - min_max[j]) < _mpy.eps_pos
                 ):
                     if value:
                         min_max_nodes.append(node_list[index])
@@ -251,12 +251,12 @@ def is_node_on_plane(
     ----
     node:
         Check if this node coincides with the defined plane.
-    normal: np.array, list
+    normal: _np.array, list
         Normal vector of defined plane.
     origin_distance: float
         Distance between origin and defined plane. Mutually exclusive with
         point_on_plane.
-    point_on_plane: np.array, list
+    point_on_plane: _np.array, list
         Point on defined plane. Mutually exclusive with origin_distance.
     tol: float
         Tolerance of evaluation if point coincides with plane
@@ -272,11 +272,11 @@ def is_node_on_plane(
         raise ValueError("Only provide origin_distance OR point_on_plane!")
 
     if origin_distance is not None:
-        projection = np.dot(node.coordinates, normal) / np.linalg.norm(normal)
-        distance = np.abs(projection - origin_distance)
+        projection = _np.dot(node.coordinates, normal) / _np.linalg.norm(normal)
+        distance = _np.abs(projection - origin_distance)
     elif point_on_plane is not None:
-        distance = np.abs(
-            np.dot(point_on_plane - node.coordinates, normal) / np.linalg.norm(normal)
+        distance = _np.abs(
+            _np.dot(point_on_plane - node.coordinates, normal) / _np.linalg.norm(normal)
         )
 
     return distance < tol

--- a/src/meshpy/utils/nodes.py
+++ b/src/meshpy/utils/nodes.py
@@ -23,12 +23,17 @@
 
 import numpy as np
 
-from meshpy.core.conf import mpy
-from meshpy.core.geometry_set import GeometryName, GeometrySet, GeometrySetBase
-from meshpy.core.node import Node, NodeCosserat
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.geometry_set import GeometryName as _GeometryName
+from meshpy.core.geometry_set import GeometrySet as _GeometrySet
+from meshpy.core.geometry_set import GeometrySetBase as _GeometrySetBase
+from meshpy.core.node import Node as _Node
+from meshpy.core.node import NodeCosserat as _NodeCosserat
 from meshpy.geometric_search.find_close_points import (
-    find_close_points,
-    point_partners_to_partner_indices,
+    find_close_points as _find_close_points,
+)
+from meshpy.geometric_search.find_close_points import (
+    point_partners_to_partner_indices as _point_partners_to_partner_indices,
 )
 
 
@@ -54,13 +59,13 @@ def find_close_nodes(nodes, **kwargs):
     coords = np.zeros([len(nodes), 3])
     for i, node in enumerate(nodes):
         coords[i, :] = node.coordinates
-    partner_indices = point_partners_to_partner_indices(
-        *find_close_points(coords, **kwargs)
+    partner_indices = _point_partners_to_partner_indices(
+        *_find_close_points(coords, **kwargs)
     )
     return [[nodes[i] for i in partners] for partners in partner_indices]
 
 
-def check_node_by_coordinate(node, axis, value, eps=mpy.eps_pos):
+def check_node_by_coordinate(node, axis, value, eps=_mpy.eps_pos):
     """Check if the node is at a certain coordinate value.
 
     Args
@@ -107,9 +112,9 @@ def get_single_node(item, *, check_cosserat_node=False):
     check_cosserat: bool
         If a check should be performed, that the given node is a CosseratNode.
     """
-    if isinstance(item, Node):
+    if isinstance(item, _Node):
         node = item
-    elif isinstance(item, GeometrySetBase):
+    elif isinstance(item, _GeometrySetBase):
         # Check if there is only one node in the set
         nodes = item.get_points()
         if len(nodes) == 1:
@@ -121,7 +126,7 @@ def get_single_node(item, *, check_cosserat_node=False):
             f'The given object can be node or GeometrySet got "{type(item)}"!'
         )
 
-    if check_cosserat_node and not isinstance(node, NodeCosserat):
+    if check_cosserat_node and not isinstance(node, _NodeCosserat):
         raise TypeError("Expected a NodeCosserat object.")
 
     return node
@@ -179,7 +184,7 @@ def get_nodal_quaternions(nodes):
     """
     quaternions = np.zeros([len(nodes), 4])
     for i, node in enumerate(nodes):
-        if isinstance(node, NodeCosserat):
+        if isinstance(node, _NodeCosserat):
             quaternions[i, :] = node.rotation.get_quaternion()
         else:
             # For the case of nodes that belong to solid elements,
@@ -217,27 +222,27 @@ def get_min_max_nodes(nodes, *, middle_nodes=False):
     """
 
     node_list = filter_nodes(nodes, middle_nodes=middle_nodes)
-    geometry = GeometryName()
+    geometry = _GeometryName()
 
     pos = get_nodal_coordinates(node_list)
     for i, direction in enumerate(["x", "y", "z"]):
         # Check if there is more than one value in dimension.
         min_max = [np.min(pos[:, i]), np.max(pos[:, i])]
-        if np.abs(min_max[1] - min_max[0]) >= mpy.eps_pos:
+        if np.abs(min_max[1] - min_max[0]) >= _mpy.eps_pos:
             for j, text in enumerate(["min", "max"]):
                 # get all nodes with the min / max coordinate
                 min_max_nodes = []
                 for index, value in enumerate(
-                    np.abs(pos[:, i] - min_max[j]) < mpy.eps_pos
+                    np.abs(pos[:, i] - min_max[j]) < _mpy.eps_pos
                 ):
                     if value:
                         min_max_nodes.append(node_list[index])
-                geometry[f"{direction}_{text}"] = GeometrySet(min_max_nodes)
+                geometry[f"{direction}_{text}"] = _GeometrySet(min_max_nodes)
     return geometry
 
 
 def is_node_on_plane(
-    node, *, normal=None, origin_distance=None, point_on_plane=None, tol=mpy.eps_pos
+    node, *, normal=None, origin_distance=None, point_on_plane=None, tol=_mpy.eps_pos
 ):
     """Query if a node lies on a plane defined by a point_on_plane or the
     origin distance.


### PR DESCRIPTION
As proposed in #278 this PR shows how it would look if we renamed all MeshPy internal imports to have a leading underscore.

Turns out the simplest way to check this is to actually parse the code, which woks very well and is added as a pre-commit hook. We now enforce the imports to look like:
```python
from meshpy.core.mesh import Mesh as _Mesh
```
it is checked that the names match and only the leading underscore is added.

A few other things:
- For now only MeshPy imports are changed, we can think about changing standard library imports as well, although I am not sure if this really needed.
- I decided to keep the names in the documentation as they are intended.
- As far as I can see, the API documentation always displays the "true" name of a type, so this should also be OK.
- I rebased this on #285 to directly add to the new coding guidelines section

~~I am marking this as draft, as~~ I would like to think about actually doing this step. I like the safer handling of imports - but I also don't think that was a big issue to beginn with. I am not so sure about the fell of the new code, but maybe that just takes a while to get used to. What I don't like, is that we have to maintain our own pre-commit hook (although that script is not too complicated).

I would very much appreciate the opinion of the MeshPy developers and users.