### PR TITLE
Add converters of MeshPy rotation with numpy quaternion

### DIFF
--- a/src/meshpy/core/rotation.py
+++ b/src/meshpy/core/rotation.py
@@ -24,6 +24,7 @@
 import copy as _copy
 
 import numpy as _np
+import quaternion as _quaternion
 
 from meshpy.core.conf import mpy as _mpy
 
@@ -88,6 +89,9 @@ class Rotation:
             where we can be sure that the input quaternion is normalized to avoid
             error accumulation.
         """
+        if isinstance(q, _quaternion.quaternion):
+            q = _quaternion.as_float_array(q)
+
         rotation = object.__new__(cls)
         if normalized:
             rotation.q = _np.array(q)
@@ -195,8 +199,12 @@ class Rotation:
 
     def get_quaternion(self):
         """Return the quaternion for this rotation, as numpy array (copy)."""
-
         return _np.array(self.q)
+
+    def get_numpy_quaternion(self):
+        """Return a numpy quaternion object representing this rotation
+        (copy)."""
+        return _quaternion.from_float_array(_np.array(self.q))
 
     def get_rotation_vector(self):
         """Return the rotation vector for this object."""

--- a/src/meshpy/cosserat_curve/cosserat_curve.py
+++ b/src/meshpy/cosserat_curve/cosserat_curve.py
@@ -150,8 +150,8 @@ def get_relative_distance_and_rotations(
             _Rotation(),
             relative_distance_local,
         )
-        relative_distances_rotation[i_segment] = _quaternion.from_float_array(
-            smallest_relative_rotation_onto_distance.q
+        relative_distances_rotation[i_segment] = (
+            smallest_relative_rotation_onto_distance.get_numpy_quaternion()
         )
 
         relative_rotations[i_segment] = (
@@ -230,9 +230,7 @@ class CosseratCurve(object):
 
         # Check if we have to apply a twist for the rotations
         if starting_triad_guess is not None:
-            first_rotation = _Rotation.from_quaternion(
-                _quaternion.as_float_array(self.quaternions[0])
-            )
+            first_rotation = _Rotation.from_quaternion(self.quaternions[0])
             starting_triad_e1 = starting_triad_guess * [1, 0, 0]
             if _np.dot(first_rotation * [1, 0, 0], starting_triad_e1) < 0.5:
                 raise ValueError(
@@ -265,7 +263,7 @@ class CosseratCurve(object):
     def rotate(self, rotation: _Rotation, *, origin=None):
         """Rotate the curve and the quaternions."""
 
-        self.quaternions = _quaternion.from_float_array(rotation.q) * self.quaternions
+        self.quaternions = rotation.get_numpy_quaternion() * self.quaternions
         self.coordinates = _rotate_coordinates(
             self.coordinates, rotation, origin=origin
         )
@@ -277,9 +275,10 @@ class CosseratCurve(object):
         Args:
             twist_angle: The rotation angle (in radiants).
         """
-        material_twist_rotation = _quaternion.from_float_array(
-            _Rotation([1, 0, 0], twist_angle).q
-        )
+        material_twist_rotation = _Rotation(
+            [1, 0, 0], twist_angle
+        ).get_numpy_quaternion()
+
         self.quaternions = self.quaternions * material_twist_rotation
         self.relative_distances_rotation = (
             material_twist_rotation.conjugate()
@@ -405,9 +404,7 @@ class CosseratCurve(object):
                 sol_r[i_point] = get_spline_interpolation(
                     coordinates, self.point_arc_length
                 )(centerline_arc_length)
-                sol_q[i_point] = _quaternion.as_float_array(
-                    _quaternion.slerp_evaluate(q1, q2, xi)
-                )
+                sol_q[i_point] = _quaternion.slerp_evaluate(q1, q2, xi)
             else:
                 raise ValueError("Centerline value out of bounds")
 
@@ -431,9 +428,7 @@ class CosseratCurve(object):
             length = arc_length - self.point_arc_length[index]
             r = sol_r[index]
             q = sol_q[index]
-            sol_r_final[i] = r + _Rotation.from_quaternion(
-                _quaternion.as_float_array(q)
-            ) * [length, 0, 0]
+            sol_r_final[i] = r + _Rotation.from_quaternion(q) * [length, 0, 0]
             sol_q_final[i] = q
 
         return sol_r_final, sol_q_final

--- a/src/meshpy/cosserat_curve/cosserat_curve.py
+++ b/src/meshpy/cosserat_curve/cosserat_curve.py
@@ -277,39 +277,20 @@ class CosseratCurve(object):
         Args:
             twist_angle: The rotation angle (in radiants).
         """
-
-        material_twist_rotation = _Rotation([1, 0, 0], twist_angle)
-        # TODO: use numpy array functions for the following operations.
-        for i in range(len(self.quaternions)):
-            self.quaternions[i] = self.quaternions[i] * _quaternion.from_float_array(
-                material_twist_rotation.q
-            )
-        for i, (relative_distances_rotation, relative_rotation) in enumerate(
-            zip(self.relative_distances_rotation, self.relative_rotations)
-        ):
-            relative_distances_rotation = _Rotation.from_quaternion(
-                _quaternion.as_float_array(relative_distances_rotation)
-            )
-            relative_rotation = _Rotation.from_quaternion(
-                _quaternion.as_float_array(relative_rotation)
-            )
-
-            new_relative_distances_rotation = (
-                material_twist_rotation.inv()
-                * relative_distances_rotation
-                * material_twist_rotation
-            )
-            new_relative_rotation = (
-                material_twist_rotation.inv()
-                * relative_rotation
-                * material_twist_rotation
-            )
-            self.relative_distances_rotation[i] = _quaternion.from_float_array(
-                new_relative_distances_rotation.q
-            )
-            self.relative_rotations[i] = _quaternion.from_float_array(
-                new_relative_rotation.q
-            )
+        material_twist_rotation = _quaternion.from_float_array(
+            _Rotation([1, 0, 0], twist_angle).q
+        )
+        self.quaternions = self.quaternions * material_twist_rotation
+        self.relative_distances_rotation = (
+            material_twist_rotation.conjugate()
+            * self.relative_distances_rotation
+            * material_twist_rotation
+        )
+        self.relative_rotations = (
+            material_twist_rotation.conjugate()
+            * self.relative_rotations
+            * material_twist_rotation
+        )
 
     def get_centerline_position_and_rotation(
         self, arc_length: float, **kwargs

--- a/src/meshpy/cosserat_curve/warping_along_cosserat_curve.py
+++ b/src/meshpy/cosserat_curve/warping_along_cosserat_curve.py
@@ -207,9 +207,7 @@ def get_mesh_transformation(
             )
 
             rigid_body_rotation_for_factor = _quaternion.slerp_evaluate(
-                _quaternion.from_float_array(reference_rotation.q),
-                rigid_body_rotation,
-                factor,
+                reference_rotation.get_numpy_quaternion(), rigid_body_rotation, factor
             )
 
             current_pos = (
@@ -230,7 +228,7 @@ def get_mesh_transformation(
             relative_rotations[i_step, i_node] = (
                 rigid_body_rotation_for_factor
                 * centerline_relative_rotation
-                * _quaternion.from_float_array(reference_rotation.q).conjugate()
+                * reference_rotation.get_numpy_quaternion().conjugate()
             )
 
     return positions, relative_rotations
@@ -345,7 +343,4 @@ def warp_mesh_along_curve(
         new_pos = pos[0, i_node]
         node.coordinates = new_pos
         if isinstance(node, _NodeCosserat):
-            node.rotation = (
-                _Rotation.from_quaternion(_quaternion.as_float_array(rot[0, i_node]))
-                * node.rotation
-            )
+            node.rotation = _Rotation.from_quaternion(rot[0, i_node]) * node.rotation

--- a/src/meshpy/space_time/beam_to_space_time.py
+++ b/src/meshpy/space_time/beam_to_space_time.py
@@ -168,8 +168,6 @@ def beam_to_space_time(
         # Since the basic space meshes here contain nodes that don't have the
         # arc_length attribute by default, we have to do the following check
         # and branching.
-        # TODO: Think if it makes sense to somehow add this as a member to the
-        # default Node object.
         nodes_have_arc_length_attribute = {
             hasattr(node, "arc_length") for node in mesh_space_current_time.nodes
         }

--- a/tests/test_cosserat_curve.py
+++ b/tests/test_cosserat_curve.py
@@ -127,27 +127,16 @@ def test_cosserat_curve_translate_and_rotate(
 
     def get_compare_rot_with_twist(name):
         """Apply twist rotations to reference files."""
-        rotations = load_compare(name)
-        # TODO: use numpy array functions for this.
-        for i in range(len(rotations)):
-            rotations[i] = (
-                Rotation.from_quaternion(rotations[i]) * relative_rotation
-            ).q
+        rotations = quaternion.from_float_array(
+            load_compare(name)
+        ) * quaternion.from_float_array(relative_rotation.q)
         return rotations
 
     assert np.allclose(sol_half_pos, load_compare("pos_half_ref"), rtol=1e-14)
-    assert np.allclose(
-        quaternion.as_float_array(sol_half_q),
-        get_compare_rot_with_twist("q_half_ref"),
-        rtol=1e-14,
-    )
+    assert np.allclose(sol_half_q, get_compare_rot_with_twist("q_half_ref"), rtol=1e-14)
 
     assert np.allclose(sol_full_pos, load_compare("pos_full_ref"), rtol=1e-14)
-    assert np.allclose(
-        quaternion.as_float_array(sol_full_q),
-        get_compare_rot_with_twist("q_full_ref"),
-        rtol=1e-14,
-    )
+    assert np.allclose(sol_full_q, get_compare_rot_with_twist("q_full_ref"), rtol=1e-14)
 
 
 def test_cosserat_curve_bad_guess_triad(get_corresponding_reference_file_path):

--- a/tests/test_cosserat_curve.py
+++ b/tests/test_cosserat_curve.py
@@ -127,9 +127,10 @@ def test_cosserat_curve_translate_and_rotate(
 
     def get_compare_rot_with_twist(name):
         """Apply twist rotations to reference files."""
-        rotations = quaternion.from_float_array(
-            load_compare(name)
-        ) * quaternion.from_float_array(relative_rotation.q)
+        rotations = (
+            quaternion.from_float_array(load_compare(name))
+            * relative_rotation.get_numpy_quaternion()
+        )
         return rotations
 
     assert np.allclose(sol_half_pos, load_compare("pos_half_ref"), rtol=1e-14)
@@ -193,7 +194,7 @@ def test_cosserat_curve_mesh_transformation(
 
     curve = load_cosserat_curve_from_file(get_corresponding_reference_file_path)
     pos, rot = curve.get_centerline_position_and_rotation(0)
-    rot = Rotation.from_quaternion(quaternion.as_float_array(rot))
+    rot = Rotation.from_quaternion(rot)
     curve.translate(-pos)
     curve.translate([1, 2, 3])
 
@@ -224,7 +225,7 @@ def test_cosserat_curve_mesh_warp(
     # Load the curve
     curve = load_cosserat_curve_from_file(get_corresponding_reference_file_path)
     pos, rot = curve.get_centerline_position_and_rotation(0)
-    rot = Rotation.from_quaternion(quaternion.as_float_array(rot))
+    rot = Rotation.from_quaternion(rot)
     curve.translate(-pos)
     curve.translate([1, 2, 3])
 
@@ -252,7 +253,7 @@ def test_cosserat_curve_mesh_warp_transform_boundary_conditions(
     # Load the curve
     curve = load_cosserat_curve_from_file(get_corresponding_reference_file_path)
     pos, rot = curve.get_centerline_position_and_rotation(0)
-    rot = Rotation.from_quaternion(quaternion.as_float_array(rot))
+    rot = Rotation.from_quaternion(rot)
     curve.translate(-pos)
     curve.translate([1, 2, 3])
 


### PR DESCRIPTION
Add controlled converters between the MeshPy quaternion implementation and the numpy quaternion package.

In the future we can think if we want to completely get rid of the quaternion dependency or make it the core data structure of the `Rotation` class.