### PR TITLE
Fix bandit pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
     hooks:
       - id: bandit
         name: Run bandit (security linter for python)
-        args: ["-c", "pyproject.toml", "-r", "-ll", "src/meshpy/", "tests/"]
+        args: ["--configfile", "pyproject.toml", "--exclude", "tests/*"]
         additional_dependencies: ["bandit[toml]"]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v19.1.5

--- a/src/meshpy/four_c/input_file.py
+++ b/src/meshpy/four_c/input_file.py
@@ -25,7 +25,8 @@
 import datetime
 import os
 import re
-import subprocess
+import shutil
+import subprocess  # nosec B404
 import sys
 
 from meshpy.core.base_mesh_item import BaseMeshItemFull, BaseMeshItemString
@@ -919,14 +920,17 @@ class InputFile(Mesh):
 
         def get_git_data(repo):
             """Return the hash and date of the current git commit."""
-            out_sha = subprocess.run(
-                ["git", "rev-parse", "HEAD"],
+            git = shutil.which("git")
+            if git is None:
+                raise RuntimeError("Git executable not found")
+            out_sha = subprocess.run(  # nosec B603
+                [git, "rev-parse", "HEAD"],
                 cwd=repo,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
             )
-            out_date = subprocess.run(
-                ["git", "show", "-s", "--format=%ci"],
+            out_date = subprocess.run(  # nosec B603
+                [git, "show", "-s", "--format=%ci"],
                 cwd=repo,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,

--- a/src/meshpy/four_c/run_four_c.py
+++ b/src/meshpy/four_c/run_four_c.py
@@ -23,7 +23,7 @@
 
 import os
 import shutil
-import subprocess
+import subprocess  # nosec B404
 import sys
 from pathlib import Path
 
@@ -110,7 +110,7 @@ def run_four_c(
     # Actually run the command
     with open(log_file, "w") as stdout_file, open(error_file, "w") as stderr_file:
         process = subprocess.Popen(
-            command,
+            command,  # nosec B603
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=output_dir,


### PR DESCRIPTION
This fixes a wrong configuration of the pre-commit setup that resulted in bandit not being run at all. Now it is run for the actual source code, but not the tests.

As far as I could figure out, the `# nosec` are required and kind of confirm that the developers checked that this is save, as bandit cannot ensure that. Theoretically one could modify the expected behaviour by injecting something into `MESHPY_FOUR_C_EXE` but that means that the system is already compromised, so I see no issue with skipping that warning.