### PR TITLE
Remove mesh from input file and rework input file read in mechanism

### DIFF
--- a/src/meshpy/core/conf.py
+++ b/src/meshpy/core/conf.py
@@ -156,9 +156,6 @@ class MeshPy(object):
         # match.
         self.allow_beam_rotation = True
 
-        # Import meshes as pure dict or import the geometry.
-        self.import_mesh_full = False
-
         # Number of digits for node set output (this will be set in the
         # Mesh.get_unique_geometry_sets() method.
         self.vtk_node_set_format = "{:05}"

--- a/src/meshpy/four_c/beam_potential.py
+++ b/src/meshpy/four_c/beam_potential.py
@@ -23,6 +23,7 @@
 interaction potentials."""
 
 from meshpy.core.boundary_condition import BoundaryCondition as _BoundaryCondition
+from meshpy.core.mesh import Mesh as _Mesh
 
 
 class BeamPotential:
@@ -32,6 +33,7 @@ class BeamPotential:
     def __init__(
         self,
         input_file,
+        mesh,
         *,
         pot_law_prefactor=None,
         pot_law_exponent=None,
@@ -44,6 +46,8 @@ class BeamPotential:
         ----
         input_file:
             Input file of current problem setup.
+        mesh:
+            Mesh object of current problem setup.
         pot_law_prefactors: float, int, _np.array, list
             Prefactors of a potential law in form of a power law. Same number
             of prefactors and exponents/line charge densities/functions must be
@@ -63,6 +67,7 @@ class BeamPotential:
         """
 
         self.input_file = input_file
+        self.mesh = mesh
 
         # if only one potential law prefactor/exponent is present, convert it
         # into a list for simplified usage
@@ -230,7 +235,7 @@ class BeamPotential:
             )
         ):
             if func != "none":
-                self.input_file.add(func)
+                self.mesh.add(func)
 
             bc = _BoundaryCondition(
                 geometry_set,
@@ -238,4 +243,4 @@ class BeamPotential:
                 bc_type="DESIGN LINE BEAM POTENTIAL CHARGE CONDITIONS",
             )
 
-            self.input_file.add(bc)
+            self.mesh.add(bc)

--- a/src/meshpy/four_c/input_file.py
+++ b/src/meshpy/four_c/input_file.py
@@ -33,63 +33,28 @@ from typing import Dict as _Dict
 from typing import List as _List
 from typing import Optional as _Optional
 from typing import Tuple as _Tuple
-from typing import TypeVar as _TypeVar
-from typing import Union as _Union
 
 import yaml as _yaml
 
-import meshpy.core.conf as _conf
 from meshpy.core.boundary_condition import BoundaryCondition as _BoundaryCondition
-from meshpy.core.boundary_condition import (
-    BoundaryConditionBase as _BoundaryConditionBase,
-)
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.container import ContainerBase as _ContainerBase
-from meshpy.core.coupling import Coupling as _Coupling
-from meshpy.core.element import Element as _Element
 from meshpy.core.geometry_set import GeometryName as _GeometryName
-from meshpy.core.geometry_set import GeometrySetNodes as _GeometrySetNodes
 from meshpy.core.mesh import Mesh as _Mesh
-from meshpy.core.node import Node as _Node
 from meshpy.core.nurbs_patch import NURBSPatch as _NURBSPatch
+from meshpy.four_c.input_file_mappings import (
+    boundary_condition_names as _boundary_condition_names,
+)
+from meshpy.four_c.input_file_mappings import geometry_set_names as _geometry_set_names
 from meshpy.four_c.yaml_dumper import MeshPyDumper as _MeshPyDumper
 from meshpy.utils.environment import cubitpy_is_available as _cubitpy_is_available
 from meshpy.utils.environment import fourcipp_is_available as _fourcipp_is_available
-
-# necessary to allow for type hint of from_4C_yaml for python version <3.11
-# can be replaced with _Self in python 3.11
-T = _TypeVar("T", bound="InputFile")
 
 if _cubitpy_is_available():
     import cubitpy as _cubitpy
 
 
-def _boundary_condition_from_dict(
-    geometry_set: _GeometrySetNodes,
-    bc_key: _Union[_conf.BoundaryCondition, str],
-    data: _Dict,
-) -> _BoundaryConditionBase:
-    """This function acts as a factory and creates the correct boundary
-    condition object from a dictionary parsed from an input file."""
-
-    del data["E"]
-
-    if bc_key in (
-        _mpy.bc.dirichlet,
-        _mpy.bc.neumann,
-        _mpy.bc.locsys,
-        _mpy.bc.beam_to_solid_surface_meshtying,
-        _mpy.bc.beam_to_solid_surface_contact,
-        _mpy.bc.beam_to_solid_volume_meshtying,
-    ) or isinstance(bc_key, str):
-        return _BoundaryCondition(geometry_set, data, bc_type=bc_key)
-    elif bc_key is _mpy.bc.point_coupling:
-        return _Coupling(geometry_set, bc_key, data, check_overlapping_nodes=False)
-    else:
-        raise ValueError("Got unexpected boundary condition!")
-
-
-def _get_geometry_set_indices_from_section(
+def get_geometry_set_indices_from_section(
     section_list: _List, *, append_node_ids: bool = True
 ) -> _Dict:
     """Return a dictionary with the geometry set ID as keys and the node IDs as
@@ -116,96 +81,11 @@ def _get_geometry_set_indices_from_section(
     return geometry_set_dict
 
 
-def _get_yaml_geometry_sets(
-    nodes: _List[_Node], geometry_key: _conf.Geometry, section_list: _List
-) -> _Dict[int, _GeometrySetNodes]:
-    """Add sets of points, lines, surfaces or volumes to the object."""
-
-    # Create the individual geometry sets. The nodes are still integers at this
-    # point. They have to be converted to links to the actual nodes later on.
-    geometry_set_dict = _get_geometry_set_indices_from_section(section_list)
-    geometry_sets_in_this_section = {}
-    for geometry_set_id, node_ids in geometry_set_dict.items():
-        geometry_sets_in_this_section[geometry_set_id] = _GeometrySetNodes(
-            geometry_key, nodes=[nodes[node_id] for node_id in node_ids]
-        )
-    return geometry_sets_in_this_section
-
-
 class InputFile:
     """An item that represents a complete 4C input file."""
 
-    # Define the names of sections and boundary conditions in the input file.
-    geometry_set_names = {
-        _mpy.geo.point: "DNODE-NODE TOPOLOGY",
-        _mpy.geo.line: "DLINE-NODE TOPOLOGY",
-        _mpy.geo.surface: "DSURF-NODE TOPOLOGY",
-        _mpy.geo.volume: "DVOL-NODE TOPOLOGY",
-    }
-    boundary_condition_names = {
-        (_mpy.bc.dirichlet, _mpy.geo.point): "DESIGN POINT DIRICH CONDITIONS",
-        (_mpy.bc.dirichlet, _mpy.geo.line): "DESIGN LINE DIRICH CONDITIONS",
-        (_mpy.bc.dirichlet, _mpy.geo.surface): "DESIGN SURF DIRICH CONDITIONS",
-        (_mpy.bc.dirichlet, _mpy.geo.volume): "DESIGN VOL DIRICH CONDITIONS",
-        (_mpy.bc.locsys, _mpy.geo.point): "DESIGN POINT LOCSYS CONDITIONS",
-        (_mpy.bc.locsys, _mpy.geo.line): "DESIGN LINE LOCSYS CONDITIONS",
-        (_mpy.bc.locsys, _mpy.geo.surface): "DESIGN SURF LOCSYS CONDITIONS",
-        (_mpy.bc.locsys, _mpy.geo.volume): "DESIGN VOL LOCSYS CONDITIONS",
-        (_mpy.bc.neumann, _mpy.geo.point): "DESIGN POINT NEUMANN CONDITIONS",
-        (_mpy.bc.neumann, _mpy.geo.line): "DESIGN LINE NEUMANN CONDITIONS",
-        (_mpy.bc.neumann, _mpy.geo.surface): "DESIGN SURF NEUMANN CONDITIONS",
-        (_mpy.bc.neumann, _mpy.geo.volume): "DESIGN VOL NEUMANN CONDITIONS",
-        (
-            _mpy.bc.moment_euler_bernoulli,
-            _mpy.geo.point,
-        ): "DESIGN POINT MOMENT EB CONDITIONS",
-        (
-            _mpy.bc.beam_to_solid_volume_meshtying,
-            _mpy.geo.line,
-        ): "BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING LINE",
-        (
-            _mpy.bc.beam_to_solid_volume_meshtying,
-            _mpy.geo.volume,
-        ): "BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING VOLUME",
-        (
-            _mpy.bc.beam_to_solid_surface_meshtying,
-            _mpy.geo.line,
-        ): "BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING LINE",
-        (
-            _mpy.bc.beam_to_solid_surface_meshtying,
-            _mpy.geo.surface,
-        ): "BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING SURFACE",
-        (
-            _mpy.bc.beam_to_solid_surface_contact,
-            _mpy.geo.line,
-        ): "BEAM INTERACTION/BEAM TO SOLID SURFACE CONTACT LINE",
-        (
-            _mpy.bc.beam_to_solid_surface_contact,
-            _mpy.geo.surface,
-        ): "BEAM INTERACTION/BEAM TO SOLID SURFACE CONTACT SURFACE",
-        (_mpy.bc.point_coupling, _mpy.geo.point): "DESIGN POINT COUPLING CONDITIONS",
-        (
-            _mpy.bc.beam_to_beam_contact,
-            _mpy.geo.line,
-        ): "BEAM INTERACTION/BEAM TO BEAM CONTACT CONDITIONS",
-        (
-            _mpy.bc.point_coupling_penalty,
-            _mpy.geo.point,
-        ): "DESIGN POINT PENALTY COUPLING CONDITIONS",
-        (
-            "DESIGN SURF MORTAR CONTACT CONDITIONS 3D",
-            _mpy.geo.surface,
-        ): "DESIGN SURF MORTAR CONTACT CONDITIONS 3D",
-    }
-
-    def __init__(self, *, cubit=None):
-        """Initialize the input file.
-
-        Args:
-            cubit:
-                A cubit object, that contains an input file which will be loaded
-                into this input file.
-        """
+    def __init__(self):
+        """Initialize the input file."""
 
         # Everything that is not a full MeshPy object is stored here, e.g., parameters
         # and imported nodes/elements/materials/...
@@ -213,131 +93,6 @@ class InputFile:
 
         # Contents of NOX xml file.
         self.nox_xml_contents = ""
-
-        # TODO fix once cubit is converted to YAML
-        # if cubit is not None:
-        #     self._read_dat_lines(cubit.get_dat_lines())
-
-    @classmethod
-    def from_4C_yaml(
-        cls: type[T], input_file_path: _Path, convert_input_to_mesh: bool = False
-    ) -> _Tuple[T, _Mesh]:
-        """Read an existing input file and optionally convert it into a MeshPy
-        mesh.
-
-        Args:
-            input_file_path: A file path to an existing input file that will be read
-                into this object.
-            convert_input_to_mesh: If True, the input file will be converted to a
-                MeshPy mesh.
-
-        Returns:
-            A tuple with the input file and the mesh. If convert_input_to_mesh is
-            False, the mesh will be empty.
-        """
-
-        if _fourcipp_is_available():
-            raise ValueError("Use fourcipp to parse the yaml file.")
-
-        instance = cls()
-
-        with open(input_file_path) as stream:
-            instance.sections = _yaml.safe_load(stream)
-
-        if convert_input_to_mesh:
-            return instance, instance.sections_to_mesh()
-        else:
-            return instance, _Mesh()
-
-    def sections_to_mesh(self):
-        """Convert mesh items, e.g., nodes, elements, element sets, node sets,
-        boundary conditions, materials, ...
-
-        Note: In the current implementation we cannibalize the mesh sections in
-            the self.sections dictionary. This should be reconsidered and be done
-            in a better way when this function is generalized.
-
-        to "true" MeshPy objects.
-        """
-
-        def _get_section_items(section_name):
-            """Return the items in a given section.
-
-            Since we will add the created MeshPy objects to the mesh, we
-            delete them from the plain data storage to avoid having
-            duplicate entries.
-            """
-            if section_name in self.sections:
-                return_list = self.sections[section_name]
-                self.sections[section_name] = []
-            else:
-                return_list = []
-            return return_list
-
-        # Go through all sections that have to be converted to full MeshPy objects
-        mesh = _Mesh()
-
-        # Add nodes
-        for item in _get_section_items("NODE COORDS"):
-            mesh.nodes.append(_Node.from_legacy_string(item))
-
-        # Add elements
-        for item in _get_section_items("STRUCTURE ELEMENTS"):
-            if _fourcipp_is_available():
-                raise ValueError(
-                    "Port this functionality to not use the legacy string."
-                )
-
-            # Get a list containing the element nodes.
-            element_nodes = []
-            for split_item in item.split()[3:]:
-                if split_item.isdigit():
-                    node_id = int(split_item) - 1
-                    element_nodes.append(mesh.nodes[node_id])
-                else:
-                    break
-            else:
-                raise ValueError(
-                    f'The input line:\n"{item}"\ncould not be converted to a element!'
-                )
-
-            mesh.elements.append(_Element.from_legacy_string(element_nodes, item))
-
-        # Add geometry sets
-        geometry_sets_in_sections = {key: None for key in _mpy.geo}
-        for section_name in self.sections.keys():
-            if section_name.endswith("TOPOLOGY"):
-                section_items = _get_section_items(section_name)
-                if len(section_items) > 0:
-                    # Get the geometry key for this set
-                    for key, value in self.geometry_set_names.items():
-                        if value == section_name:
-                            geometry_key = key
-                            break
-                    else:
-                        raise ValueError(f"Could not find the set {section_name}")
-                    geometry_sets_in_section = _get_yaml_geometry_sets(
-                        mesh.nodes, geometry_key, section_items
-                    )
-                    geometry_sets_in_sections[geometry_key] = geometry_sets_in_section
-                    mesh.geometry_sets[geometry_key] = list(
-                        geometry_sets_in_section.values()
-                    )
-
-        # Add boundary conditions
-        for (
-            bc_key,
-            geometry_key,
-        ), section_name in self.boundary_condition_names.items():
-            for item in _get_section_items(section_name):
-                geometry_set_id = item["E"]
-                geometry_set = geometry_sets_in_sections[geometry_key][geometry_set_id]
-                mesh.boundary_conditions.append(
-                    (bc_key, geometry_key),
-                    _boundary_condition_from_dict(geometry_set, bc_key, item),
-                )
-
-        return mesh
 
     def add(self, *args, **kwargs):
         """Add to this object.
@@ -481,12 +236,12 @@ class InputFile:
             """Get the indices for the first "real" MeshPy geometry sets."""
 
             start_indices_geometry_set = {}
-            for geometry_type, section_name in self.geometry_set_names.items():
+            for geometry_type, section_name in _geometry_set_names.items():
                 max_geometry_set_id = 0
                 if section_name in dictionary:
                     section_list = dictionary[section_name]
                     if len(section_list) > 0:
-                        geometry_set_dict = _get_geometry_set_indices_from_section(
+                        geometry_set_dict = get_geometry_set_indices_from_section(
                             section_list, append_node_ids=False
                         )
                         max_geometry_set_id = max(geometry_set_dict.keys())
@@ -657,7 +412,7 @@ class InputFile:
                 section_name = (
                     bc_key
                     if isinstance(bc_key, str)
-                    else self.boundary_condition_names[bc_key, geom_key]
+                    else _boundary_condition_names[bc_key, geom_key]
                 )
                 _dump_mesh_items(self.sections, section_name, bc_list)
 
@@ -668,7 +423,7 @@ class InputFile:
         # Add the geometry sets.
         for geom_key, item in mesh_sets.items():
             if len(item) > 0:
-                _dump_mesh_items(self.sections, self.geometry_set_names[geom_key], item)
+                _dump_mesh_items(self.sections, _geometry_set_names[geom_key], item)
 
         # Add the nodes and elements.
         _dump_mesh_items(self.sections, "NODE COORDS", mesh.nodes)

--- a/src/meshpy/four_c/input_file.py
+++ b/src/meshpy/four_c/input_file.py
@@ -106,7 +106,7 @@ class InputFile:
         # the super method directly
 
         if isinstance(object_to_add, _Mesh):
-            self.add_mesh_to_dict(mesh=object_to_add, **kwargs)
+            self.add_mesh_to_input_file(mesh=object_to_add, **kwargs)
 
         elif isinstance(object_to_add, dict):
             self.add_section(object_to_add, **kwargs)
@@ -156,8 +156,8 @@ class InputFile:
         *,
         nox_xml_file: bool | str = False,
         add_header_default: bool = True,
+        add_header_information: bool = True,
         add_footer_application_script: bool = True,
-        **kwargs,
     ):
         """Write the input file to disk.
 
@@ -171,6 +171,10 @@ class InputFile:
                 input file with the extension ".xml".
             add_header_default:
                 Prepend the default MeshPy header comment to the input file.
+            add_header_information:
+                If the information header should be exported to the input file
+                Contains creation date, git details of MeshPy, CubitPy and
+                original application which created the input file if available.
             add_footer_application_script:
                 Append the application script which creates the input files as a
                 comment at the end of the input file.
@@ -191,6 +195,10 @@ class InputFile:
                 _os.path.join(_os.path.dirname(file_path), xml_file_name), "w"
             ) as xml_file:
                 xml_file.write(self.nox_xml_contents)
+
+        # Add information header to the input file
+        if add_header_information:
+            self.sections["TITLE"] = self._get_header()
 
         with open(file_path, "w") as input_file:
             # write MeshPy header
@@ -214,29 +222,16 @@ class InputFile:
                 )
                 input_file.writelines(application_script_lines)
 
-    def add_mesh_to_dict(
-        self,
-        mesh: _Mesh,
-        *,
-        add_header_information: bool = True,
-    ):
-        """Return the dictionary representation of this input file for dumping
-        to a yaml file.
+    def add_mesh_to_input_file(self, mesh: _Mesh):
+        """Add a mesh to the input file.
 
         Args:
-            add_header_information:
-                If the information header should be exported to the input file
-                Contains creation date, git details of MeshPy, CubitPy and
-                original application which created the input file if available.
+            mesh: The mesh to be added to the input file.
         """
 
         # Perform some checks on the mesh.
         if _mpy.check_overlapping_elements:
             mesh.check_overlapping_elements()
-
-        # Add information header to the input file
-        if add_header_information:
-            self.sections["TITLE"] = self._get_header()
 
         def _get_global_start_geometry_set(dictionary):
             """Get the indices for the first "real" MeshPy geometry sets."""

--- a/src/meshpy/four_c/input_file.py
+++ b/src/meshpy/four_c/input_file.py
@@ -185,6 +185,8 @@ class InputFile:
                 xml_file_name = _os.path.splitext(file_path)[0] + ".xml"
             elif isinstance(nox_xml_file, str):
                 xml_file_name = nox_xml_file
+            else:
+                raise TypeError("nox_xml_file must be a string or a boolean value.")
 
             self.sections["STRUCT NOX/Status Test"] = {"XML File": xml_file_name}
 
@@ -427,6 +429,7 @@ class InputFile:
         # Add the nodes and elements.
         _dump_mesh_items(self.sections, "NODE COORDS", mesh.nodes)
         _dump_mesh_items(self.sections, "STRUCTURE ELEMENTS", mesh.elements)
+        # TODO: reset all links and counters set in this method.
 
     def _get_header(self) -> dict:
         """Return the information header for the current MeshPy run.

--- a/src/meshpy/four_c/input_file.py
+++ b/src/meshpy/four_c/input_file.py
@@ -38,8 +38,6 @@ import yaml as _yaml
 
 from meshpy.core.boundary_condition import BoundaryCondition as _BoundaryCondition
 from meshpy.core.conf import mpy as _mpy
-from meshpy.core.container import ContainerBase as _ContainerBase
-from meshpy.core.geometry_set import GeometryName as _GeometryName
 from meshpy.core.mesh import Mesh as _Mesh
 from meshpy.core.nurbs_patch import NURBSPatch as _NURBSPatch
 from meshpy.four_c.input_file_mappings import (

--- a/src/meshpy/four_c/input_file.py
+++ b/src/meshpy/four_c/input_file.py
@@ -94,22 +94,28 @@ class InputFile:
         # Contents of NOX xml file.
         self.nox_xml_contents = ""
 
-    def add(self, *args, **kwargs):
-        """Add to this object.
+    def add(self, object_to_add, **kwargs):
+        """Add a mesh or a dictionary to the input file.
 
-        If the type is not recognized, the child add method is called.
+        Args:
+            object: The object to be added. This can be a mesh or a dictionary.
+            **kwargs: Additional arguments to be passed to the add method.
         """
-        if len(args) == 1 and isinstance(args[0], dict):
-            # TODO: We have to check here if the item is not of any of the types we
-            # use that derive from dict, as they should be added in super().add
-            if not isinstance(args[0], _ContainerBase) and not isinstance(
-                args[0], _GeometryName
-            ):
-                self.add_section(args[0], **kwargs)
-                return
 
-        # convert mesh to dict and recall add
-        self.add_mesh_to_dict(mesh=args[0], **kwargs)
+        # TODO rework this once fourcipp is available to call
+        # the super method directly
+
+        if isinstance(object_to_add, _Mesh):
+            self.add_mesh_to_dict(mesh=object_to_add, **kwargs)
+
+        elif isinstance(object_to_add, dict):
+            self.add_section(object_to_add, **kwargs)
+
+        else:
+            raise TypeError(
+                f"Cannot add object of type {type(object_to_add)} to the input file."
+                " Only MeshPy meshes and dictionaries are supported."
+            )
 
     def add_section(self, section, *, option_overwrite=False):
         """Add a section to the object.

--- a/src/meshpy/four_c/input_file.py
+++ b/src/meshpy/four_c/input_file.py
@@ -32,8 +32,8 @@ from typing import Any as _Any
 from typing import Dict as _Dict
 from typing import List as _List
 from typing import Optional as _Optional
-from typing import Self as _Self
 from typing import Tuple as _Tuple
+from typing import TypeVar as _TypeVar
 from typing import Union as _Union
 
 import yaml as _yaml
@@ -55,6 +55,10 @@ from meshpy.core.nurbs_patch import NURBSPatch as _NURBSPatch
 from meshpy.four_c.yaml_dumper import MeshPyDumper as _MeshPyDumper
 from meshpy.utils.environment import cubitpy_is_available as _cubitpy_is_available
 from meshpy.utils.environment import fourcipp_is_available as _fourcipp_is_available
+
+# necessary to allow for type hint of from_4C_yaml for python version <3.11
+# can be replaced with _Self in python 3.11
+T = _TypeVar("T", bound="InputFile")
 
 if _cubitpy_is_available():
     import cubitpy as _cubitpy
@@ -217,8 +221,8 @@ class InputFile:
 
     @classmethod
     def from_4C_yaml(
-        cls, input_file_path: _Path, convert_input_to_mesh: bool = False
-    ) -> _Tuple[_Self, _Mesh]:
+        cls: type[T], input_file_path: _Path, convert_input_to_mesh: bool = False
+    ) -> _Tuple[T, _Mesh]:
         """Read an existing input file and optionally convert it into a MeshPy
         mesh.
 

--- a/src/meshpy/four_c/input_file_mappings.py
+++ b/src/meshpy/four_c/input_file_mappings.py
@@ -1,0 +1,88 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2025 MeshPy Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""This file provides the mappings between MeshPy objects and 4C input
+files."""
+
+from meshpy.core.conf import mpy as _mpy
+
+# Define the names of sections and boundary conditions in the input file.
+geometry_set_names = {
+    _mpy.geo.point: "DNODE-NODE TOPOLOGY",
+    _mpy.geo.line: "DLINE-NODE TOPOLOGY",
+    _mpy.geo.surface: "DSURF-NODE TOPOLOGY",
+    _mpy.geo.volume: "DVOL-NODE TOPOLOGY",
+}
+boundary_condition_names = {
+    (_mpy.bc.dirichlet, _mpy.geo.point): "DESIGN POINT DIRICH CONDITIONS",
+    (_mpy.bc.dirichlet, _mpy.geo.line): "DESIGN LINE DIRICH CONDITIONS",
+    (_mpy.bc.dirichlet, _mpy.geo.surface): "DESIGN SURF DIRICH CONDITIONS",
+    (_mpy.bc.dirichlet, _mpy.geo.volume): "DESIGN VOL DIRICH CONDITIONS",
+    (_mpy.bc.locsys, _mpy.geo.point): "DESIGN POINT LOCSYS CONDITIONS",
+    (_mpy.bc.locsys, _mpy.geo.line): "DESIGN LINE LOCSYS CONDITIONS",
+    (_mpy.bc.locsys, _mpy.geo.surface): "DESIGN SURF LOCSYS CONDITIONS",
+    (_mpy.bc.locsys, _mpy.geo.volume): "DESIGN VOL LOCSYS CONDITIONS",
+    (_mpy.bc.neumann, _mpy.geo.point): "DESIGN POINT NEUMANN CONDITIONS",
+    (_mpy.bc.neumann, _mpy.geo.line): "DESIGN LINE NEUMANN CONDITIONS",
+    (_mpy.bc.neumann, _mpy.geo.surface): "DESIGN SURF NEUMANN CONDITIONS",
+    (_mpy.bc.neumann, _mpy.geo.volume): "DESIGN VOL NEUMANN CONDITIONS",
+    (
+        _mpy.bc.moment_euler_bernoulli,
+        _mpy.geo.point,
+    ): "DESIGN POINT MOMENT EB CONDITIONS",
+    (
+        _mpy.bc.beam_to_solid_volume_meshtying,
+        _mpy.geo.line,
+    ): "BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING LINE",
+    (
+        _mpy.bc.beam_to_solid_volume_meshtying,
+        _mpy.geo.volume,
+    ): "BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING VOLUME",
+    (
+        _mpy.bc.beam_to_solid_surface_meshtying,
+        _mpy.geo.line,
+    ): "BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING LINE",
+    (
+        _mpy.bc.beam_to_solid_surface_meshtying,
+        _mpy.geo.surface,
+    ): "BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING SURFACE",
+    (
+        _mpy.bc.beam_to_solid_surface_contact,
+        _mpy.geo.line,
+    ): "BEAM INTERACTION/BEAM TO SOLID SURFACE CONTACT LINE",
+    (
+        _mpy.bc.beam_to_solid_surface_contact,
+        _mpy.geo.surface,
+    ): "BEAM INTERACTION/BEAM TO SOLID SURFACE CONTACT SURFACE",
+    (_mpy.bc.point_coupling, _mpy.geo.point): "DESIGN POINT COUPLING CONDITIONS",
+    (
+        _mpy.bc.beam_to_beam_contact,
+        _mpy.geo.line,
+    ): "BEAM INTERACTION/BEAM TO BEAM CONTACT CONDITIONS",
+    (
+        _mpy.bc.point_coupling_penalty,
+        _mpy.geo.point,
+    ): "DESIGN POINT PENALTY COUPLING CONDITIONS",
+    (
+        "DESIGN SURF MORTAR CONTACT CONDITIONS 3D",
+        _mpy.geo.surface,
+    ): "DESIGN SURF MORTAR CONTACT CONDITIONS 3D",
+}

--- a/src/meshpy/four_c/model_importer.py
+++ b/src/meshpy/four_c/model_importer.py
@@ -1,0 +1,221 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2025 MeshPy Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""This module contains functions to load and parse existing 4C input files."""
+
+from pathlib import Path as _Path
+from typing import Dict as _Dict
+from typing import List as _List
+from typing import Tuple as _Tuple
+from typing import Union as _Union
+
+import yaml as _yaml
+
+import meshpy.core.conf as _conf
+from meshpy.core.boundary_condition import BoundaryCondition as _BoundaryCondition
+from meshpy.core.boundary_condition import (
+    BoundaryConditionBase as _BoundaryConditionBase,
+)
+from meshpy.core.conf import mpy as _mpy
+from meshpy.core.coupling import Coupling as _Coupling
+from meshpy.core.element import Element as _Element
+from meshpy.core.geometry_set import GeometrySetNodes as _GeometrySetNodes
+from meshpy.core.mesh import Mesh as _Mesh
+from meshpy.core.node import Node as _Node
+from meshpy.four_c.input_file import InputFile as _InputFile
+from meshpy.four_c.input_file import (
+    get_geometry_set_indices_from_section as _get_geometry_set_indices_from_section,
+)
+from meshpy.four_c.input_file_mappings import (
+    boundary_condition_names as _boundary_condition_names,
+)
+from meshpy.four_c.input_file_mappings import geometry_set_names as _geometry_set_names
+from meshpy.utils.environment import fourcipp_is_available as _fourcipp_is_available
+
+
+def import_4C_model(
+    input_file_path: _Path, convert_input_to_mesh: bool = False
+) -> _Tuple[_InputFile, _Mesh]:
+    """Import an existing 4C input file and optionally convert it into a MeshPy
+    mesh.
+
+    Args:
+        input_file_path: A file path to an existing 4C input file that will be
+            imported.
+        convert_input_to_mesh: If True, the input file will be converted to a
+            MeshPy mesh.
+
+    Returns:
+        A tuple with the input file and the mesh. If convert_input_to_mesh is
+        False, the mesh will be empty. Note that the input sections which are
+        converted to a MeshPy mesh are removed from the input file object.
+    """
+
+    if _fourcipp_is_available():
+        raise ValueError("Use fourcipp to parse the yaml file.")
+
+    with open(input_file_path) as stream:
+        input_file = _InputFile()
+        input_file.sections = _yaml.safe_load(stream)
+
+    if convert_input_to_mesh:
+        return sections_to_mesh(input_file)
+    else:
+        return input_file, _Mesh()
+
+
+def boundary_condition_from_dict(
+    geometry_set: _GeometrySetNodes,
+    bc_key: _Union[_conf.BoundaryCondition, str],
+    data: _Dict,
+) -> _BoundaryConditionBase:
+    """This function acts as a factory and creates the correct boundary
+    condition object from a dictionary parsed from an input file."""
+
+    del data["E"]
+
+    if bc_key in (
+        _mpy.bc.dirichlet,
+        _mpy.bc.neumann,
+        _mpy.bc.locsys,
+        _mpy.bc.beam_to_solid_surface_meshtying,
+        _mpy.bc.beam_to_solid_surface_contact,
+        _mpy.bc.beam_to_solid_volume_meshtying,
+    ) or isinstance(bc_key, str):
+        return _BoundaryCondition(geometry_set, data, bc_type=bc_key)
+    elif bc_key is _mpy.bc.point_coupling:
+        return _Coupling(geometry_set, bc_key, data, check_overlapping_nodes=False)
+    else:
+        raise ValueError("Got unexpected boundary condition!")
+
+
+def get_yaml_geometry_sets(
+    nodes: _List[_Node], geometry_key: _conf.Geometry, section_list: _List
+) -> _Dict[int, _GeometrySetNodes]:
+    """Add sets of points, lines, surfaces or volumes to the object."""
+
+    # Create the individual geometry sets. The nodes are still integers at this
+    # point. They have to be converted to links to the actual nodes later on.
+    geometry_set_dict = _get_geometry_set_indices_from_section(section_list)
+    geometry_sets_in_this_section = {}
+    for geometry_set_id, node_ids in geometry_set_dict.items():
+        geometry_sets_in_this_section[geometry_set_id] = _GeometrySetNodes(
+            geometry_key, nodes=[nodes[node_id] for node_id in node_ids]
+        )
+    return geometry_sets_in_this_section
+
+
+def sections_to_mesh(input_file: _InputFile) -> _Tuple[_InputFile, _Mesh]:
+    """Convert an existing input file to a MeshPy mesh with mesh items, e.g.,
+    nodes, elements, element sets, node sets, boundary conditions, materials.
+
+    Note: In the current implementation we cannibalize the mesh sections in
+        the self.sections dictionary. This should be reconsidered and be done
+        in a better way when this function is generalized.
+
+
+    Args:
+        input_file: The input file object that contains the sections to be
+            converted to a MeshPy mesh.
+    Returns:
+        A tuple with the input file and the mesh. The input file will be
+            modified to remove the sections that have been converted to a
+            MeshPy mesh.
+    """
+
+    def _get_section_items(section_name):
+        """Return the items in a given section.
+
+        Since we will add the created MeshPy objects to the mesh, we
+        delete them from the plain data storage to avoid having
+        duplicate entries.
+        """
+        if section_name in input_file.sections:
+            return_list = input_file.sections[section_name]
+            input_file.sections[section_name] = []
+        else:
+            return_list = []
+        return return_list
+
+    # Go through all sections that have to be converted to full MeshPy objects
+    mesh = _Mesh()
+
+    # Add nodes
+    for item in _get_section_items("NODE COORDS"):
+        mesh.nodes.append(_Node.from_legacy_string(item))
+
+    # Add elements
+    for item in _get_section_items("STRUCTURE ELEMENTS"):
+        if _fourcipp_is_available():
+            raise ValueError("Port this functionality to not use the legacy string.")
+
+        # Get a list containing the element nodes.
+        element_nodes = []
+        for split_item in item.split()[3:]:
+            if split_item.isdigit():
+                node_id = int(split_item) - 1
+                element_nodes.append(mesh.nodes[node_id])
+            else:
+                break
+        else:
+            raise ValueError(
+                f'The input line:\n"{item}"\ncould not be converted to a element!'
+            )
+
+        mesh.elements.append(_Element.from_legacy_string(element_nodes, item))
+
+    # Add geometry sets
+    geometry_sets_in_sections: dict[str, dict[int, _GeometrySetNodes]] = {
+        key: {} for key in _mpy.geo
+    }
+    for section_name in input_file.sections.keys():
+        if section_name.endswith("TOPOLOGY"):
+            section_items = _get_section_items(section_name)
+            if len(section_items) > 0:
+                # Get the geometry key for this set
+                for key, value in _geometry_set_names.items():
+                    if value == section_name:
+                        geometry_key = key
+                        break
+                else:
+                    raise ValueError(f"Could not find the set {section_name}")
+                geometry_sets_in_section = get_yaml_geometry_sets(
+                    mesh.nodes, geometry_key, section_items
+                )
+                geometry_sets_in_sections[geometry_key] = geometry_sets_in_section
+                mesh.geometry_sets[geometry_key] = list(
+                    geometry_sets_in_section.values()
+                )
+
+    # Add boundary conditions
+    for (
+        bc_key,
+        geometry_key,
+    ), section_name in _boundary_condition_names.items():
+        for item in _get_section_items(section_name):
+            geometry_set_id = item["E"]
+            geometry_set = geometry_sets_in_sections[geometry_key][geometry_set_id]
+            mesh.boundary_conditions.append(
+                (bc_key, geometry_key),
+                boundary_condition_from_dict(geometry_set, bc_key, item),
+            )
+
+    return input_file, mesh

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,7 +279,6 @@ def assert_results_equal(get_string, tmp_path, current_test_name) -> Callable:
         result: Union[Path, str, dict, InputFile, Mesh],
         rtol: Optional[float] = None,
         atol: Optional[float] = None,
-        input_file_kwargs: dict = {"add_header_information": False},
         **kwargs,
     ) -> None:
         """Comparison between reference and result with relative or absolute
@@ -292,8 +291,6 @@ def assert_results_equal(get_string, tmp_path, current_test_name) -> Callable:
             result: The result data.
             rtol: The relative tolerance.
             atol: The absolute tolerance.
-            input_file_kwargs: Dictionary which contains the settings when
-                dumping the input file.
         """
 
         # Per default we do a string comparison of the objects. Some data types, e.g.,
@@ -343,7 +340,7 @@ def assert_results_equal(get_string, tmp_path, current_test_name) -> Callable:
                 # TODO this should be improved in the future
                 if isinstance(data, Mesh):
                     input_file = InputFile()
-                    input_file.add(data, **input_file_kwargs)
+                    input_file.add(data)
                     data = input_file
 
                 if isinstance(data, InputFile):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,7 +279,7 @@ def assert_results_equal(get_string, tmp_path, current_test_name) -> Callable:
         result: Union[Path, str, dict, InputFile, Mesh],
         rtol: Optional[float] = None,
         atol: Optional[float] = None,
-        input_file_kwargs: dict = {"add_header_information": False, "check_nox": False},
+        input_file_kwargs: dict = {"add_header_information": False},
         **kwargs,
     ) -> None:
         """Comparison between reference and result with relative or absolute

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -343,7 +343,7 @@ def assert_results_equal(get_string, tmp_path, current_test_name) -> Callable:
                 # TODO this should be improved in the future
                 if isinstance(data, Mesh):
                     input_file = InputFile()
-                    input_file.add(data)
+                    input_file.add(data, **input_file_kwargs)
                     data = input_file
 
                 if isinstance(data, InputFile):
@@ -355,7 +355,7 @@ def assert_results_equal(get_string, tmp_path, current_test_name) -> Callable:
 
                     return yaml.safe_load(
                         yaml.dump(
-                            data.get_dict_to_dump(**input_file_kwargs),
+                            data.sections,
                             Dumper=_MeshPyDumper,
                             width=float("inf"),
                         )

--- a/tests/reference-files/test_four_c_simulation_beam_to_beam_contact_example.4C.yaml
+++ b/tests/reference-files/test_four_c_simulation_beam_to_beam_contact_example.4C.yaml
@@ -343,8 +343,6 @@ STRUCT NOX/Printing:
   Inner Iteration: false
   Linear Solver Details: true
   Test Details: true
-STRUCT NOX/Status Test:
-  XML File: NOT_DEFINED
 STRUCTURAL DYNAMIC:
   DYNAMICTYPE: Statics
   INT_STRATEGY: Standard

--- a/tests/reference-files/test_four_c_simulation_dbc_monitor_to_input_initial.4C.yaml
+++ b/tests/reference-files/test_four_c_simulation_dbc_monitor_to_input_initial.4C.yaml
@@ -124,8 +124,6 @@ STRUCT NOX/Printing:
   Inner Iteration: false
   Linear Solver Details: true
   Test Details: true
-STRUCT NOX/Status Test:
-  XML File: NOT_DEFINED
 STRUCTURAL DYNAMIC:
   DYNAMICTYPE: Statics
   INT_STRATEGY: Standard

--- a/tests/reference-files/test_four_c_simulation_dbc_monitor_to_input_restart.4C.yaml
+++ b/tests/reference-files/test_four_c_simulation_dbc_monitor_to_input_restart.4C.yaml
@@ -150,9 +150,6 @@ STRUCT NOX/Printing:
   Error: true
   Inner Iteration: false
   Linear Solver Details: true
-  Test Details: true
-STRUCT NOX/Status Test:
-  XML File: NOT_DEFINED
 STRUCTURAL DYNAMIC:
   DYNAMICTYPE: Statics
   INT_STRATEGY: Standard

--- a/tests/reference-files/test_four_c_simulation_dbc_monitor_to_input_restart.4C.yaml
+++ b/tests/reference-files/test_four_c_simulation_dbc_monitor_to_input_restart.4C.yaml
@@ -150,6 +150,7 @@ STRUCT NOX/Printing:
   Error: true
   Inner Iteration: false
   Linear Solver Details: true
+  Test Details: true
 STRUCTURAL DYNAMIC:
   DYNAMICTYPE: Statics
   INT_STRATEGY: Standard

--- a/tests/reference-files/test_four_c_simulation_dirichlet_boundary_to_neumann_boundary_with_all_values_dirichlet.4C.yaml
+++ b/tests/reference-files/test_four_c_simulation_dirichlet_boundary_to_neumann_boundary_with_all_values_dirichlet.4C.yaml
@@ -446,8 +446,6 @@ STRUCT NOX/Printing:
   Inner Iteration: false
   Linear Solver Details: true
   Test Details: true
-STRUCT NOX/Status Test:
-  XML File: NOT_DEFINED
 STRUCTURAL DYNAMIC:
   DYNAMICTYPE: Statics
   INT_STRATEGY: Standard

--- a/tests/reference-files/test_four_c_simulation_dirichlet_boundary_to_neumann_boundary_with_all_values_neumann.4C.yaml
+++ b/tests/reference-files/test_four_c_simulation_dirichlet_boundary_to_neumann_boundary_with_all_values_neumann.4C.yaml
@@ -1456,8 +1456,6 @@ STRUCT NOX/Printing:
   Inner Iteration: false
   Linear Solver Details: true
   Test Details: true
-STRUCT NOX/Status Test:
-  XML File: NOT_DEFINED
 STRUCTURAL DYNAMIC:
   DYNAMICTYPE: Statics
   INT_STRATEGY: Standard

--- a/tests/reference-files/test_four_c_simulation_rotated_beam_axis.4C.yaml
+++ b/tests/reference-files/test_four_c_simulation_rotated_beam_axis.4C.yaml
@@ -340,8 +340,6 @@ STRUCT NOX/Printing:
   Inner Iteration: false
   Linear Solver Details: true
   Test Details: true
-STRUCT NOX/Status Test:
-  XML File: NOT_DEFINED
 STRUCTURAL DYNAMIC:
   DYNAMICTYPE: Statics
   INT_STRATEGY: Standard

--- a/tests/reference-files/test_header_functions_static.4C.yaml
+++ b/tests/reference-files/test_header_functions_static.4C.yaml
@@ -72,8 +72,6 @@ STRUCT NOX/Printing:
   Inner Iteration: false
   Linear Solver Details: true
   Test Details: true
-STRUCT NOX/Status Test:
-  XML File: NOT_DEFINED
 STRUCTURAL DYNAMIC:
   DYNAMICTYPE: Statics
   INT_STRATEGY: Standard

--- a/tests/reference-files/test_header_functions_static_prestress.4C.yaml
+++ b/tests/reference-files/test_header_functions_static_prestress.4C.yaml
@@ -36,8 +36,6 @@ STRUCT NOX/Printing:
   Inner Iteration: false
   Linear Solver Details: true
   Test Details: true
-STRUCT NOX/Status Test:
-  XML File: NOT_DEFINED
 STRUCTURAL DYNAMIC:
   DYNAMICTYPE: Statics
   INT_STRATEGY: Standard

--- a/tests/reference-files/test_header_functions_static_time_all.4C.yaml
+++ b/tests/reference-files/test_header_functions_static_time_all.4C.yaml
@@ -15,8 +15,6 @@ STRUCT NOX/Printing:
   Inner Iteration: false
   Linear Solver Details: true
   Test Details: true
-STRUCT NOX/Status Test:
-  XML File: NOT_DEFINED
 STRUCTURAL DYNAMIC:
   DYNAMICTYPE: Statics
   INT_STRATEGY: Standard

--- a/tests/reference-files/test_header_functions_static_time_no_n_steps.4C.yaml
+++ b/tests/reference-files/test_header_functions_static_time_no_n_steps.4C.yaml
@@ -15,8 +15,6 @@ STRUCT NOX/Printing:
   Inner Iteration: false
   Linear Solver Details: true
   Test Details: true
-STRUCT NOX/Status Test:
-  XML File: NOT_DEFINED
 STRUCTURAL DYNAMIC:
   DYNAMICTYPE: Statics
   INT_STRATEGY: Standard

--- a/tests/reference-files/test_header_functions_static_time_no_time_step.4C.yaml
+++ b/tests/reference-files/test_header_functions_static_time_no_time_step.4C.yaml
@@ -15,8 +15,6 @@ STRUCT NOX/Printing:
   Inner Iteration: false
   Linear Solver Details: true
   Test Details: true
-STRUCT NOX/Status Test:
-  XML File: NOT_DEFINED
 STRUCTURAL DYNAMIC:
   DYNAMICTYPE: Statics
   INT_STRATEGY: Standard

--- a/tests/reference-files/test_header_functions_static_time_no_total_time.4C.yaml
+++ b/tests/reference-files/test_header_functions_static_time_no_total_time.4C.yaml
@@ -15,8 +15,6 @@ STRUCT NOX/Printing:
   Inner Iteration: false
   Linear Solver Details: true
   Test Details: true
-STRUCT NOX/Status Test:
-  XML File: NOT_DEFINED
 STRUCTURAL DYNAMIC:
   DYNAMICTYPE: Statics
   INT_STRATEGY: Standard

--- a/tests/reference-files/test_header_functions_stress_output.4C.yaml
+++ b/tests/reference-files/test_header_functions_stress_output.4C.yaml
@@ -50,8 +50,6 @@ STRUCT NOX/Printing:
   Inner Iteration: false
   Linear Solver Details: true
   Test Details: true
-STRUCT NOX/Status Test:
-  XML File: NOT_DEFINED
 STRUCTURAL DYNAMIC:
   DYNAMICTYPE: Statics
   INT_STRATEGY: Standard

--- a/tests/reference-files/test_meshpy_nurbs_import.4C.yaml
+++ b/tests/reference-files/test_meshpy_nurbs_import.4C.yaml
@@ -726,8 +726,6 @@ STRUCT NOX/Printing:
   Inner Iteration: false
   Linear Solver Details: true
   Test Details: true
-STRUCT NOX/Status Test:
-  XML File: NOT_DEFINED
 STRUCTURAL DYNAMIC:
   DYNAMICTYPE: Statics
   INT_STRATEGY: Standard

--- a/tests/test_cosserat_curve.py
+++ b/tests/test_cosserat_curve.py
@@ -36,7 +36,7 @@ from meshpy.cosserat_curve.warping_along_cosserat_curve import (
 )
 from meshpy.four_c.element_beam import Beam3rHerm2Line3
 from meshpy.four_c.material import MaterialReissner
-from meshpy.four_c.model_importer import import_4C_model
+from meshpy.four_c.model_importer import import_four_c_model
 from meshpy.mesh_creation_functions.beam_basic_geometry import create_beam_mesh_helix
 
 
@@ -55,7 +55,7 @@ def load_cosserat_curve_from_file(get_corresponding_reference_file_path, **kwarg
 def create_beam_solid_input_file(get_corresponding_reference_file_path):
     """Create a beam and solid input file for testing purposes."""
 
-    _, mesh = import_4C_model(
+    _, mesh = import_four_c_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="test_cosserat_curve_mesh"
         ),

--- a/tests/test_cosserat_curve.py
+++ b/tests/test_cosserat_curve.py
@@ -35,8 +35,8 @@ from meshpy.cosserat_curve.warping_along_cosserat_curve import (
     warp_mesh_along_curve,
 )
 from meshpy.four_c.element_beam import Beam3rHerm2Line3
-from meshpy.four_c.input_file import InputFile
 from meshpy.four_c.material import MaterialReissner
+from meshpy.four_c.model_importer import import_4C_model
 from meshpy.mesh_creation_functions.beam_basic_geometry import create_beam_mesh_helix
 
 
@@ -55,7 +55,7 @@ def load_cosserat_curve_from_file(get_corresponding_reference_file_path, **kwarg
 def create_beam_solid_input_file(get_corresponding_reference_file_path):
     """Create a beam and solid input file for testing purposes."""
 
-    _, mesh = InputFile.from_4C_yaml(
+    _, mesh = import_4C_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="test_cosserat_curve_mesh"
         ),

--- a/tests/test_cosserat_curve.py
+++ b/tests/test_cosserat_curve.py
@@ -55,12 +55,12 @@ def load_cosserat_curve_from_file(get_corresponding_reference_file_path, **kwarg
 def create_beam_solid_input_file(get_corresponding_reference_file_path):
     """Create a beam and solid input file for testing purposes."""
 
-    mpy.import_mesh_full = True
-    mesh = InputFile(
-        yaml_file=get_corresponding_reference_file_path(
+    _, mesh = InputFile.from_4C_yaml(
+        input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="test_cosserat_curve_mesh"
-        )
-    ).mesh
+        ),
+        convert_input_to_mesh=True,
+    )
 
     create_beam_mesh_helix(
         mesh,

--- a/tests/test_four_c.py
+++ b/tests/test_four_c.py
@@ -38,6 +38,7 @@ from meshpy.four_c.function import Function
 from meshpy.four_c.input_file import InputFile
 from meshpy.four_c.locsys_condition import LocSysCondition
 from meshpy.four_c.material import MaterialReissner
+from meshpy.four_c.model_importer import import_4C_model
 from meshpy.four_c.solid_shell_thickness_direction import (
     get_visualization_third_parameter_direction_hex8,
     set_solid_shell_thickness_direction,
@@ -261,7 +262,7 @@ def test_four_c_solid_shell_direction_detection(
     """Test the solid shell direction detection functionality."""
 
     # Test the plates
-    _, mesh_block = InputFile.from_4C_yaml(
+    _, mesh_block = import_4C_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="test_create_cubit_input_solid_shell_blocks"
         ),
@@ -281,7 +282,7 @@ def test_four_c_solid_shell_direction_detection(
     )
 
     # Test the dome
-    _, mesh_dome_original = InputFile.from_4C_yaml(
+    _, mesh_dome_original = import_4C_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="test_create_cubit_input_solid_shell_dome"
         ),
@@ -641,7 +642,7 @@ def test_four_c_beam_to_solid(
     works."""
 
     # Load a solid
-    _, mesh = InputFile.from_4C_yaml(
+    _, mesh = import_4C_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="test_create_cubit_input_block"
         ),
@@ -735,7 +736,7 @@ def test_four_c_import_non_consecutive_geometry_sets(
 ):
     """Test that we can import non-consecutively numbered geometry sets."""
 
-    input_file, mesh = InputFile.from_4C_yaml(
+    input_file, mesh = import_4C_model(
         input_file_path=get_corresponding_reference_file_path(
             additional_identifier="input"
         ),

--- a/tests/test_four_c.py
+++ b/tests/test_four_c.py
@@ -38,7 +38,7 @@ from meshpy.four_c.function import Function
 from meshpy.four_c.input_file import InputFile
 from meshpy.four_c.locsys_condition import LocSysCondition
 from meshpy.four_c.material import MaterialReissner
-from meshpy.four_c.model_importer import import_4C_model
+from meshpy.four_c.model_importer import import_four_c_model
 from meshpy.four_c.solid_shell_thickness_direction import (
     get_visualization_third_parameter_direction_hex8,
     set_solid_shell_thickness_direction,
@@ -262,7 +262,7 @@ def test_four_c_solid_shell_direction_detection(
     """Test the solid shell direction detection functionality."""
 
     # Test the plates
-    _, mesh_block = import_4C_model(
+    _, mesh_block = import_four_c_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="test_create_cubit_input_solid_shell_blocks"
         ),
@@ -282,7 +282,7 @@ def test_four_c_solid_shell_direction_detection(
     )
 
     # Test the dome
-    _, mesh_dome_original = import_4C_model(
+    _, mesh_dome_original = import_four_c_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="test_create_cubit_input_solid_shell_dome"
         ),
@@ -642,7 +642,7 @@ def test_four_c_beam_to_solid(
     works."""
 
     # Load a solid
-    _, mesh = import_4C_model(
+    _, mesh = import_four_c_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="test_create_cubit_input_block"
         ),
@@ -736,7 +736,7 @@ def test_four_c_import_non_consecutive_geometry_sets(
 ):
     """Test that we can import non-consecutively numbered geometry sets."""
 
-    input_file, mesh = import_4C_model(
+    input_file, mesh = import_four_c_model(
         input_file_path=get_corresponding_reference_file_path(
             additional_identifier="input"
         ),

--- a/tests/test_four_c.py
+++ b/tests/test_four_c.py
@@ -168,7 +168,7 @@ def test_four_c_material_numbering(
     mesh = Mesh()
     mesh.add(MaterialReissner(youngs_modulus=1.0, radius=2.0))
 
-    input_file.add(mesh, add_header_information=False)
+    input_file.add(mesh)
 
     assert_results_equal(get_corresponding_reference_file_path(), input_file)
 
@@ -249,7 +249,7 @@ def test_four_c_simulation_beam_potential_helix(
         )
     )
 
-    input_file.add(mesh, add_header_information=False)
+    input_file.add(mesh)
 
     assert_results_equal(get_corresponding_reference_file_path(), input_file)
 
@@ -755,7 +755,7 @@ def test_four_c_import_non_consecutive_geometry_sets(
         )
         mesh.add(beam_set)
 
-    input_file.add(mesh, add_header_information=False)
+    input_file.add(mesh)
 
     assert_results_equal(
         get_corresponding_reference_file_path(

--- a/tests/test_four_c.py
+++ b/tests/test_four_c.py
@@ -167,7 +167,7 @@ def test_four_c_material_numbering(
     mesh = Mesh()
     mesh.add(MaterialReissner(youngs_modulus=1.0, radius=2.0))
 
-    input_file.add(mesh, add_header_information=False, check_nox=False)
+    input_file.add(mesh, add_header_information=False)
 
     assert_results_equal(get_corresponding_reference_file_path(), input_file)
 
@@ -248,7 +248,7 @@ def test_four_c_simulation_beam_potential_helix(
         )
     )
 
-    input_file.add(mesh, add_header_information=False, check_nox=False)
+    input_file.add(mesh, add_header_information=False)
 
     assert_results_equal(get_corresponding_reference_file_path(), input_file)
 
@@ -754,7 +754,7 @@ def test_four_c_import_non_consecutive_geometry_sets(
         )
         mesh.add(beam_set)
 
-    input_file.add(mesh, add_header_information=False, check_nox=False)
+    input_file.add(mesh, add_header_information=False)
 
     assert_results_equal(
         get_corresponding_reference_file_path(

--- a/tests/test_four_c_simulation.py
+++ b/tests/test_four_c_simulation.py
@@ -96,7 +96,7 @@ def create_cantilever_model(n_steps, time_step=0.5):
         mesh, Beam3rHerm2Line3, mat, [0, 0, 0], [2, 0, 0], n_el=10
     )
 
-    input_file.add(mesh, add_header_information=False, check_nox=False)
+    input_file.add(mesh, add_header_information=False)
 
     return input_file, beam_set
 
@@ -164,7 +164,7 @@ def test_four_c_simulation_honeycomb_sphere(
     )
     # add mesh back to the input file to check if import works
     if full_import:
-        input_file.add(mesh, add_header_information=False, check_nox=False)
+        input_file.add(mesh, add_header_information=False)
 
     # Modify the time step options.
     input_file.add(
@@ -262,7 +262,7 @@ def test_four_c_simulation_honeycomb_sphere(
     )
 
     # Add the mesh to the imported solid mesh.
-    input_file.add(mesh_honeycomb, add_header_information=False, check_nox=False)
+    input_file.add(mesh_honeycomb, add_header_information=False)
 
     # Check the created input file
     assert_results_equal(
@@ -304,7 +304,7 @@ def test_four_c_simulation_beam_and_solid_tube(
     )
     # Add mesh back to the input file to check if import works
     if full_import:
-        input_file.add(imported_mesh, add_header_information=False, check_nox=False)
+        input_file.add(imported_mesh, add_header_information=False)
 
     # Add options for beam_output.
     input_file.add(
@@ -372,7 +372,7 @@ def test_four_c_simulation_beam_and_solid_tube(
     mesh.get_unique_geometry_sets(link_to_nodes="all_nodes")
 
     # Add mesh to input file
-    input_file.add(mesh, add_header_information=False, check_nox=False)
+    input_file.add(mesh, add_header_information=False)
 
     # Check the created input file
     assert_results_equal(
@@ -539,7 +539,7 @@ def test_four_c_simulation_honeycomb_variants(
             counter += 1
 
     # Add mesh to input file.
-    input_file.add(mesh, add_header_information=False, check_nox=False)
+    input_file.add(mesh, add_header_information=False)
 
     # Add result checks.
     displacements = [
@@ -675,7 +675,7 @@ def test_four_c_simulation_rotated_beam_axis(
     add_result_description(input_file, displacements, nodes)
 
     # Add the mesh to the input file
-    input_file.add(mesh, add_header_information=False, check_nox=False)
+    input_file.add(mesh, add_header_information=False)
 
     # Check the created input file
     assert_results_equal(get_corresponding_reference_file_path(), input_file)
@@ -759,7 +759,7 @@ def test_four_c_simulation_dbc_monitor_to_input(
             }
         }
     )
-    initial_input_file.add(initial_mesh, add_header_information=False, check_nox=False)
+    initial_input_file.add(initial_mesh, add_header_information=False)
 
     # Check the input file
     assert_results_equal(
@@ -831,7 +831,7 @@ def test_four_c_simulation_dbc_monitor_to_input(
             initial_run_name + " is not yet implemented for this test case."
         )
 
-    restart_input_file.add(restart_mesh, header_information=False, check_nox=False)
+    restart_input_file.add(restart_mesh, header_information=False)
 
     displacements = [
         [-4.09988307566066690e-01, 9.93075098427816383e-01, 6.62050065618549843e-01]
@@ -939,7 +939,7 @@ def test_four_c_simulation_dirichlet_boundary_to_neumann_boundary_with_all_value
                     )
                 )
 
-    initial_simulation.add(mesh, add_header_information=False, check_nox=False)
+    initial_simulation.add(mesh, add_header_information=False)
 
     # Add DB-monitor header.
     initial_simulation.add(
@@ -999,7 +999,7 @@ def test_four_c_simulation_dirichlet_boundary_to_neumann_boundary_with_all_value
                     n_dof=9,
                 )
 
-    force_simulation.add(mesh, add_header_information=False, check_nox=False)
+    force_simulation.add(mesh, add_header_information=False)
 
     displacements = [[0.0, 0.0, 0.0]]
     nodes = [21]
@@ -1214,7 +1214,7 @@ def test_four_c_simulation_beam_to_beam_contact_example(
     )
 
     # Add the mesh to the input file.
-    input_file.add(mesh, add_header_information=False, check_nox=False)
+    input_file.add(mesh, add_header_information=False)
 
     # Add normal runtime output.
     set_runtime_output(input_file)

--- a/tests/test_four_c_simulation.py
+++ b/tests/test_four_c_simulation.py
@@ -48,6 +48,7 @@ from meshpy.four_c.header_functions import (
 )
 from meshpy.four_c.input_file import InputFile
 from meshpy.four_c.material import MaterialReissner
+from meshpy.four_c.model_importer import import_4C_model
 from meshpy.four_c.run_four_c import run_four_c
 from meshpy.mesh_creation_functions.beam_basic_geometry import create_beam_mesh_line
 from meshpy.mesh_creation_functions.beam_honeycomb import create_beam_mesh_honeycomb
@@ -156,7 +157,7 @@ def test_four_c_simulation_honeycomb_sphere(
     """
 
     # Read input file with information of the sphere and simulation.
-    input_file, mesh = InputFile.from_4C_yaml(
+    input_file, mesh = import_4C_model(
         input_file_path=get_corresponding_reference_file_path(
             additional_identifier="import"
         ),
@@ -296,7 +297,7 @@ def test_four_c_simulation_beam_and_solid_tube(
     """Merge a solid tube with a beam tube and simulate them together."""
 
     # Create the input file and read solid mesh data.
-    input_file, imported_mesh = InputFile.from_4C_yaml(
+    input_file, imported_mesh = import_4C_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="test_create_cubit_input_tube"
         ),

--- a/tests/test_four_c_simulation.py
+++ b/tests/test_four_c_simulation.py
@@ -97,7 +97,7 @@ def create_cantilever_model(n_steps, time_step=0.5):
         mesh, Beam3rHerm2Line3, mat, [0, 0, 0], [2, 0, 0], n_el=10
     )
 
-    input_file.add(mesh, add_header_information=False)
+    input_file.add(mesh)
 
     return input_file, beam_set
 
@@ -165,7 +165,7 @@ def test_four_c_simulation_honeycomb_sphere(
     )
     # add mesh back to the input file to check if import works
     if full_import:
-        input_file.add(mesh, add_header_information=False)
+        input_file.add(mesh)
 
     # Modify the time step options.
     input_file.add(
@@ -263,7 +263,7 @@ def test_four_c_simulation_honeycomb_sphere(
     )
 
     # Add the mesh to the imported solid mesh.
-    input_file.add(mesh_honeycomb, add_header_information=False)
+    input_file.add(mesh_honeycomb)
 
     # Check the created input file
     assert_results_equal(
@@ -305,7 +305,7 @@ def test_four_c_simulation_beam_and_solid_tube(
     )
     # Add mesh back to the input file to check if import works
     if full_import:
-        input_file.add(imported_mesh, add_header_information=False)
+        input_file.add(imported_mesh)
 
     # Add options for beam_output.
     input_file.add(
@@ -373,7 +373,7 @@ def test_four_c_simulation_beam_and_solid_tube(
     mesh.get_unique_geometry_sets(link_to_nodes="all_nodes")
 
     # Add mesh to input file
-    input_file.add(mesh, add_header_information=False)
+    input_file.add(mesh)
 
     # Check the created input file
     assert_results_equal(
@@ -540,7 +540,7 @@ def test_four_c_simulation_honeycomb_variants(
             counter += 1
 
     # Add mesh to input file.
-    input_file.add(mesh, add_header_information=False)
+    input_file.add(mesh)
 
     # Add result checks.
     displacements = [
@@ -676,7 +676,7 @@ def test_four_c_simulation_rotated_beam_axis(
     add_result_description(input_file, displacements, nodes)
 
     # Add the mesh to the input file
-    input_file.add(mesh, add_header_information=False)
+    input_file.add(mesh)
 
     # Check the created input file
     assert_results_equal(get_corresponding_reference_file_path(), input_file)
@@ -760,7 +760,7 @@ def test_four_c_simulation_dbc_monitor_to_input(
             }
         }
     )
-    initial_input_file.add(initial_mesh, add_header_information=False)
+    initial_input_file.add(initial_mesh)
 
     # Check the input file
     assert_results_equal(
@@ -940,7 +940,7 @@ def test_four_c_simulation_dirichlet_boundary_to_neumann_boundary_with_all_value
                     )
                 )
 
-    initial_simulation.add(mesh, add_header_information=False)
+    initial_simulation.add(mesh)
 
     # Add DB-monitor header.
     initial_simulation.add(
@@ -1000,7 +1000,7 @@ def test_four_c_simulation_dirichlet_boundary_to_neumann_boundary_with_all_value
                     n_dof=9,
                 )
 
-    force_simulation.add(mesh, add_header_information=False)
+    force_simulation.add(mesh)
 
     displacements = [[0.0, 0.0, 0.0]]
     nodes = [21]
@@ -1215,7 +1215,7 @@ def test_four_c_simulation_beam_to_beam_contact_example(
     )
 
     # Add the mesh to the input file.
-    input_file.add(mesh, add_header_information=False)
+    input_file.add(mesh)
 
     # Add normal runtime output.
     set_runtime_output(input_file)

--- a/tests/test_four_c_simulation.py
+++ b/tests/test_four_c_simulation.py
@@ -48,7 +48,7 @@ from meshpy.four_c.header_functions import (
 )
 from meshpy.four_c.input_file import InputFile
 from meshpy.four_c.material import MaterialReissner
-from meshpy.four_c.model_importer import import_4C_model
+from meshpy.four_c.model_importer import import_four_c_model
 from meshpy.four_c.run_four_c import run_four_c
 from meshpy.mesh_creation_functions.beam_basic_geometry import create_beam_mesh_line
 from meshpy.mesh_creation_functions.beam_honeycomb import create_beam_mesh_honeycomb
@@ -157,7 +157,7 @@ def test_four_c_simulation_honeycomb_sphere(
     """
 
     # Read input file with information of the sphere and simulation.
-    input_file, mesh = import_4C_model(
+    input_file, mesh = import_four_c_model(
         input_file_path=get_corresponding_reference_file_path(
             additional_identifier="import"
         ),
@@ -297,7 +297,7 @@ def test_four_c_simulation_beam_and_solid_tube(
     """Merge a solid tube with a beam tube and simulate them together."""
 
     # Create the input file and read solid mesh data.
-    input_file, imported_mesh = import_4C_model(
+    input_file, imported_mesh = import_four_c_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="test_create_cubit_input_tube"
         ),

--- a/tests/test_four_c_simulation.py
+++ b/tests/test_four_c_simulation.py
@@ -33,8 +33,8 @@ from meshpy.core.mesh import Mesh
 from meshpy.core.rotation import Rotation
 from meshpy.four_c.beam_interaction_conditions import add_beam_interaction_condition
 from meshpy.four_c.dbc_monitor import (
-    dbc_monitor_to_input,
-    dbc_monitor_to_input_all_values,
+    dbc_monitor_to_mesh,
+    dbc_monitor_to_mesh_all_values,
 )
 from meshpy.four_c.element_beam import Beam3rHerm2Line3
 from meshpy.four_c.function import Function
@@ -804,11 +804,10 @@ def test_four_c_simulation_dbc_monitor_to_input(
         ]
     )
     restart_mesh.add(function_nbc)
-    restart_input_file.add(restart_mesh, header_information=False, check_nox=False)
 
     if initial_run_name == "test_cantilever_w_dbc_monitor_to_input":
-        dbc_monitor_to_input(
-            restart_input_file,
+        dbc_monitor_to_mesh(
+            restart_mesh,
             tmp_path
             / initial_run_name
             / f"{initial_run_name}_monitor_dbc"
@@ -817,8 +816,8 @@ def test_four_c_simulation_dbc_monitor_to_input(
             function=function_nbc,
         )
     elif initial_run_name == "test_cantilever_w_dbc_monitor_to_input_all_values":
-        dbc_monitor_to_input_all_values(
-            restart_input_file,
+        dbc_monitor_to_mesh_all_values(
+            restart_mesh,
             tmp_path
             / initial_run_name
             / f"{initial_run_name}_monitor_dbc"
@@ -831,6 +830,8 @@ def test_four_c_simulation_dbc_monitor_to_input(
         raise ValueError(
             initial_run_name + " is not yet implemented for this test case."
         )
+
+    restart_input_file.add(restart_mesh, header_information=False, check_nox=False)
 
     displacements = [
         [-4.09988307566066690e-01, 9.93075098427816383e-01, 6.62050065618549843e-01]
@@ -981,7 +982,6 @@ def test_four_c_simulation_dirichlet_boundary_to_neumann_boundary_with_all_value
             bc_type=mpy.bc.dirichlet,
         )
     )
-    force_simulation.add(mesh, add_header_information=False, check_nox=False)
 
     # Set up path to monitor.
     monitor_db_path = tmp_path / initial_run_name / (initial_run_name + "_monitor_dbc")
@@ -990,14 +990,16 @@ def test_four_c_simulation_dirichlet_boundary_to_neumann_boundary_with_all_value
     for _, _, file_names in os.walk(monitor_db_path):
         for file_name in sorted(file_names):
             if "_monitor_dbc" in file_name:
-                dbc_monitor_to_input_all_values(
-                    force_simulation,
+                dbc_monitor_to_mesh_all_values(
+                    mesh,
                     os.path.join(monitor_db_path, file_name),
                     steps=[0, n_steps + 1],
                     time_span=[0, n_steps * dt, 2 * n_steps * dt],
                     type="hat",
                     n_dof=9,
                 )
+
+    force_simulation.add(mesh, add_header_information=False, check_nox=False)
 
     displacements = [[0.0, 0.0, 0.0]]
     nodes = [21]

--- a/tests/test_meshpy.py
+++ b/tests/test_meshpy.py
@@ -277,7 +277,7 @@ def test_meshpy_mesh_transformations_with_solid(
         if reflect:
             mesh.reflect([0.1, -2, 1])
 
-        input_file.add(mesh, add_header_information=False, check_nox=False)
+        input_file.add(mesh, add_header_information=False)
 
         # Check the output.
         assert_results_equal(
@@ -327,7 +327,7 @@ def test_meshpy_fluid_element_section(
         beam_mesh, Beam3eb, material, [0, -0.5, 0], [0, 0.2, 0], n_el=5
     )
 
-    input_file.add(beam_mesh, add_header_information=False, check_nox=False)
+    input_file.add(beam_mesh, add_header_information=False)
 
     # Check the output.
     assert_results_equal(get_corresponding_reference_file_path(), input_file)
@@ -1228,7 +1228,7 @@ def test_meshpy_beam_to_solid_conditions(
     input_file, mesh = create_beam_to_solid_conditions_model(
         get_corresponding_reference_file_path, full_import=full_import
     )
-    input_file.add(mesh, add_header_information=False, check_nox=False)
+    input_file.add(mesh, add_header_information=False)
 
     # Check results
     assert_results_equal(
@@ -1252,7 +1252,7 @@ def test_meshpy_surface_to_surface_contact_import(
         convert_input_to_mesh=True,
     )
 
-    input_file.add(mesh, add_header_information=False, check_nox=False)
+    input_file.add(mesh, add_header_information=False)
 
     # Compare with the reference file.
     assert_results_equal(get_corresponding_reference_file_path(), input_file)
@@ -1388,7 +1388,7 @@ def test_meshpy_nurbs_import(
     add_result_description(input_file, displacements, nodes)
 
     # Add the mesh to the input file
-    input_file.add(mesh, add_header_information=False, check_nox=False)
+    input_file.add(mesh, add_header_information=False)
 
     # Compare with the reference solution.
     assert_results_equal(get_corresponding_reference_file_path(), input_file)

--- a/tests/test_meshpy.py
+++ b/tests/test_meshpy.py
@@ -278,7 +278,7 @@ def test_meshpy_mesh_transformations_with_solid(
         if reflect:
             mesh.reflect([0.1, -2, 1])
 
-        input_file.add(mesh, add_header_information=False)
+        input_file.add(mesh)
 
         # Check the output.
         assert_results_equal(
@@ -328,7 +328,7 @@ def test_meshpy_fluid_element_section(
         beam_mesh, Beam3eb, material, [0, -0.5, 0], [0, 0.2, 0], n_el=5
     )
 
-    input_file.add(beam_mesh, add_header_information=False)
+    input_file.add(beam_mesh)
 
     # Check the output.
     assert_results_equal(get_corresponding_reference_file_path(), input_file)
@@ -1229,7 +1229,7 @@ def test_meshpy_beam_to_solid_conditions(
     input_file, mesh = create_beam_to_solid_conditions_model(
         get_corresponding_reference_file_path, full_import=full_import
     )
-    input_file.add(mesh, add_header_information=False)
+    input_file.add(mesh)
 
     # Check results
     assert_results_equal(
@@ -1253,7 +1253,7 @@ def test_meshpy_surface_to_surface_contact_import(
         convert_input_to_mesh=True,
     )
 
-    input_file.add(mesh, add_header_information=False)
+    input_file.add(mesh)
 
     # Compare with the reference file.
     assert_results_equal(get_corresponding_reference_file_path(), input_file)
@@ -1389,7 +1389,7 @@ def test_meshpy_nurbs_import(
     add_result_description(input_file, displacements, nodes)
 
     # Add the mesh to the input file
-    input_file.add(mesh, add_header_information=False)
+    input_file.add(mesh)
 
     # Compare with the reference solution.
     assert_results_equal(get_corresponding_reference_file_path(), input_file)

--- a/tests/test_meshpy.py
+++ b/tests/test_meshpy.py
@@ -61,7 +61,7 @@ from meshpy.four_c.material import (
     MaterialReissnerElastoplastic,
     MaterialStVenantKirchhoff,
 )
-from meshpy.four_c.model_importer import import_4C_model
+from meshpy.four_c.model_importer import import_four_c_model
 from meshpy.mesh_creation_functions.beam_basic_geometry import (
     create_beam_mesh_arc_segment_via_rotation,
     create_beam_mesh_line,
@@ -252,7 +252,7 @@ def test_meshpy_mesh_transformations_with_solid(
         function."""
 
         # Create the mesh.
-        input_file, mesh = import_4C_model(
+        input_file, mesh = import_four_c_model(
             input_file_path=get_corresponding_reference_file_path(
                 reference_file_base_name="4C_input_solid_cuboid"
             ),
@@ -314,7 +314,7 @@ def test_meshpy_fluid_element_section(
 ):
     """Add beam elements to an input file containing fluid elements."""
 
-    input_file, _ = import_4C_model(
+    input_file, _ = import_four_c_model(
         input_file_path=get_corresponding_reference_file_path(
             additional_identifier="import"
         )
@@ -397,7 +397,7 @@ def test_meshpy_get_min_max_coordinates(get_corresponding_reference_file_path):
     """Test if the get_min_max_coordinates function works properly."""
 
     # Create the mesh.
-    _, mesh = import_4C_model(
+    _, mesh = import_four_c_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="4C_input_solid_cuboid"
         ),
@@ -1174,7 +1174,7 @@ def create_beam_to_solid_conditions_model(
     """Create the input file for the beam-to-solid input conditions tests."""
 
     # Create input file
-    input_file, mesh = import_4C_model(
+    input_file, mesh = import_four_c_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="test_create_cubit_input_block"
         ),
@@ -1252,7 +1252,7 @@ def test_meshpy_surface_to_surface_contact_import(
     """Test that surface-to-surface contact problems can be imported as
     expected."""
 
-    input_file, mesh = import_4C_model(
+    input_file, mesh = import_four_c_model(
         input_file_path=get_corresponding_reference_file_path(
             additional_identifier="solid_mesh"
         ),
@@ -1275,7 +1275,7 @@ def test_meshpy_nurbs_import(
     """
 
     # Create mesh and load solid file.
-    input_file, mesh = import_4C_model(
+    input_file, mesh = import_four_c_model(
         input_file_path=get_corresponding_reference_file_path(
             additional_identifier="solid_mesh"
         )
@@ -1631,7 +1631,7 @@ def test_meshpy_vtk_writer_solid(
     """Import a solid mesh and check the VTK output."""
 
     # Convert the solid mesh to meshpy objects.
-    _, mesh = import_4C_model(
+    _, mesh = import_four_c_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="test_create_cubit_input_tube"
         ),
@@ -1657,7 +1657,7 @@ def test_meshpy_vtk_writer_solid_elements(
     """Import a solid mesh with all solid types and check the VTK output."""
 
     # Convert the solid mesh to meshpy objects.
-    _, mesh = import_4C_model(
+    _, mesh = import_four_c_model(
         input_file_path=get_corresponding_reference_file_path(
             additional_identifier="import"
         ),
@@ -1752,7 +1752,7 @@ def test_meshpy_cubitpy_import(
     # Create the input file and read the file.
     file_path = os.path.join(tmp_path, "test_cubitpy_import.4C.yaml")
     create_tube(file_path)
-    input_file, _ = import_4C_model(input_file_path=file_path)
+    input_file, _ = import_four_c_model(input_file_path=file_path)
 
     # Create the input file and read the cubit object.
     input_file_cubit = InputFile(cubit=create_tube_cubit())
@@ -1761,7 +1761,7 @@ def test_meshpy_cubitpy_import(
     file_path_ref = get_corresponding_reference_file_path(
         reference_file_base_name="test_create_cubit_input_tube"
     )
-    input_file_ref, _ = import_4C_model(input_file_path=file_path_ref)
+    input_file_ref, _ = import_four_c_model(input_file_path=file_path_ref)
 
     # Compare the input files.
     assert_results_equal(input_file, input_file_cubit)

--- a/tests/test_meshpy.py
+++ b/tests/test_meshpy.py
@@ -1212,7 +1212,13 @@ def create_beam_to_solid_conditions_model(
     return input_file, mesh
 
 
-# TODO change additional identifier
+# TODO: Standardize test parameterization for (full_import, additional_identifier).
+# Currently, different tests use inconsistent patterns for parametrize:
+#   - (False, "dict_import"), (True, "full_import")
+#   - (False, None), (True, "full")
+#   - Only "full_import" as a boolean param
+# Consider unifying these under a shared fixture or helper to reduce redundancy
+# and improve readability across tests. Also adjust reference file names.
 @pytest.mark.parametrize(
     ("full_import", "additional_identifier"),
     [(False, None), (True, "full")],

--- a/tests/test_meshpy.py
+++ b/tests/test_meshpy.py
@@ -61,6 +61,7 @@ from meshpy.four_c.material import (
     MaterialReissnerElastoplastic,
     MaterialStVenantKirchhoff,
 )
+from meshpy.four_c.model_importer import import_4C_model
 from meshpy.mesh_creation_functions.beam_basic_geometry import (
     create_beam_mesh_arc_segment_via_rotation,
     create_beam_mesh_line,
@@ -251,7 +252,7 @@ def test_meshpy_mesh_transformations_with_solid(
         function."""
 
         # Create the mesh.
-        input_file, mesh = InputFile.from_4C_yaml(
+        input_file, mesh = import_4C_model(
             input_file_path=get_corresponding_reference_file_path(
                 reference_file_base_name="4C_input_solid_cuboid"
             ),
@@ -313,7 +314,7 @@ def test_meshpy_fluid_element_section(
 ):
     """Add beam elements to an input file containing fluid elements."""
 
-    input_file, _ = InputFile.from_4C_yaml(
+    input_file, _ = import_4C_model(
         input_file_path=get_corresponding_reference_file_path(
             additional_identifier="import"
         )
@@ -396,7 +397,7 @@ def test_meshpy_get_min_max_coordinates(get_corresponding_reference_file_path):
     """Test if the get_min_max_coordinates function works properly."""
 
     # Create the mesh.
-    _, mesh = InputFile.from_4C_yaml(
+    _, mesh = import_4C_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="4C_input_solid_cuboid"
         ),
@@ -1173,7 +1174,7 @@ def create_beam_to_solid_conditions_model(
     """Create the input file for the beam-to-solid input conditions tests."""
 
     # Create input file
-    input_file, mesh = InputFile.from_4C_yaml(
+    input_file, mesh = import_4C_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="test_create_cubit_input_block"
         ),
@@ -1245,7 +1246,7 @@ def test_meshpy_surface_to_surface_contact_import(
     """Test that surface-to-surface contact problems can be imported as
     expected."""
 
-    input_file, mesh = InputFile.from_4C_yaml(
+    input_file, mesh = import_4C_model(
         input_file_path=get_corresponding_reference_file_path(
             additional_identifier="solid_mesh"
         ),
@@ -1268,7 +1269,7 @@ def test_meshpy_nurbs_import(
     """
 
     # Create mesh and load solid file.
-    input_file, mesh = InputFile.from_4C_yaml(
+    input_file, mesh = import_4C_model(
         input_file_path=get_corresponding_reference_file_path(
             additional_identifier="solid_mesh"
         )
@@ -1624,7 +1625,7 @@ def test_meshpy_vtk_writer_solid(
     """Import a solid mesh and check the VTK output."""
 
     # Convert the solid mesh to meshpy objects.
-    _, mesh = InputFile.from_4C_yaml(
+    _, mesh = import_4C_model(
         input_file_path=get_corresponding_reference_file_path(
             reference_file_base_name="test_create_cubit_input_tube"
         ),
@@ -1650,7 +1651,7 @@ def test_meshpy_vtk_writer_solid_elements(
     """Import a solid mesh with all solid types and check the VTK output."""
 
     # Convert the solid mesh to meshpy objects.
-    _, mesh = InputFile.from_4C_yaml(
+    _, mesh = import_4C_model(
         input_file_path=get_corresponding_reference_file_path(
             additional_identifier="import"
         ),
@@ -1745,7 +1746,7 @@ def test_meshpy_cubitpy_import(
     # Create the input file and read the file.
     file_path = os.path.join(tmp_path, "test_cubitpy_import.4C.yaml")
     create_tube(file_path)
-    input_file, _ = InputFile.from_4C_yaml(input_file_path=file_path)
+    input_file, _ = import_4C_model(input_file_path=file_path)
 
     # Create the input file and read the cubit object.
     input_file_cubit = InputFile(cubit=create_tube_cubit())
@@ -1754,7 +1755,7 @@ def test_meshpy_cubitpy_import(
     file_path_ref = get_corresponding_reference_file_path(
         reference_file_base_name="test_create_cubit_input_tube"
     )
-    input_file_ref, _ = InputFile.from_4C_yaml(input_file_path=file_path_ref)
+    input_file_ref, _ = import_4C_model(input_file_path=file_path_ref)
 
     # Compare the input files.
     assert_results_equal(input_file, input_file_cubit)

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -33,7 +33,7 @@ from meshpy.core.rotation import Rotation
 from meshpy.four_c.element_beam import Beam3rHerm2Line3
 from meshpy.four_c.input_file import InputFile
 from meshpy.four_c.material import MaterialReissner
-from meshpy.four_c.model_importer import import_4C_model
+from meshpy.four_c.model_importer import import_four_c_model
 from meshpy.geometric_search.find_close_points import (
     FindClosePointAlgorithm,
     find_close_points,
@@ -113,7 +113,7 @@ def create_solid_block(file_path, nx, ny, nz):
 def load_solid(solid_file, full_import):
     """Load a solid into an input file."""
 
-    import_4C_model(input_file_path=solid_file, convert_input_to_mesh=full_import)
+    import_four_c_model(input_file_path=solid_file, convert_input_to_mesh=full_import)
 
 
 def create_large_beam_mesh(n_x, n_y, n_z, n_el):

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -112,8 +112,9 @@ def create_solid_block(file_path, nx, ny, nz):
 def load_solid(solid_file, full_import):
     """Load a solid into an input file."""
 
-    mpy.import_mesh_full = full_import
-    InputFile(yaml_file=solid_file)
+    InputFile.from_4C_yaml(
+        input_file_path=solid_file, convert_input_to_mesh=full_import
+    )
 
 
 def create_large_beam_mesh(n_x, n_y, n_z, n_el):

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -33,6 +33,7 @@ from meshpy.core.rotation import Rotation
 from meshpy.four_c.element_beam import Beam3rHerm2Line3
 from meshpy.four_c.input_file import InputFile
 from meshpy.four_c.material import MaterialReissner
+from meshpy.four_c.model_importer import import_4C_model
 from meshpy.geometric_search.find_close_points import (
     FindClosePointAlgorithm,
     find_close_points,
@@ -112,9 +113,7 @@ def create_solid_block(file_path, nx, ny, nz):
 def load_solid(solid_file, full_import):
     """Load a solid into an input file."""
 
-    InputFile.from_4C_yaml(
-        input_file_path=solid_file, convert_input_to_mesh=full_import
-    )
+    import_4C_model(input_file_path=solid_file, convert_input_to_mesh=full_import)
 
 
 def create_large_beam_mesh(n_x, n_y, n_z, n_el):


### PR DESCRIPTION
This PR now removes the mesh entirely from the input file.

Additionally this PR introduces our new API to read in an existing input file as discussed. In my opinion it makes sense that this function is not a free function - but we overwrite the existing function from fourcipp (hopefully this is soon included).

With this change the next step would be to introduce fourcipp into MeshPy. This should be rather straight forward.