### PR TITLE
Add pre commit import style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,3 +127,13 @@ repos:
       - id: yamlfmt
         name: Run yamlfmt
         args: ["-formatter", "retain_line_breaks_single=true"]
+  # Custom hooks
+  - repo: local
+    hooks:
+      - id: check-imports
+        name: Check Python Imports
+        entry: python3 utils/check_python_imports.py
+        files: ^src/meshpy.*\.py$
+        language: system
+        types: [python]
+        require_serial: true # Necessary to print opening and closing message only once

--- a/README.md
+++ b/README.md
@@ -266,17 +266,26 @@ pytest
   # Not OK
   import numpy  # No alias
   import numpy as np  # Missing leading underscore
+
+  from numpy import *  # Wildcard imports
+  from numpy import _core  # We don't allow the import of private functionality
   from numpy.linalg import norm  # No alias
-  from meshpy.core.mesh import Mesh as _BeamMesh  # MeshPy imports have to be aliased with the same name — should be `_Mesh`
+  from numpy import sin as sin2  # Missing leading underscore
+  from meshpy.core.mesh import Mesh as _BeamMesh  # MeshPy imports have to be aliased with the same name, i.e., should be `_Mesh` (imports from third party libraries can be renamed)
 
   # OK
   import numpy as _np
   import sys as _sys
+
   from pathlib import Path as _Path
+
+  from math import sin as _math_sin
+  from numpy import sin as _np_sin
 
   import meshpy.core.conf as _conf
   from meshpy.core.mesh import Mesh as _Mesh
-  from meshpy.core.node import Node as _Node, NodeCosserat as _NodeCosserat
+  from meshpy.core.node import Node as _Node
+  from meshpy.core.node import NodeCosserat as _NodeCosserat
   ```
   </details>
 

--- a/utils/check_python_imports.py
+++ b/utils/check_python_imports.py
@@ -1,0 +1,214 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2025 MeshPy Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""This script checks if all Python imports within provided files align with
+our coding style, as described in the section "Coding guidelines" in the
+repository README.md."""
+
+import ast as _ast
+import sys as _sys
+from dataclasses import dataclass as _dataclass
+from pathlib import Path as _Path
+from typing import Optional as _Optional
+
+
+@_dataclass
+class Error:
+    """Class to store import errors."""
+
+    filename: str
+    message: str
+    line_nr: _Optional[int] = None
+    column_nr: _Optional[int] = None
+
+
+class ImportChecker(_ast.NodeVisitor):
+    """Class to check if Python imports align with our coding style."""
+
+    def __init__(self, filename: str) -> None:
+        """Initialize the ImportChecker.
+
+        Args:
+            filename: The filename of the current file (to store for errors)
+        """
+
+        self.errors: list[Error] = []
+        self.filename = filename
+
+    def visit_Import(self, node: _ast.Import) -> None:
+        """Visit an import statement and check if the import aligns with our
+        coding style.
+
+        Args:
+            node: The import node to check.
+        """
+
+        for alias in node.names:
+            if alias.asname is None:
+                self.errors.append(
+                    Error(
+                        self.filename,
+                        f"Import '{alias.name}' has no alias!",
+                        node.lineno,
+                        node.col_offset,
+                    )
+                )
+            elif not alias.asname.startswith("_"):
+                self.errors.append(
+                    Error(
+                        self.filename,
+                        f"Import '{alias.name}' has alias '{alias.asname}' that doesn't start with '_'!",
+                        node.lineno,
+                        node.col_offset,
+                    )
+                )
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: _ast.ImportFrom) -> None:
+        """Visit an import from statement and check if the import aligns with
+        our coding style.
+
+        Args:
+            node: The import from node to check.
+        """
+
+        for alias in node.names:
+            # Check for wildcard imports
+            if alias.name == "*":
+                self.errors.append(
+                    Error(
+                        self.filename,
+                        "Wildcard imports are not allowed!",
+                        node.lineno,
+                        node.col_offset,
+                    )
+                )
+                continue
+
+            # Check for private imports from third party libraries
+            if not (
+                node.module is not None and node.module.startswith("meshpy.")
+            ) and alias.name.startswith("_"):
+                from_module = node.module or f"relative import (level {node.level})"
+                self.errors.append(
+                    Error(
+                        self.filename,
+                        f"Import of private functionality '{alias.name}' from '{from_module}' is not allowed!",
+                        node.lineno,
+                        node.col_offset,
+                    )
+                )
+                continue
+
+            # Check for missing aliases
+            if alias.asname is None:
+                from_module = node.module or f"relative import (level {node.level})"
+                self.errors.append(
+                    Error(
+                        self.filename,
+                        f"Import '{alias.name}' from '{from_module}' has no alias!",
+                        node.lineno,
+                        node.col_offset,
+                    )
+                )
+            else:
+                # Check for correct aliases (internal imports cannot be renamed)
+                if node.module is not None and node.module.startswith("meshpy."):
+                    expected_asname = "_" + alias.name
+                    if alias.asname != expected_asname:
+                        from_module = (
+                            node.module or f"relative import (level {node.level})"
+                        )
+                        self.errors.append(
+                            Error(
+                                self.filename,
+                                f"Internal import '{alias.name}' from '{from_module}' has incorrect alias '{alias.asname}'! It should be '{expected_asname}'!",
+                                node.lineno,
+                                node.col_offset,
+                            )
+                        )
+                # Check for correct aliases (external imports can be renamed)
+                elif not alias.asname.startswith("_"):
+                    from_module = node.module or f"relative import (level {node.level})"
+                    self.errors.append(
+                        Error(
+                            self.filename,
+                            f"External import '{alias.name}' from '{from_module}' has incorrect alias '{alias.asname}'! It should be '_{alias.asname}'!",
+                            node.lineno,
+                            node.col_offset,
+                        )
+                    )
+        self.generic_visit(node)
+
+
+def check_file(filename: str) -> list[Error]:
+    """Check a Python file for import errors.
+
+    Args:
+        filename: The filename of the Python file to check.
+
+    Returns:
+        List of errors found in the Python file.
+    """
+
+    with open(filename, "r") as file:
+        content = file.read()
+    tree = _ast.parse(content, filename=filename)
+
+    checker = ImportChecker(filename)
+    checker.visit(tree)
+    return checker.errors
+
+
+def main() -> None:
+    """Check all provided Python files for import errors."""
+
+    errors: list[Error] = []
+
+    for filename in _sys.argv[1:]:
+        if not _Path(filename).exists():
+            errors.append(Error(filename, "File not found!"))
+            continue
+
+        errors.extend(check_file(filename))
+
+    if errors:
+        print("Found imports which do not align with our coding style:\n")
+
+        for error in errors:
+            if error.line_nr is not None and error.column_nr is not None:
+                print(
+                    f"    * {error.filename}:{error.line_nr}:{error.column_nr}: {error.message}\n"
+                )
+            else:
+                print(f"{error.filename}: {error.message}\n")
+
+        print(
+            "For more information on how to fix these issues, please refer to the contributing guidelines in our README.md."
+        )
+        _sys.exit(1)
+    else:
+        _sys.exit(0)
+
+
+if __name__ == "__main__":
+    """Run the main function if the script is executed."""
+    main()


### PR DESCRIPTION
Closes #294

Follows #278 #287 #293

The major part of the script is generated with deepseek AI

I've reworked the error detection for better error messages and a more reliable detection.

The error of the current code base looks like this

```
Check Python Imports.................................................................Failed
- hook id: check-imports
- exit code: 1

Found imports which do not align with our coding style:

    * src/meshpy/mesh_creation_functions/nurbs_geometries.py:26:0: Import 'compatibility' from 'geomdl' has incorrect alias '_compat'; should be '_compatibility'!

For more information on how to fix these issues, please refer to the contributing guidelines in our README.md.
```

The nice thing is that we now have line and column numbering. By clicking on the file this directly brings you to the related part in your IDE/Editor

The last question remaining is if we also want to check if the initial import already starts with an `_` and throw an error? This almost always means that a private function is imported. Currently this throws an error and suggests two under scores.