### PR TITLE
Cleanup functionality used for dat import but no longer needed

### DIFF
--- a/src/meshpy/core/base_mesh_item.py
+++ b/src/meshpy/core/base_mesh_item.py
@@ -22,37 +22,21 @@
 """This module implements the class that will be used as the base for all items
 that are in a mesh."""
 
+from typing import Any as _Any
+from typing import Optional as _Optional
+
 
 class BaseMeshItem:
     """Base class for all objects that are related to a mesh."""
 
-    def __init__(self, data=None, comments=None):
-        """Create the object.
+    def __init__(self, data: _Optional[_Any] = None):
+        """Create the base object.
 
-        Args
-        ----
-        data: str, list(str)
-            Data for this object.
-        TODO: comments
+        Args:
+            data: General data to be stored for this item.
         """
 
         self.data = data
 
-        # Overall index of this item in the mesh.
+        # Global index of this item in a mesh.
         self.i_global = None
-
-        # Comments regarding this Mesh Item.
-        if comments is None:
-            self.comments = []
-        else:
-            self.comments = comments
-
-
-class BaseMeshItemFull(BaseMeshItem):
-    """Base class for all objects that are related to a mesh and are fully
-    created in MeshPy."""
-
-
-class BaseMeshItemString(BaseMeshItem):
-    """Base class for all objects that are imported from an input file as a
-    plain string."""

--- a/src/meshpy/core/boundary_condition.py
+++ b/src/meshpy/core/boundary_condition.py
@@ -22,13 +22,12 @@
 """This module implements a class to represent boundary conditions in
 MeshPy."""
 
-from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
-from meshpy.core.base_mesh_item import BaseMeshItemString as _BaseMeshItemString
+from meshpy.core.base_mesh_item import BaseMeshItem as _BaseMeshItem
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.container import ContainerBase as _ContainerBase
 
 
-class BoundaryConditionBase(_BaseMeshItemFull):
+class BoundaryConditionBase(_BaseMeshItem):
     """This is a base object, which represents one boundary condition in the
     input file, e.g. Dirichlet, Neumann, coupling or beam-to-solid."""
 
@@ -100,7 +99,7 @@ class BoundaryConditionContainer(_ContainerBase):
         """Initialize the container and create the default keys in the map."""
         super().__init__(*args, **kwargs)
 
-        self.item_types = [_BaseMeshItemString, BoundaryConditionBase]
+        self.item_types = [BoundaryConditionBase]
 
         for bc_key in _mpy.bc:
             for geometry_key in _mpy.geo:

--- a/src/meshpy/core/coupling.py
+++ b/src/meshpy/core/coupling.py
@@ -64,10 +64,7 @@ class Coupling(_BoundaryConditionBase):
             up when the coupling is read.
         """
 
-        if isinstance(geometry, int):
-            # This is the case if the boundary condition is read from an existing input file
-            pass
-        elif isinstance(geometry, _GeometrySetBase):
+        if isinstance(geometry, _GeometrySetBase):
             pass
         elif isinstance(geometry, list):
             geometry = _GeometrySet(geometry)

--- a/src/meshpy/core/element.py
+++ b/src/meshpy/core/element.py
@@ -23,12 +23,12 @@
 
 from typing import List as _List
 
-from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
+from meshpy.core.base_mesh_item import BaseMeshItem as _BaseMeshItem
 from meshpy.core.node import Node as _Node
 from meshpy.utils.environment import fourcipp_is_available as _fourcipp_is_available
 
 
-class Element(_BaseMeshItemFull):
+class Element(_BaseMeshItem):
     """A base class for an FEM element in the mesh."""
 
     def __init__(self, nodes=None, material=None, **kwargs):
@@ -95,7 +95,6 @@ class Element(_BaseMeshItemFull):
                     nodes=nodes,
                     string_pre_nodes=string_pre_nodes,
                     string_post_nodes=string_post_nodes,
-                    comments=input_line[1],
                 )
             case 4:
                 return _VolumeTET4(

--- a/src/meshpy/core/geometry_set.py
+++ b/src/meshpy/core/geometry_set.py
@@ -24,8 +24,7 @@ file."""
 
 import numpy as _np
 
-from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
-from meshpy.core.base_mesh_item import BaseMeshItemString as _BaseMeshItemString
+from meshpy.core.base_mesh_item import BaseMeshItem as _BaseMeshItem
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.container import ContainerBase as _ContainerBase
 from meshpy.core.element_beam import Beam as _Beam
@@ -33,7 +32,7 @@ from meshpy.core.node import Node as _Node
 from meshpy.utils.environment import fourcipp_is_available as _fourcipp_is_available
 
 
-class GeometrySetBase(_BaseMeshItemFull):
+class GeometrySetBase(_BaseMeshItem):
     """Base class for a geometry set."""
 
     # Node set names for the input file file.
@@ -348,7 +347,7 @@ class GeometrySetContainer(_ContainerBase):
         """Initialize the container and create the default keys in the map."""
         super().__init__(*args, **kwargs)
 
-        self.item_types = [_BaseMeshItemString, GeometrySetBase]
+        self.item_types = [GeometrySetBase]
 
         for geometry_key in _mpy.geo:
             self[geometry_key] = []

--- a/src/meshpy/core/material.py
+++ b/src/meshpy/core/material.py
@@ -23,10 +23,10 @@
 
 import numpy as _np
 
-from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
+from meshpy.core.base_mesh_item import BaseMeshItem as _BaseMeshItem
 
 
-class Material(_BaseMeshItemFull):
+class Material(_BaseMeshItem):
     """Base class for all materials."""
 
     def __init__(self, data=None, **kwargs):

--- a/src/meshpy/core/node.py
+++ b/src/meshpy/core/node.py
@@ -23,12 +23,12 @@
 
 import numpy as _np
 
-from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
+from meshpy.core.base_mesh_item import BaseMeshItem as _BaseMeshItem
 from meshpy.core.conf import mpy as _mpy
 from meshpy.utils.environment import fourcipp_is_available as _fourcipp_is_available
 
 
-class Node(_BaseMeshItemFull):
+class Node(_BaseMeshItem):
     """This object represents one node in the mesh."""
 
     def __init__(self, coordinates, *, is_middle_node=False, **kwargs):

--- a/src/meshpy/four_c/boundary_condition.py
+++ b/src/meshpy/four_c/boundary_condition.py
@@ -77,10 +77,6 @@ class BoundaryCondition(_BoundaryConditionBase):
         """Check for point Neumann boundaries that there is not a double Node
         in the set."""
 
-        if isinstance(self.geometry_set, int):
-            # In the case of solid imports this is a integer at initialization.
-            return
-
         if self.double_nodes is _mpy.double_nodes.keep:
             return
 

--- a/src/meshpy/four_c/function.py
+++ b/src/meshpy/four_c/function.py
@@ -22,10 +22,10 @@
 """This module implements a basic class to manage functions in the 4C input
 file."""
 
-from meshpy.core.base_mesh_item import BaseMeshItemFull as _BaseMeshItemFull
+from meshpy.core.base_mesh_item import BaseMeshItem as _BaseMeshItem
 
 
-class Function(_BaseMeshItemFull):
+class Function(_BaseMeshItem):
     """Holds information for a function."""
 
     def __init__(self, function_list):


### PR DESCRIPTION
Remove the `BaseMeshItemFull` and `BaseMeshItemString` objects as they are no longer needed. Also, clean up some parts related to dat import in geometry sets and boundary conditions.