### PR TITLE
Restore header functionality of 4C input file

### DIFF
--- a/src/meshpy/core/conf.py
+++ b/src/meshpy/core/conf.py
@@ -181,14 +181,11 @@ class MeshPy(object):
 
         # Lines to be added to each created input file
         self.input_file_meshpy_header = [
-            "-" * 77,
+            "-" * 40,
             "This input file was created with MeshPy.",
-            "Copyright (c) 2018-2025",
-            "    Ivo Steinbrecher",
-            "    Institute for Mathematics and Computer-Based Simulation",
-            "    Universitaet der Bundeswehr Muenchen",
-            "    https://www.unibw.de/imcs-en",
-            "-" * 77,
+            "Copyright (c) 2018-2025 MeshPy Authors",
+            "https://imcs-compsim.github.io/meshpy/",
+            "-" * 40,
         ]
 
 

--- a/src/meshpy/four_c/input_file.py
+++ b/src/meshpy/four_c/input_file.py
@@ -23,16 +23,17 @@
 4C."""
 
 import copy as _copy
-import datetime as _datetime
 import os as _os
 import shutil as _shutil
 import subprocess as _subprocess  # nosec B404
 import sys as _sys
+from datetime import datetime as _datetime
 from pathlib import Path as _Path
 from typing import Any as _Any
 from typing import Dict as _Dict
 from typing import List as _List
 from typing import Optional as _Optional
+from typing import Tuple as _Tuple
 
 import yaml as _yaml
 
@@ -346,16 +347,25 @@ class InputFile(_Mesh):
             raise Warning(f"Section {section_name} does not exist!")
 
     def write_input_file(
-        self, file_path: _Path, *, nox_xml_file: _Optional[str] = None, **kwargs
+        self,
+        file_path: _Path,
+        *,
+        nox_xml_file: _Optional[str] = None,
+        add_application_script: _Optional[bool] = False,
+        **kwargs,
     ):
         """Write the input file to disk.
 
         Args:
-            file_path: str
+            file_path:
                 Path to the input file that should be created.
-            nox_xml_file: str
+            nox_xml_file:
                 (optional) If this argument is given, the xml file will be created
                 with this name, in the same directory as the input file.
+            add_application_script:
+                (optional) If this argument is set to True, the script that
+                created this input file will be added to the input file as a
+                comment.
         """
 
         # Check if a xml file needs to be written.
@@ -382,22 +392,28 @@ class InputFile(_Mesh):
                 width=float("inf"),
             )
 
+            # Add the application script to the input file.
+            if add_application_script:
+                application_path = _Path(_sys.argv[0]).resolve()
+                application_script_lines = self._get_application_script(
+                    application_path
+                )
+                input_file.writelines(application_script_lines)
+
     def get_dict_to_dump(
         self,
         *,
-        header: bool = True,
-        add_script_to_header: bool = True,
+        information_header: bool = False,
         check_nox: bool = True,
     ):
         """Return the dictionary representation of this input file for dumping
         to a yaml file.
 
         Args:
-            header:
-                If the header should be exported to the input file files.
-            add_script_to_header:
-                If true, a copy of the executing script will be added to the input
-                file. This is only in affect when header is True.
+            information_header:
+                If the information header should be exported to the input file
+                Contains creation date, git details of MeshPy, CubitPy and
+                original application which created the input file if available.
             check_nox:
                 If this is true, an error will be thrown if no nox file is set.
         """
@@ -412,14 +428,9 @@ class InputFile(_Mesh):
         # TODO: Check if the deepcopy makes sense to be optional
         yaml_dict = _copy.deepcopy(self.sections)
 
-        # TODO: Add header to yaml
-        # # Add header to the input file.
-        # end_text = None
-
-        # lines.extend(["// " + line for line in _mpy.input_file_meshpy_header])
-        # if header:
-        #     header_text, end_text = self._get_header(add_script_to_header)
-        #     lines.append(header_text)
+        # Add information header to the input file
+        if information_header:
+            yaml_dict["TITLE"] = self._get_header()
 
         # Check if a file has to be created for the NOX xml information.
         if self.nox_xml is not None:
@@ -622,104 +633,104 @@ class InputFile(_Mesh):
         _dump_mesh_items(yaml_dict, "NODE COORDS", self.nodes)
         _dump_mesh_items(yaml_dict, "STRUCTURE ELEMENTS", self.elements)
 
-        # TODO: what to do here - how to add the script
-        # # Add end text.
-        # if end_text is not None:
-        #     lines.append(end_text)
-
         return yaml_dict
 
-    def _get_header(self, add_script):
-        """Return the header for the input file."""
+    def _get_header(self) -> dict:
+        """Return the information header for the current MeshPy run.
 
-        def get_git_data(repo):
-            """Return the hash and date of the current git commit."""
+        Returns:
+            A dictionary with the header information.
+        """
+
+        def _get_git_data(repo_path: _Path) -> _Tuple[_Optional[str], _Optional[str]]:
+            """Return the hash and date of the current git commit.
+
+            Args:
+                repo_path: Path to the git repository.
+            Returns:
+                A tuple with the hash and date of the current git commit
+                if available, otherwise None.
+            """
             git = _shutil.which("git")
             if git is None:
                 raise RuntimeError("Git executable not found")
             out_sha = _subprocess.run(  # nosec B603
                 [git, "rev-parse", "HEAD"],
-                cwd=repo,
+                cwd=repo_path,
                 stdout=_subprocess.PIPE,
                 stderr=_subprocess.DEVNULL,
             )
             out_date = _subprocess.run(  # nosec B603
                 [git, "show", "-s", "--format=%ci"],
-                cwd=repo,
+                cwd=repo_path,
                 stdout=_subprocess.PIPE,
                 stderr=_subprocess.DEVNULL,
             )
+
             if not out_sha.returncode + out_date.returncode == 0:
                 return None, None
-            else:
-                sha = out_sha.stdout.decode("ascii").strip()
-                date = out_date.stdout.decode("ascii").strip()
-                return sha, date
 
-        headers = []
-        end_text = None
+            git_sha = out_sha.stdout.decode("ascii").strip()
+            git_date = out_date.stdout.decode("ascii").strip()
+            return git_sha, git_date
 
-        # Header containing model information.
-        current_time_string = _datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        model_header = f"// Date:       {current_time_string}\n"
-        if self.description:
-            model_header += f"// Description: {self.description}\n"
-        headers.append(model_header)
+        header: dict = {"MeshPy": {}}
 
-        # Get information about the script.
-        script_path = _os.path.realpath(_sys.argv[0])
-        script_git_sha, script_git_date = get_git_data(_os.path.dirname(script_path))
-        script_header = "// Script used to create input file:\n"
-        script_header += f"// path:       {script_path}\n"
-        if script_git_sha is not None:
-            script_header += (
-                f"// git sha:    {script_git_sha}\n// git date:   {script_git_date}\n"
-            )
-        headers.append(script_header)
-
-        # Header containing meshpy information.
-        meshpy_git_sha, meshpy_git_date = get_git_data(
-            _os.path.dirname(_os.path.realpath(__file__))
-        )
-        headers.append(
-            "// Input file created with meshpy\n"
-            f"// git sha:    {meshpy_git_sha}\n"
-            f"// git date:   {meshpy_git_date}\n"
+        header["MeshPy"]["creation_date"] = _datetime.now().isoformat(
+            sep=" ", timespec="seconds"
         )
 
+        # application which created the input file
+        application_path = _Path(_sys.argv[0]).resolve()
+        header["MeshPy"]["Application"] = {"path": str(application_path)}
+
+        application_git_sha, application_git_date = _get_git_data(
+            application_path.parent
+        )
+        if application_git_sha is not None and application_git_date is not None:
+            header["MeshPy"]["Application"] = {
+                "git_sha": application_git_sha,
+                "git_date": application_git_date,
+            }
+
+        # MeshPy information
+        meshpy_git_sha, meshpy_git_date = _get_git_data(
+            _Path(__file__).resolve().parent
+        )
+        if meshpy_git_sha is not None and meshpy_git_date is not None:
+            header["MeshPy"]["MeshPy"] = {
+                "git_SHA": meshpy_git_sha,
+                "git_date": meshpy_git_date,
+            }
+
+        # CubitPy information
         if _cubitpy_is_available():
-            # Get git information about cubitpy.
-            cubitpy_git_sha, cubitpy_git_date = get_git_data(
+            cubitpy_git_sha, cubitpy_git_date = _get_git_data(
                 _os.path.dirname(_cubitpy.__file__)
             )
 
-            if cubitpy_git_sha is not None:
-                # Cubitpy_header.
-                headers.append(
-                    "// The module cubitpy was loaded\n"
-                    f"// git sha:    {cubitpy_git_sha}\n"
-                    f"// git date:   {cubitpy_git_date}\n"
-                )
+            if cubitpy_git_sha is not None and cubitpy_git_date is not None:
+                header["MeshPy"]["CubitPy"] = {
+                    "git_SHA": cubitpy_git_sha,
+                    "git_date": cubitpy_git_date,
+                }
 
-        string_line = "// " + "".join(["-"] * 80)
+        return header
 
-        # If needed, append the contents of the script.
-        if add_script:
-            # Header for the script 'section'.
-            script_lines = [
-                string_line
-                + "\n// Full script used to create this input file.\n"
-                + string_line
-                + "\n"
-            ]
+    def _get_application_script(self, application_path: _Path) -> list[str]:
+        """Get the script that created this input file.
 
-            # Get the contents of script.
-            with open(script_path) as script_file:
-                script_lines.extend(script_file.readlines())
+        Args:
+            application_path: Path to the script that created this input file.
+        Returns:
+            A list of strings with the script that created this input file.
+        """
 
-            # Comment the python code lines.
-            end_text = "//".join(script_lines)
+        application_script_lines = [
+            "# Application script which created this input file:\n"
+        ]
 
-        return (
-            string_line + "\n" + (string_line + "\n").join(headers) + string_line
-        ), end_text
+        with open(application_path) as script_file:
+            application_script_lines.extend("# " + line for line in script_file)
+
+        return application_script_lines

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,6 +278,7 @@ def assert_results_equal(get_string, tmp_path, current_test_name) -> Callable:
         result: Union[Path, str, dict, InputFile],
         rtol: Optional[float] = None,
         atol: Optional[float] = None,
+        input_file_kwargs: dict = {"add_header_information": False, "check_nox": False},
         **kwargs,
     ) -> None:
         """Comparison between reference and result with relative or absolute
@@ -290,6 +291,8 @@ def assert_results_equal(get_string, tmp_path, current_test_name) -> Callable:
             result: The result data.
             rtol: The relative tolerance.
             atol: The absolute tolerance.
+            input_file_kwargs: Dictionary which contains the settings when
+                dumping the input file.
         """
 
         # Per default we do a string comparison of the objects. Some data types, e.g.,
@@ -341,7 +344,7 @@ def assert_results_equal(get_string, tmp_path, current_test_name) -> Callable:
 
                     return yaml.safe_load(
                         yaml.dump(
-                            data.get_dict_to_dump(check_nox=False),
+                            data.get_dict_to_dump(**input_file_kwargs),
                             Dumper=_MeshPyDumper,
                             width=float("inf"),
                         )

--- a/tests/reference-files/test_abaqus_frame_normal.inp
+++ b/tests/reference-files/test_abaqus_frame_normal.inp
@@ -1,11 +1,8 @@
-** -----------------------------------------------------------------------------
+** ----------------------------------------
 ** This input file was created with MeshPy.
-** Copyright (c) 2018-2025
-**     Ivo Steinbrecher
-**     Institute for Mathematics and Computer-Based Simulation
-**     Universitaet der Bundeswehr Muenchen
-**     https://www.unibw.de/imcs-en
-** -----------------------------------------------------------------------------
+** Copyright (c) 2018-2025 MeshPy Authors
+** https://imcs-compsim.github.io/meshpy/
+** ----------------------------------------
 *Node
      1,  0.00000000000000e+00,  0.00000000000000e+00,  0.00000000000000e+00
      2,  2.50000000000000e-01,  0.00000000000000e+00,  0.00000000000000e+00

--- a/tests/reference-files/test_abaqus_frame_normal_and_extra_node.inp
+++ b/tests/reference-files/test_abaqus_frame_normal_and_extra_node.inp
@@ -1,11 +1,8 @@
-** -----------------------------------------------------------------------------
+** ----------------------------------------
 ** This input file was created with MeshPy.
-** Copyright (c) 2018-2025
-**     Ivo Steinbrecher
-**     Institute for Mathematics and Computer-Based Simulation
-**     Universitaet der Bundeswehr Muenchen
-**     https://www.unibw.de/imcs-en
-** -----------------------------------------------------------------------------
+** Copyright (c) 2018-2025 MeshPy Authors
+** https://imcs-compsim.github.io/meshpy/
+** ----------------------------------------
 *Node
      1,  0.00000000000000e+00,  0.00000000000000e+00,  0.00000000000000e+00
      2,  2.50000000000000e-01,  0.00000000000000e+00,  0.00000000000000e+00

--- a/tests/reference-files/test_abaqus_helix_normal.inp
+++ b/tests/reference-files/test_abaqus_helix_normal.inp
@@ -1,11 +1,8 @@
-** -----------------------------------------------------------------------------
+** ----------------------------------------
 ** This input file was created with MeshPy.
-** Copyright (c) 2018-2025
-**     Ivo Steinbrecher
-**     Institute for Mathematics and Computer-Based Simulation
-**     Universitaet der Bundeswehr Muenchen
-**     https://www.unibw.de/imcs-en
-** -----------------------------------------------------------------------------
+** Copyright (c) 2018-2025 MeshPy Authors
+** https://imcs-compsim.github.io/meshpy/
+** ----------------------------------------
 *Node
      1,  5.00000000000000e-01,  0.00000000000000e+00,  0.00000000000000e+00
      2,  4.45503262094184e-01,  2.26995249869773e-01,  5.00000000000000e-02

--- a/tests/reference-files/test_abaqus_helix_normal_and_extra_node.inp
+++ b/tests/reference-files/test_abaqus_helix_normal_and_extra_node.inp
@@ -1,11 +1,8 @@
-** -----------------------------------------------------------------------------
+** ----------------------------------------
 ** This input file was created with MeshPy.
-** Copyright (c) 2018-2025
-**     Ivo Steinbrecher
-**     Institute for Mathematics and Computer-Based Simulation
-**     Universitaet der Bundeswehr Muenchen
-**     https://www.unibw.de/imcs-en
-** -----------------------------------------------------------------------------
+** Copyright (c) 2018-2025 MeshPy Authors
+** https://imcs-compsim.github.io/meshpy/
+** ----------------------------------------
 *Node
      1,  5.00000000000000e-01,  0.00000000000000e+00,  0.00000000000000e+00
      2,  4.45503262094184e-01,  2.26995249869773e-01,  5.00000000000000e-02

--- a/tests/test_four_c_simulation.py
+++ b/tests/test_four_c_simulation.py
@@ -119,7 +119,7 @@ def run_four_c_test(tmp_path, name, mesh, n_proc=2, restart=[None, None], **kwar
 
     # Create input file.
     input_file = os.path.join(testing_dir, name + ".4C.yaml")
-    mesh.write_input_file(input_file, add_script_to_header=False, **kwargs)
+    mesh.write_input_file(input_file, **kwargs)
 
     return_code = run_four_c(
         input_file,

--- a/tests/test_meshpy.py
+++ b/tests/test_meshpy.py
@@ -1256,10 +1256,6 @@ def test_meshpy_beam_to_solid_conditions(
     assert_results_equal(
         get_corresponding_reference_file_path(additional_identifier=test_type),
         input_file,
-        input_file_kwargs={
-            "check_nox": False,
-            "header": False,
-        },
     )
 
 


### PR DESCRIPTION
Add back functionality to write out information of current application which produces the input file, MeshPy, CubtPy if available

Also adds the option to extend the input file with a comment of the application that created the input file