### PR TITLE
Improve interface and type hints of beam generic function

### DIFF
--- a/src/meshpy/mesh_creation_functions/beam_basic_geometry.py
+++ b/src/meshpy/mesh_creation_functions/beam_basic_geometry.py
@@ -388,7 +388,7 @@ def create_beam_mesh_line_at_node(
         raise ValueError("Length has to be positive!")
 
     # Create the line starting from the given node
-    start_node = _get_single_node(start_node, check_cosserat_node=True)
+    start_node = _get_single_node(start_node)
     tangent = start_node.rotation * [1, 0, 0]
     start_position = start_node.coordinates
     end_position = start_position + tangent * length
@@ -451,7 +451,7 @@ def create_beam_mesh_arc_at_node(
         arc_axis_normal = -1.0 * arc_axis_normal
 
     # The normal has to be perpendicular to the start point tangent
-    start_node = _get_single_node(start_node, check_cosserat_node=True)
+    start_node = _get_single_node(start_node)
     tangent = start_node.rotation * [1, 0, 0]
     if _np.abs(_np.dot(tangent, arc_axis_normal)) > _mpy.eps_pos:
         raise ValueError(

--- a/src/meshpy/mesh_creation_functions/beam_basic_geometry.py
+++ b/src/meshpy/mesh_creation_functions/beam_basic_geometry.py
@@ -34,16 +34,14 @@ from meshpy.mesh_creation_functions.beam_generic import (
 from meshpy.utils.nodes import get_single_node as _get_single_node
 
 
-def create_beam_mesh_line(
-    mesh, beam_object, material, start_point, end_point, **kwargs
-):
+def create_beam_mesh_line(mesh, beam_class, material, start_point, end_point, **kwargs):
     """Generate a straight line of beam elements.
 
     Args
     ----
     mesh: Mesh
         Mesh that the line will be added to.
-    beam_object: Beam
+    beam_class: Beam
         Class of beam that will be used for this line.
     material: Material
         Material for this line.
@@ -108,7 +106,7 @@ def create_beam_mesh_line(
     # Create the beam in the mesh
     return _create_beam_mesh_function(
         mesh,
-        beam_object=beam_object,
+        beam_class=beam_class,
         material=material,
         function_generator=get_beam_geometry,
         interval=[0.0, 1.0],
@@ -118,7 +116,7 @@ def create_beam_mesh_line(
 
 
 def create_beam_mesh_arc_segment_via_rotation(
-    mesh, beam_object, material, center, axis_rotation, radius, angle, **kwargs
+    mesh, beam_class, material, center, axis_rotation, radius, angle, **kwargs
 ):
     """Generate a circular segment of beam elements.
 
@@ -132,7 +130,7 @@ def create_beam_mesh_arc_segment_via_rotation(
     ----
     mesh: Mesh
         Mesh that the arc segment will be added to.
-    beam_object: Beam
+    beam_class: Beam
         Class of beam that will be used for this line.
     material: Material
         Material for this segment.
@@ -169,13 +167,13 @@ def create_beam_mesh_arc_segment_via_rotation(
     axis = axis_rotation * [0, 0, 1]
     start_point = center + radius * (axis_rotation * [0, -1, 0])
     return create_beam_mesh_arc_segment_via_axis(
-        mesh, beam_object, material, axis, center, start_point, angle, **kwargs
+        mesh, beam_class, material, axis, center, start_point, angle, **kwargs
     )
 
 
 def create_beam_mesh_arc_segment_via_axis(
     mesh,
-    beam_object,
+    beam_class,
     material,
     axis,
     axis_point,
@@ -194,7 +192,7 @@ def create_beam_mesh_arc_segment_via_axis(
     ----
     mesh: Mesh
         Mesh that the arc segment will be added to.
-    beam_object: Beam
+    beam_class: Beam
         Class of beam that will be used for this line.
     material: Material
         Material for this segment.
@@ -270,7 +268,7 @@ def create_beam_mesh_arc_segment_via_axis(
     # Create the beam in the mesh
     return _create_beam_mesh_function(
         mesh,
-        beam_object=beam_object,
+        beam_class=beam_class,
         material=material,
         function_generator=get_beam_geometry,
         interval=[0.0, angle],
@@ -281,7 +279,7 @@ def create_beam_mesh_arc_segment_via_axis(
 
 
 def create_beam_mesh_arc_segment_2d(
-    mesh, beam_object, material, center, radius, phi_start, phi_end, **kwargs
+    mesh, beam_class, material, center, radius, phi_start, phi_end, **kwargs
 ):
     """Generate a circular segment of beam elements in the x-y plane.
 
@@ -289,7 +287,7 @@ def create_beam_mesh_arc_segment_2d(
     ----
     mesh: Mesh
         Mesh that the arc segment will be added to.
-    beam_object: Beam
+    beam_class: Beam
         Class of beam that will be used for this line.
     material: Material
         Material for this segment.
@@ -338,7 +336,7 @@ def create_beam_mesh_arc_segment_2d(
 
     return create_beam_mesh_arc_segment_via_axis(
         mesh,
-        beam_object,
+        beam_class,
         material,
         axis,
         center,
@@ -349,7 +347,7 @@ def create_beam_mesh_arc_segment_2d(
 
 
 def create_beam_mesh_line_at_node(
-    mesh, beam_object, material, start_node, length, **kwargs
+    mesh, beam_class, material, start_node, length, **kwargs
 ):
     """Generate a straight line at a given node. The tangent will be the same
     as at that node.
@@ -358,7 +356,7 @@ def create_beam_mesh_line_at_node(
     ----
     mesh: Mesh
         Mesh that the arc segment will be added to.
-    beam_object: Beam
+    beam_class: Beam
         Class of beam that will be used for this line.
     material: Material
         Material for this segment.
@@ -395,7 +393,7 @@ def create_beam_mesh_line_at_node(
 
     return create_beam_mesh_line(
         mesh,
-        beam_object,
+        beam_class,
         material,
         start_position,
         end_position,
@@ -405,7 +403,7 @@ def create_beam_mesh_line_at_node(
 
 
 def create_beam_mesh_arc_at_node(
-    mesh, beam_object, material, start_node, arc_axis_normal, radius, angle, **kwargs
+    mesh, beam_class, material, start_node, arc_axis_normal, radius, angle, **kwargs
 ):
     """Generate a circular segment starting at a given node. The arc will be
     tangent to the given node.
@@ -414,7 +412,7 @@ def create_beam_mesh_arc_at_node(
     ----
     mesh: Mesh
         Mesh that the arc segment will be added to.
-    beam_object: Beam
+    beam_class: Beam
         Class of beam that will be used for this line.
     material: Material
         Material for this segment.
@@ -465,7 +463,7 @@ def create_beam_mesh_arc_at_node(
 
     return create_beam_mesh_arc_segment_via_axis(
         mesh,
-        beam_object,
+        beam_class,
         material,
         arc_axis_normal,
         center,
@@ -478,7 +476,7 @@ def create_beam_mesh_arc_at_node(
 
 def create_beam_mesh_helix(
     mesh,
-    beam_object,
+    beam_class,
     material,
     axis_vector,
     axis_point,
@@ -499,7 +497,7 @@ def create_beam_mesh_helix(
     ----
     mesh: Mesh
         Mesh that the helical segment will be added to.
-    beam_object: Beam
+    beam_class: Beam
         Class of beam that will be used for this line.
     material: Material
         Material for this segment.
@@ -599,7 +597,7 @@ def create_beam_mesh_helix(
 
         line_sets = create_beam_mesh_line(
             mesh_temp,
-            beam_object,
+            beam_class,
             material,
             start_point=start_point,
             end_point=end_point,
@@ -644,7 +642,7 @@ def create_beam_mesh_helix(
 
     helix_sets = create_beam_mesh_line(
         mesh_temp,
-        beam_object,
+        beam_class,
         material,
         start_point=[radius, 0, 0],
         end_point=end_point,

--- a/src/meshpy/mesh_creation_functions/beam_curve.py
+++ b/src/meshpy/mesh_creation_functions/beam_curve.py
@@ -37,7 +37,7 @@ from meshpy.mesh_creation_functions.beam_generic import (
 
 def create_beam_mesh_curve(
     mesh,
-    beam_object,
+    beam_class,
     material,
     function,
     interval,
@@ -55,7 +55,7 @@ def create_beam_mesh_curve(
     ----
     mesh: Mesh
         Mesh that the curve will be added to.
-    beam_object: Beam
+    beam_class: Beam
         Class of beam that will be used for this line.
     material: Material
         Material for this line.
@@ -257,7 +257,7 @@ def create_beam_mesh_curve(
     # Create the beam in the mesh
     created_sets = _create_beam_mesh_function(
         mesh,
-        beam_object=beam_object,
+        beam_class=beam_class,
         material=material,
         function_generator=BeamFunctions(),
         interval=[0.0, length],

--- a/src/meshpy/mesh_creation_functions/beam_fibers_in_rectangle.py
+++ b/src/meshpy/mesh_creation_functions/beam_fibers_in_rectangle.py
@@ -113,7 +113,7 @@ def _intersect_line_with_rectangle(
 
 def create_fibers_in_rectangle(
     mesh,
-    beam_object,
+    beam_class,
     material,
     length,
     width,
@@ -130,8 +130,8 @@ def create_fibers_in_rectangle(
     ----
     mesh: Mesh
         Mesh that the fibers will be added to.
-    beam_object: Beam
-        Object that will be used to create the beam elements.
+    beam_class: Beam
+        Class that will be used to create the beam elements.
     material: Material
         Material for the beam.
     length: float
@@ -208,7 +208,7 @@ def create_fibers_in_rectangle(
                     fiber_nel = _np.max([fiber_nel, 1])
                     _create_beam_mesh_line(
                         mesh,
-                        beam_object,
+                        beam_class,
                         material,
                         _np.append(start, 0.0),
                         _np.append(end, 0.0),

--- a/src/meshpy/mesh_creation_functions/beam_generic.py
+++ b/src/meshpy/mesh_creation_functions/beam_generic.py
@@ -21,29 +21,42 @@
 # THE SOFTWARE.
 """Generic function used to create all beams within meshpy."""
 
+from typing import Callable as _Callable
+from typing import Dict as _Dict
+from typing import List as _List
+from typing import Optional as _Optional
+from typing import Tuple as _Tuple
+from typing import Type as _Type
+from typing import Union as _Union
+
 import numpy as _np
 
 from meshpy.core.conf import mpy as _mpy
+from meshpy.core.element_beam import Beam as _Beam
 from meshpy.core.geometry_set import GeometryName as _GeometryName
 from meshpy.core.geometry_set import GeometrySet as _GeometrySet
+from meshpy.core.material import MaterialBeam as _MaterialBeam
+from meshpy.core.mesh import Mesh as _Mesh
+from meshpy.core.node import NodeCosserat as _NodeCosserat
 from meshpy.utils.nodes import get_single_node as _get_single_node
 
 
 def create_beam_mesh_function(
-    mesh,
+    mesh: _Mesh,
     *,
-    beam_object=None,
-    material=None,
-    function_generator=None,
-    interval=None,
-    n_el=None,
-    l_el=None,
-    interval_length=None,
-    node_positions_of_elements=None,
-    start_node=None,
-    end_node=None,
-    vtk_cell_data=None,
-):
+    beam_object: _Type[_Beam],
+    material: _MaterialBeam,
+    function_generator: _Callable,
+    interval: _Tuple[float, float],
+    n_el: _Optional[int] = None,
+    l_el: _Optional[float] = None,
+    interval_length: _Optional[float] = None,
+    node_positions_of_elements: _Optional[_List[float]] = None,
+    start_node: _Optional[_Union[_NodeCosserat, _GeometrySet]] = None,
+    end_node: _Optional[_Union[_NodeCosserat, _GeometrySet]] = None,
+    close_beam: _Optional[bool] = False,
+    vtk_cell_data: _Optional[_Dict[str, _Tuple]] = None,
+) -> _GeometryName:
     """Generic beam creation function.
 
     Remark for given start and/or end nodes:
@@ -52,57 +65,57 @@ def create_beam_mesh_function(
         the same (for axi-symmetric beam cross-sections) but the nodes can
         be reused.
 
-    Args
-    ----
-    mesh: Mesh
-        Mesh that the created beam(s) should be added to.
-    beam_object: Beam
-        Class of beam that will be used for this line.
-    material: Material
-        Material for this line.
-    function_generator: function that returns function
-        The function_generator has to take two variables, point_a and
-        point_b (both within the interval) and return a function(xi) that
-        calculates the position and rotation along the beam, where
-        point_a -> xi = -1 and point_b -> xi = 1.
-    interval: [start end]
-        Start and end values for interval that will be used to create the
-        beam.
-    n_el: int
-        Number of equally spaced beam elements along the line. Defaults to 1.
-        Mutually exclusive with l_el
-    l_el: float
-        Desired length of beam elements. This requires the option interval_length
-        to be set. Mutually exclusive with n_el. Be aware, that this length
-        might not be achieved, if the elements are warped after they are
-        created.
-    interval_length:
-        Total length of the interval. Is required when the option l_el is given.
-    node_positions_of_elements: [double]
-        A list of normalized positions (within [0,1] and in ascending order)
-        that define the boundaries of beam elements along the created curve.
-        The given values will be mapped to the actual `interval` given as an
-        argument to this function. These values specify where elements start
-        and end, additional internal nodes (such as midpoints in higher-order
-        elements) may be placed automatically.
-    start_node: Node, GeometrySet
-        Node to use as the first node for this line. Use this if the line
-        is connected to other lines (angles have to be the same, otherwise
-        connections should be used). If a geometry set is given, it can
-        contain one, and one node only.
-    end_node: Node, GeometrySet, bool
-        If this is a Node or GeometrySet, the last node of the created beam
-        is set to that node.
-        If it is True the created beam is closed within itself.
-    vtk_cell_data: {cell_data_name (str): cell_data_value (float)}
-        With this argument, a vtk cell data can be set for the elements
-        created within this function. This can be used to check which
-        elements are created by which function.
+    Args:
+        mesh:
+            Mesh that the created beam(s) should be added to.
+        beam_object:
+            Class of beam that will be used for this line.
+        material:
+            Material for this line.
+        function_generator:
+            The function_generator has to take two variables, point_a and
+            point_b (both within the interval) and return a function(xi) that
+            calculates the position and rotation along the beam, where
+            point_a -> xi = -1 and point_b -> xi = 1.
+        interval:
+            Start and end values for interval that will be used to create the
+            beam.
+        n_el:
+            Number of equally spaced beam elements along the line. Defaults to 1.
+            Mutually exclusive with l_el
+        l_el:
+            Desired length of beam elements. This requires the option interval_length
+            to be set. Mutually exclusive with n_el. Be aware, that this length
+            might not be achieved, if the elements are warped after they are
+            created.
+        interval_length:
+            Total length of the interval. Is required when the option l_el is given.
+        node_positions_of_elements:
+            A list of normalized positions (within [0,1] and in ascending order)
+            that define the boundaries of beam elements along the created curve.
+            The given values will be mapped to the actual `interval` given as an
+            argument to this function. These values specify where elements start
+            and end, additional internal nodes (such as midpoints in higher-order
+            elements) may be placed automatically.
+        start_node:
+            Node to use as the first node for this line. Use this if the line
+            is connected to other lines (angles have to be the same, otherwise
+            connections should be used). If a geometry set is given, it can
+            contain one, and one node only.
+        end_node:
+            If this is a Node or GeometrySet, the last node of the created beam
+            is set to that node.
+            If it is True the created beam is closed within itself.
+        close_beam:
+            If it is True the created beam is closed within itself (mutually
+            exclusive with end_node).
+        vtk_cell_data:
+            With this argument, a vtk cell data can be set for the elements
+            created within this function. This can be used to check which
+            elements are created by which function.
 
-    Return
-    ----
-    return_set: GeometryName
-        Set with the 'start' and 'end' node of the curve. Also a 'line' set
+    Returns:
+        Geometry sets with the 'start' and 'end' node of the curve. Also a 'line' set
         with all nodes of the curve.
     """
 
@@ -120,6 +133,11 @@ def create_beam_mesh_function(
             'The arguments "n_el", "l_el" and "node_positions_of_elements" are mutually exclusive'
         )
 
+    if close_beam and end_node is not None:
+        raise ValueError(
+            'The arguments "close_beam" and "end_node" are mutually exclusive'
+        )
+
     # Cases where we have equally spaced elements
     if n_el is not None or l_el is not None:
         if l_el is not None:
@@ -129,12 +147,15 @@ def create_beam_mesh_function(
                     'The parameter "l_el" requires "interval_length" to be set.'
                 )
             n_el = max([1, round(interval_length / l_el)])
+        elif n_el is None:
+            raise ValueError("n_el should not be None at this point")
+
         interval_node_positions_of_elements = [
             interval[0] + i_node * (interval[1] - interval[0]) / n_el
             for i_node in range(n_el + 1)
         ]
     # A list for the element node positions was provided
-    else:
+    elif node_positions_of_elements is not None:
         # Check that the given positions are in ascending order and start with 1 and end with 0
         for index, value, name in zip([0, -1], [0, 1], ["First", "Last"]):
             if not _np.isclose(
@@ -156,6 +177,9 @@ def create_beam_mesh_function(
         interval_node_positions_of_elements = interval[0] + (
             interval[1] - interval[0]
         ) * _np.asarray(node_positions_of_elements)
+
+    # We need to make sure we have the number of elements for the case a given end node
+    n_el = len(interval_node_positions_of_elements) - 1
 
     # Make sure the material is in the mesh.
     mesh.add_material(material)
@@ -214,10 +238,7 @@ def create_beam_mesh_function(
         relative_twist_start = get_relative_twist(start_node.rotation, start_rotation)
 
     # If an end node is given, check what behavior is wanted.
-    close_beam = False
-    if end_node is True:
-        close_beam = True
-    elif end_node is not None:
+    if end_node is not None:
         end_node = _get_single_node(end_node)
         check_given_node(end_node)
         _, end_rotation = function_over_whole_interval(1.0)

--- a/src/meshpy/mesh_creation_functions/beam_generic.py
+++ b/src/meshpy/mesh_creation_functions/beam_generic.py
@@ -44,7 +44,7 @@ from meshpy.utils.nodes import get_single_node as _get_single_node
 def create_beam_mesh_function(
     mesh: _Mesh,
     *,
-    beam_object: _Type[_Beam],
+    beam_class: _Type[_Beam],
     material: _MaterialBeam,
     function_generator: _Callable,
     interval: _Tuple[float, float],
@@ -68,7 +68,7 @@ def create_beam_mesh_function(
     Args:
         mesh:
             Mesh that the created beam(s) should be added to.
-        beam_object:
+        beam_class:
             Class of beam that will be used for this line.
         material:
             Material for this line.
@@ -285,7 +285,7 @@ def create_beam_mesh_function(
         else:
             last_node = None
 
-        element = beam_object(material=material)
+        element = beam_class(material=material)
         elements.append(element)
         nodes.extend(
             element.create_beam(

--- a/src/meshpy/mesh_creation_functions/beam_generic.py
+++ b/src/meshpy/mesh_creation_functions/beam_generic.py
@@ -207,7 +207,7 @@ def create_beam_mesh_function(
 
     # If a start node is given, set this as the first node for this beam.
     if start_node is not None:
-        start_node = _get_single_node(start_node, check_cosserat_node=True)
+        start_node = _get_single_node(start_node)
         nodes = [start_node]
         check_given_node(start_node)
         _, start_rotation = function_over_whole_interval(-1.0)
@@ -218,7 +218,7 @@ def create_beam_mesh_function(
     if end_node is True:
         close_beam = True
     elif end_node is not None:
-        end_node = _get_single_node(end_node, check_cosserat_node=True)
+        end_node = _get_single_node(end_node)
         check_given_node(end_node)
         _, end_rotation = function_over_whole_interval(1.0)
         relative_twist_end = get_relative_twist(end_node.rotation, end_rotation)

--- a/src/meshpy/mesh_creation_functions/beam_generic.py
+++ b/src/meshpy/mesh_creation_functions/beam_generic.py
@@ -40,7 +40,6 @@ def create_beam_mesh_function(
     l_el=None,
     interval_length=None,
     node_positions_of_elements=None,
-    add_sets=False,
     start_node=None,
     end_node=None,
     vtk_cell_data=None,
@@ -86,10 +85,6 @@ def create_beam_mesh_function(
         argument to this function. These values specify where elements start
         and end, additional internal nodes (such as midpoints in higher-order
         elements) may be placed automatically.
-    add_sets: bool
-        If this is true the sets are added to the mesh and then displayed
-        in eventual VTK output, even if they are not used for a boundary
-        condition or coupling.
     start_node: Node, GeometrySet
         Node to use as the first node for this line. Use this if the line
         is connected to other lines (angles have to be the same, otherwise
@@ -311,6 +306,5 @@ def create_beam_mesh_function(
     return_set["start"] = _GeometrySet(nodes[0])
     return_set["end"] = _GeometrySet(end_node)
     return_set["line"] = _GeometrySet(elements)
-    if add_sets:
-        mesh.add(return_set)
+
     return return_set

--- a/src/meshpy/mesh_creation_functions/beam_honeycomb.py
+++ b/src/meshpy/mesh_creation_functions/beam_honeycomb.py
@@ -35,7 +35,7 @@ from meshpy.utils.nodes import get_min_max_nodes as _get_min_max_nodes
 
 def create_beam_mesh_honeycomb_flat(
     mesh,
-    beam_object,
+    beam_class,
     material,
     width,
     n_width,
@@ -54,8 +54,8 @@ def create_beam_mesh_honeycomb_flat(
     ----
     mesh: Mesh
         Mesh that the honeycomb will be added to.
-    beam_object: Beam
-        Object that will be used to create the beam elements.
+    beam_class: Beam
+        Class that will be used to create the beam elements.
     material: Material
         Material for the beam.
     width: float
@@ -88,7 +88,7 @@ def create_beam_mesh_honeycomb_flat(
     def add_line(pointa, pointb):
         """Shortcut to add line."""
         return _create_beam_mesh_line(
-            mesh_honeycomb, beam_object, material, pointa, pointb, n_el=n_el
+            mesh_honeycomb, beam_class, material, pointa, pointb, n_el=n_el
         )
 
     # Geometrical shortcuts.
@@ -165,7 +165,7 @@ def create_beam_mesh_honeycomb_flat(
 
 def create_beam_mesh_honeycomb(
     mesh,
-    beam_object,
+    beam_class,
     material,
     diameter,
     n_circumference,
@@ -183,8 +183,8 @@ def create_beam_mesh_honeycomb(
     ----
     mesh: Mesh
         Mesh that the honeycomb will be added to.
-    beam_object: Beam
-        Object that will be used to create the beam elements.
+    beam_class: Beam
+        Class that will be used to create the beam elements.
     material: Material
         Material for the beam.
     diameter: float
@@ -242,7 +242,7 @@ def create_beam_mesh_honeycomb(
     mesh_temp = _Mesh()
     honeycomb_sets = create_beam_mesh_honeycomb_flat(
         mesh_temp,
-        beam_object,
+        beam_class,
         material,
         width,
         n_width,

--- a/src/meshpy/mesh_creation_functions/beam_nurbs.py
+++ b/src/meshpy/mesh_creation_functions/beam_nurbs.py
@@ -110,7 +110,7 @@ def get_nurbs_curve_function_and_jacobian_for_integration(curve, tol=None):
 
 
 def create_beam_mesh_from_nurbs(
-    mesh, beam_object, material, curve, *, tol=None, **kwargs
+    mesh, beam_class, material, curve, *, tol=None, **kwargs
 ):
     """Generate a beam from a NURBS curve.
 
@@ -118,7 +118,7 @@ def create_beam_mesh_from_nurbs(
     ----
     mesh: Mesh
         Mesh that the curve will be added to.
-    beam_object: Beam
+    beam_class: Beam
         Class of beam that will be used for this line.
     material: Material
         Material for this line.
@@ -152,7 +152,7 @@ def create_beam_mesh_from_nurbs(
     # Create the beams
     return _create_beam_mesh_curve(
         mesh,
-        beam_object,
+        beam_class,
         material,
         function,
         [curve_start, curve_end],

--- a/src/meshpy/mesh_creation_functions/beam_stent.py
+++ b/src/meshpy/mesh_creation_functions/beam_stent.py
@@ -37,7 +37,7 @@ from meshpy.utils.nodes import get_min_max_nodes as _get_min_max_nodes
 
 
 def create_stent_cell(
-    beam_object,
+    beam_class,
     material,
     width,
     height,
@@ -54,8 +54,8 @@ def create_stent_cell(
 
     Args
     ----
-    beam_object: Beam
-        Object that will be used to create the beam elements.
+    beam_class: Beam
+        Class that will be used to create the beam elements.
     material: Material
         Material for the beam.
     width: float
@@ -88,14 +88,14 @@ def create_stent_cell(
     def add_line(pointa, pointb, n_el_line):
         """Shortcut to add line."""
         return _create_beam_mesh_line(
-            mesh, beam_object, material, pointa, pointb, n_el=n_el_line
+            mesh, beam_class, material, pointa, pointb, n_el=n_el_line
         )
 
     def add_segment(center, axis_rotation, radius, angle, n_el_segment):
         """Shortcut to add arc segment."""
         return _create_beam_mesh_arc_segment_via_rotation(
             mesh,
-            beam_object,
+            beam_class,
             material,
             center,
             axis_rotation,
@@ -153,15 +153,15 @@ def create_stent_cell(
 
 
 def create_stent_column(
-    beam_object, material, width, height, n_height, n_el=1, **kwargs
+    beam_class, material, width, height, n_height, n_el=1, **kwargs
 ):
     """Create a column of completed cells. A completed cell consists of one
     cell, that is created with the create cell function and it's reflection.
 
     Args
     ----
-    beam_object: Beam
-        Object that will be used to create the beam elements.
+    beam_class: Beam
+        Class that will be used to create the beam elements.
     material: Material
         Material for the beam.
     width: float
@@ -197,7 +197,7 @@ def create_stent_column(
         if i == n_height - 2:
             S3 = False
         unit_cell = create_stent_cell(
-            beam_object,
+            beam_class,
             material,
             width,
             height,
@@ -218,14 +218,14 @@ def create_stent_column(
 
 
 def create_beam_mesh_stent_flat(
-    beam_object, material, width_flat, height_flat, n_height, n_column, n_el=1, **kwargs
+    beam_class, material, width_flat, height_flat, n_height, n_column, n_el=1, **kwargs
 ):
     """Create a flat stent structure on the x-y plane.
 
     Args
     ----
-    beam_object: Beam
-        Object that will be used to create the beam elements.
+    beam_class: Beam
+        Class that will be used to create the beam elements.
     material: Material
         Material for the beam.
     width_flat: float
@@ -249,7 +249,7 @@ def create_beam_mesh_stent_flat(
     width = width_flat / n_column / 2
     height = height_flat / n_height
     column_mesh = create_stent_column(
-        beam_object, material, width, height, n_height, n_el=n_el, **kwargs
+        beam_class, material, width, height, n_height, n_el=n_el, **kwargs
     )
     for i in range(n_column):
         column_copy = column_mesh.copy()
@@ -260,7 +260,7 @@ def create_beam_mesh_stent_flat(
         for j in range(n_height - 1):
             _create_beam_mesh_line(
                 mesh_flat,
-                beam_object,
+                beam_class,
                 material,
                 [4 * i * width, j * height, 0],
                 [4 * i * width, (j + 1) * height, 0],
@@ -268,7 +268,7 @@ def create_beam_mesh_stent_flat(
             )
         _create_beam_mesh_line(
             mesh_flat,
-            beam_object,
+            beam_class,
             material,
             [(4 * i + 2) * width, 0, 0],
             [(4 * i + 2) * width, height, 0],
@@ -279,7 +279,7 @@ def create_beam_mesh_stent_flat(
 
 def create_beam_mesh_stent(
     mesh,
-    beam_object,
+    beam_class,
     material,
     length,
     diameter,
@@ -295,8 +295,8 @@ def create_beam_mesh_stent(
     ----
     mesh: Mesh
         Mesh that the stent will be added to.
-    beam_object: Beam
-        Object that will be used to create the beam elements.
+    beam_class: Beam
+        Class that will be used to create the beam elements.
     material: Material
         Material for the beam.
     length: float
@@ -332,7 +332,7 @@ def create_beam_mesh_stent(
     n_column = n_circumference
 
     mesh_stent = create_beam_mesh_stent_flat(
-        beam_object, material, width_flat, height_flat, n_height, n_column, **kwargs
+        beam_class, material, width_flat, height_flat, n_height, n_column, **kwargs
     )
     mesh_stent.rotate(_Rotation([1, 0, 0], _np.pi / 2))
     mesh_stent.rotate(_Rotation([0, 0, 1], _np.pi / 2))

--- a/src/meshpy/mesh_creation_functions/beam_wire.py
+++ b/src/meshpy/mesh_creation_functions/beam_wire.py
@@ -32,7 +32,7 @@ from meshpy.utils.nodes import check_node_by_coordinate as _check_node_by_coordi
 
 
 def create_wire_fibers(
-    mesh, beam_object, material, length, *, radius=None, layers=1, n_el=1
+    mesh, beam_class, material, length, *, radius=None, layers=1, n_el=1
 ):
     """Create a steel wire consisting of multiple filaments. The wire will be
     oriented in x-direction.
@@ -41,7 +41,7 @@ def create_wire_fibers(
     ----
     mesh: Mesh
         Mesh that the line will be added to.
-    beam_object: Beam
+    beam_class: Beam
         Class of beam that will be used for this line.
     material: Material
         Material for this line.
@@ -77,7 +77,7 @@ def create_wire_fibers(
         pos_yz."""
         _create_beam_mesh_line(
             mesh,
-            beam_object,
+            beam_class,
             material,
             [0.0, pos_yz[0], pos_yz[1]],
             [length, pos_yz[0], pos_yz[1]],

--- a/src/meshpy/utils/nodes.py
+++ b/src/meshpy/utils/nodes.py
@@ -21,6 +21,8 @@
 # THE SOFTWARE.
 """Helper functions to find, filter and interact with nodes."""
 
+from typing import Union as _Union
+
 import numpy as _np
 
 from meshpy.core.conf import mpy as _mpy
@@ -101,16 +103,15 @@ def get_min_max_coordinates(nodes):
     return min_max
 
 
-def get_single_node(item, *, check_cosserat_node=False):
-    """Function to get a single node from the input variable. This function
-    accepts a Node object as well as a GeometrySet object.
+def get_single_node(item: _Union[_Node, _GeometrySetBase]) -> _NodeCosserat:
+    """Function to get a single node from the input item.
 
-    Args
-    ----
-    item:
-        This can be a GeometrySet with exactly one node or a single node object.
-    check_cosserat: bool
-        If a check should be performed, that the given node is a CosseratNode.
+    Args:
+        item: This can be a GeometrySet with exactly one node or a single node object.
+
+    Returns:
+        If a single node, or a Geometry set (point set) containing a single node
+        is given, that node is returned, otherwise an error is raised.
     """
     if isinstance(item, _Node):
         node = item
@@ -126,7 +127,7 @@ def get_single_node(item, *, check_cosserat_node=False):
             f'The given object can be node or GeometrySet got "{type(item)}"!'
         )
 
-    if check_cosserat_node and not isinstance(node, _NodeCosserat):
+    if not isinstance(node, _NodeCosserat):
         raise TypeError("Expected a NodeCosserat object.")
 
     return node

--- a/tests/test_input_file_utils.py
+++ b/tests/test_input_file_utils.py
@@ -31,13 +31,13 @@ from meshpy.mesh_creation_functions.beam_basic_geometry import create_beam_mesh_
 def test_input_file_utils_get_coupled_nodes_to_master_map():
     """Test the get_coupled_nodes_to_master_map function."""
 
-    beam_object = Beam3rLine2Line2
+    beam_class = Beam3rLine2Line2
     mat = MaterialReissner(radius=0.1)
     mesh = Mesh()
-    create_beam_mesh_line(mesh, beam_object, mat, [0, 0, 0], [1, 0, 0])
-    create_beam_mesh_line(mesh, beam_object, mat, [1, 0, 0], [1, 1, 0])
-    create_beam_mesh_line(mesh, beam_object, mat, [1, 1, 0], [2, 0, 0])
-    create_beam_mesh_line(mesh, beam_object, mat, [1, 0, 0], [2, 0, 0])
+    create_beam_mesh_line(mesh, beam_class, mat, [0, 0, 0], [1, 0, 0])
+    create_beam_mesh_line(mesh, beam_class, mat, [1, 0, 0], [1, 1, 0])
+    create_beam_mesh_line(mesh, beam_class, mat, [1, 1, 0], [2, 0, 0])
+    create_beam_mesh_line(mesh, beam_class, mat, [1, 0, 0], [2, 0, 0])
 
     mesh.couple_nodes()
 

--- a/tests/test_mesh_creation_functions.py
+++ b/tests/test_mesh_creation_functions.py
@@ -647,6 +647,8 @@ def test_mesh_creation_functions_element_length_option(
 def test_mesh_creation_functions_argument_checks():
     """Test that wrong input values leads to failure."""
 
+    dummy_arg = "dummy"
+
     # Check error messages for input parameters
     with pytest.raises(
         ValueError,
@@ -670,8 +672,15 @@ def test_mesh_creation_functions_argument_checks():
     ):
         mesh = Mesh()
         # This should raise an error because node_positions_of_elements can not be used with l_el.
+
         create_beam_mesh_function(
-            mesh, l_el=1, node_positions_of_elements=[0.0, 0.5, 1.0]
+            mesh,
+            beam_object=dummy_arg,
+            material=dummy_arg,
+            function_generator=dummy_arg,
+            interval=dummy_arg,
+            l_el=1,
+            node_positions_of_elements=[0.0, 0.5, 1.0],
         )
 
     with pytest.raises(
@@ -681,7 +690,13 @@ def test_mesh_creation_functions_argument_checks():
         mesh = Mesh()
         # This should raise an error because node_positions_of_elements can not be used with n_el.
         create_beam_mesh_function(
-            mesh, n_el=1, node_positions_of_elements=[0.0, 0.5, 1.0]
+            mesh,
+            beam_object=dummy_arg,
+            material=dummy_arg,
+            function_generator=dummy_arg,
+            interval=dummy_arg,
+            n_el=1,
+            node_positions_of_elements=[0.0, 0.5, 1.0],
         )
 
     with pytest.raises(
@@ -690,7 +705,14 @@ def test_mesh_creation_functions_argument_checks():
         mesh = Mesh()
         # This should raise an error because we set `l_el` but don't provide
         # `interval_length`.
-        create_beam_mesh_function(mesh, interval=[0.0, 1.0], l_el=2.0)
+        create_beam_mesh_function(
+            mesh,
+            beam_object=dummy_arg,
+            material=dummy_arg,
+            function_generator=dummy_arg,
+            interval=[0, 1],
+            l_el=2.0,
+        )
 
     with pytest.raises(
         ValueError,
@@ -698,14 +720,28 @@ def test_mesh_creation_functions_argument_checks():
     ):
         mesh = Mesh()
         # This should raise an error because the interval [0,1] is violated.
-        create_beam_mesh_function(mesh, node_positions_of_elements=[-1.0, 0.0, 1.0])
+        create_beam_mesh_function(
+            mesh,
+            beam_object=dummy_arg,
+            material=dummy_arg,
+            function_generator=dummy_arg,
+            interval=dummy_arg,
+            node_positions_of_elements=[-1.0, 0.0, 1.0],
+        )
 
     with pytest.raises(
         ValueError, match="Last entry of node_positions_of_elements must be 1, got 2.0"
     ):
         mesh = Mesh()
         # This should raise an error because the interval [0,1] is violated.
-        create_beam_mesh_function(mesh, node_positions_of_elements=[0.0, 1.0, 2.0])
+        create_beam_mesh_function(
+            mesh,
+            beam_object=dummy_arg,
+            material=dummy_arg,
+            function_generator=dummy_arg,
+            interval=dummy_arg,
+            node_positions_of_elements=[0.0, 1.0, 2.0],
+        )
 
     with pytest.raises(
         ValueError,
@@ -715,7 +751,33 @@ def test_mesh_creation_functions_argument_checks():
     ):
         mesh = Mesh()
         # This should raise an error because the interval is not ordered.
-        create_beam_mesh_function(mesh, node_positions_of_elements=[0.0, 0.2, 0.1, 1.0])
+        create_beam_mesh_function(
+            mesh,
+            beam_object=dummy_arg,
+            material=dummy_arg,
+            function_generator=dummy_arg,
+            interval=dummy_arg,
+            node_positions_of_elements=[0.0, 0.2, 0.1, 1.0],
+        )
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            'The arguments "close_beam" and "end_node" are mutually exclusive'
+        ),
+    ):
+        mesh = Mesh()
+        # This should raise an error because the interval is not ordered.
+        create_beam_mesh_function(
+            mesh,
+            beam_object=dummy_arg,
+            material=dummy_arg,
+            function_generator=dummy_arg,
+            interval=dummy_arg,
+            n_el=1,
+            close_beam=True,
+            end_node=dummy_arg,
+        )
 
 
 def test_mesh_creation_functions_curve_3d_helix(

--- a/tests/test_mesh_creation_functions.py
+++ b/tests/test_mesh_creation_functions.py
@@ -675,7 +675,7 @@ def test_mesh_creation_functions_argument_checks():
 
         create_beam_mesh_function(
             mesh,
-            beam_object=dummy_arg,
+            beam_class=dummy_arg,
             material=dummy_arg,
             function_generator=dummy_arg,
             interval=dummy_arg,
@@ -691,7 +691,7 @@ def test_mesh_creation_functions_argument_checks():
         # This should raise an error because node_positions_of_elements can not be used with n_el.
         create_beam_mesh_function(
             mesh,
-            beam_object=dummy_arg,
+            beam_class=dummy_arg,
             material=dummy_arg,
             function_generator=dummy_arg,
             interval=dummy_arg,
@@ -707,7 +707,7 @@ def test_mesh_creation_functions_argument_checks():
         # `interval_length`.
         create_beam_mesh_function(
             mesh,
-            beam_object=dummy_arg,
+            beam_class=dummy_arg,
             material=dummy_arg,
             function_generator=dummy_arg,
             interval=[0, 1],
@@ -722,7 +722,7 @@ def test_mesh_creation_functions_argument_checks():
         # This should raise an error because the interval [0,1] is violated.
         create_beam_mesh_function(
             mesh,
-            beam_object=dummy_arg,
+            beam_class=dummy_arg,
             material=dummy_arg,
             function_generator=dummy_arg,
             interval=dummy_arg,
@@ -736,7 +736,7 @@ def test_mesh_creation_functions_argument_checks():
         # This should raise an error because the interval [0,1] is violated.
         create_beam_mesh_function(
             mesh,
-            beam_object=dummy_arg,
+            beam_class=dummy_arg,
             material=dummy_arg,
             function_generator=dummy_arg,
             interval=dummy_arg,
@@ -753,7 +753,7 @@ def test_mesh_creation_functions_argument_checks():
         # This should raise an error because the interval is not ordered.
         create_beam_mesh_function(
             mesh,
-            beam_object=dummy_arg,
+            beam_class=dummy_arg,
             material=dummy_arg,
             function_generator=dummy_arg,
             interval=dummy_arg,
@@ -770,7 +770,7 @@ def test_mesh_creation_functions_argument_checks():
         # This should raise an error because the interval is not ordered.
         create_beam_mesh_function(
             mesh,
-            beam_object=dummy_arg,
+            beam_class=dummy_arg,
             material=dummy_arg,
             function_generator=dummy_arg,
             interval=dummy_arg,

--- a/tests/test_meshpy.py
+++ b/tests/test_meshpy.py
@@ -772,11 +772,11 @@ def test_meshpy_close_beam(assert_results_equal, get_corresponding_reference_fil
             beam_sets = function(
                 input_file,
                 start_node=input_file.nodes[0],
-                end_node=True,
+                close_beam=True,
                 **(argument_list),
             )
         else:
-            beam_sets = function(input_file, end_node=True, **(argument_list))
+            beam_sets = function(input_file, close_beam=True, **(argument_list))
         input_file.add(beam_sets)
         return input_file
 

--- a/tests/test_meshpy.py
+++ b/tests/test_meshpy.py
@@ -829,7 +829,7 @@ def test_meshpy_close_beam(assert_results_equal, get_corresponding_reference_fil
             arg_angle = np.pi
             arg_n_el = n_el
         return {
-            "beam_object": Beam3rHerm2Line3,
+            "beam_class": Beam3rHerm2Line3,
             "material": mat,
             "center": [0, 0, 0],
             "axis_rotation": Rotation([0, 0, 1], arg_rot_angle),
@@ -857,7 +857,7 @@ def test_meshpy_close_beam(assert_results_equal, get_corresponding_reference_fil
             arg_interval = [np.pi, 2 * np.pi]
             arg_n_el = n_el
         return {
-            "beam_object": Beam3rHerm2Line3,
+            "beam_class": Beam3rHerm2Line3,
             "material": mat,
             "function": circle_function,
             "interval": arg_interval,

--- a/tests/test_meshpy.py
+++ b/tests/test_meshpy.py
@@ -769,15 +769,15 @@ def test_meshpy_close_beam(assert_results_equal, get_corresponding_reference_fil
         if additional_rotation is not None:
             start_rotation = additional_rotation * Rotation([0, 0, 1], np.pi * 0.5)
             input_file.add(NodeCosserat([R, 0, 0], start_rotation))
-            function(
+            beam_sets = function(
                 input_file,
                 start_node=input_file.nodes[0],
                 end_node=True,
-                add_sets=True,
                 **(argument_list),
             )
         else:
-            function(input_file, end_node=True, add_sets=True, **(argument_list))
+            beam_sets = function(input_file, end_node=True, **(argument_list))
+        input_file.add(beam_sets)
         return input_file
 
     def two_half_circles_closed(function, argument_list, additional_rotation=None):

--- a/tests/test_space_time.py
+++ b/tests/test_space_time.py
@@ -37,11 +37,11 @@ from meshpy.space_time.beam_to_space_time import beam_to_space_time, mesh_to_dat
 from tests.test_performance import PerformanceTest
 
 
-def get_name(beam_object):
+def get_name(beam_class):
     """Return the identifier for the given beam object."""
-    if beam_object == Beam3rLine2Line2:
+    if beam_class == Beam3rLine2Line2:
         return "linear"
-    elif beam_object == Beam3rHerm2Line3:
+    elif beam_class == Beam3rHerm2Line3:
         return "quadratic"
     else:
         raise TypeError("Got unexpected beam element")

--- a/tutorial/tutorial.py
+++ b/tutorial/tutorial.py
@@ -71,9 +71,9 @@ def meshpy_tutorial(base_dir, preview=False):
     # Each mesh creation function returns certain geometry sets, where boundary
     # conditions can be applied or points can be coupled.
     mat = MaterialReissner(youngs_modulus=1.0, radius=0.02)
-    beam_object = Beam3rHerm2Line3
+    beam_class = Beam3rHerm2Line3
     beam_set_1 = create_beam_mesh_line(
-        mesh, beam_object, mat, [0, 0, 0], [0, 0.5, 0], n_el=5
+        mesh, beam_class, mat, [0, 0, 0], [0, 0.5, 0], n_el=5
     )
 
     # We now add a second line, extending the first one and we give the end
@@ -83,7 +83,7 @@ def meshpy_tutorial(base_dir, preview=False):
     # i.e. corners have to be coupled via coupling conditions.
     create_beam_mesh_line(
         mesh,
-        beam_object,
+        beam_class,
         mat,
         [0, 0.5, 0],
         [0, 1.0, 0],
@@ -121,7 +121,7 @@ def meshpy_tutorial(base_dir, preview=False):
     # Now lets add a new mesh and create a circular segment.
     mesh_arc = Mesh()
     beam_set_arc = create_beam_mesh_arc_segment_2d(
-        mesh_arc, beam_object, mat, [0, 0, 0], 1, 0, np.pi / 3.0, n_el=3
+        mesh_arc, beam_class, mat, [0, 0, 0], 1, 0, np.pi / 3.0, n_el=3
     )
 
     # Opening it in ParaView, will show the arc.
@@ -155,7 +155,7 @@ def meshpy_tutorial(base_dir, preview=False):
 
     mesh_sin = Mesh()
     beam_set_sin = create_beam_mesh_curve(
-        mesh_sin, beam_object, mat, beam_sinus, [0, 2.0 * np.pi], n_el=10
+        mesh_sin, beam_class, mat, beam_sinus, [0, 2.0 * np.pi], n_el=10
     )
     mesh_sin.write_vtk("step_5", base_dir)
 
@@ -174,7 +174,7 @@ def meshpy_tutorial(base_dir, preview=False):
     # the arc.
     start = get_single_node(beam_set_arc["end"]).coordinates
     create_beam_mesh_line(
-        mesh_honeycomb, beam_object, mat, start, start + [0, 1, 0], n_el=1
+        mesh_honeycomb, beam_class, mat, start, start + [0, 1, 0], n_el=1
     )
 
     # Half of the honeycomb is now complete.


### PR DESCRIPTION
This PR removes a not needed argument to `create_beam_mesh_function` (`add_sets`). Also type hints are added, some small bugs are fixed (for `node_positions_of_elements` `n_el` was not set).