### PR TITLE
Modularize coupling conditions

### DIFF
--- a/src/meshpy/core/boundary_condition.py
+++ b/src/meshpy/core/boundary_condition.py
@@ -75,7 +75,9 @@ class BoundaryCondition(BoundaryConditionBase):
         Args:
             geometry_set: Geometry that this boundary condition acts on.
             data: Data defining the properties of this boundary condition.
-            bc_type: Type of the boundary condition.
+            bc_type: If this is a string, this will be the section that
+                this BC will be added to. If it is a mpy.bc, the section will
+                be determined automatically.
             double_nodes: Depending on this parameter, it will be checked if point
                 Neumann conditions do contain nodes at the same spatial positions.
         """

--- a/src/meshpy/core/conf.py
+++ b/src/meshpy/core/conf.py
@@ -49,6 +49,21 @@ class BoundaryCondition(_Enum):
     point_coupling = _auto()
     point_coupling_penalty = _auto()
 
+    def is_point_coupling_pairwise(self) -> bool:
+        """Check whether the point coupling condition should be applied
+        pairwise.
+
+        Returns:
+            bool: True if the coupling should be applied individually between pairs of nodes,
+                rather than to the entire geometry set as a whole.
+        """
+        if self == self.point_coupling:
+            return False
+        elif self == self.point_coupling_penalty:
+            return True
+        else:
+            raise TypeError(f"Gor unexpected coupling type {self}")
+
 
 class BeamType(_Enum):
     """Enum for beam types."""

--- a/src/meshpy/core/coupling.py
+++ b/src/meshpy/core/coupling.py
@@ -100,49 +100,6 @@ class Coupling(_BoundaryConditionBase):
                 "The nodes given to Coupling do not have the same position."
             )
 
-    def dump_to_list(self):
-        """Return a list with a single item representing this coupling
-        condition."""
-
-        if isinstance(self.data, dict):
-            data = self.data
-        else:
-            # In this case we have to check which beams are connected to the node.
-            # TODO: Coupling also makes sense for different beam types, this can
-            # be implemented at some point.
-            nodes = self.geometry_set.get_points()
-            beam_type = nodes[0].element_link[0].beam_type
-            for node in nodes:
-                for element in node.element_link:
-                    if beam_type is not element.beam_type:
-                        raise ValueError(
-                            f'The first element in this coupling is of the type "{beam_type}" '
-                            f'another one is of type "{element.beam_type}"! They have to be '
-                            "of the same kind."
-                        )
-                    if beam_type is _mpy.beam.kirchhoff and element.rotvec is False:
-                        raise ValueError(
-                            "Couplings for Kirchhoff beams and rotvec==False not yet implemented."
-                        )
-
-            # In 4C it is not possible to couple beams of the same type, but
-            # with different centerline discretizations, e.g. Beam3rHerm2Line3
-            # and Beam3rLine2Line2, therefore, we check that all beams are
-            # exactly the same type and discretization.
-            # TODO: Remove this check once it is possible to couple beams, but
-            # then also the syntax in the next few lines has to be adapted.
-            beam_four_c_type = type(nodes[0].element_link[0])
-            for node in nodes:
-                for element in node.element_link:
-                    if beam_four_c_type is not type(element):
-                        raise ValueError(
-                            "Coupling beams of different types is not yet possible!"
-                        )
-
-            data = beam_four_c_type.get_coupling_dict(self.data)
-
-        return [{"E": self.geometry_set.i_global, **data}]
-
 
 def coupling_factory(geometry, coupling_type, coupling_dof_type, **kwargs):
     """Create coupling conditions for the nodes in geometry.

--- a/src/meshpy/core/coupling.py
+++ b/src/meshpy/core/coupling.py
@@ -43,19 +43,20 @@ class Coupling(_BoundaryConditionBase):
         self,
         geometry: _Union[_GeometrySetBase, _List[_Node]],
         coupling_type: _Union[_conf.BoundaryCondition, str],
-        coupling_dof_type,
+        coupling_dof_type: _Union[_conf.CouplingDofType, dict],
         *,
         check_overlapping_nodes: bool = True,
-        **kwargs,
     ):
         """Initialize this object.
 
         Args:
             geometry: Geometry set or nodes that should be coupled.
-            coupling_type: Type of coupling.
-            coupling_dof_type: mpy.coupling_dof, str
-                If this is a string it is the string that will be used in the input
-                file, otherwise it has to be of type mpy.coupling_dof.
+            coupling_type: If this is a string, this will be the section that
+                this coupling will be added to. If it is a mpy.bc, the section
+                will be determined automatically.
+            coupling_dof_type: If this is a dictionary it is the dictionary
+                that will be used in the input file, otherwise it has to be
+                of type mpy.coupling_dof.
             check_overlapping_nodes: If all nodes of this coupling condition
                 have to be at the same physical position.
         """
@@ -76,8 +77,7 @@ class Coupling(_BoundaryConditionBase):
         ):
             raise TypeError("Couplings are only implemented for point sets.")
 
-        super().__init__(geometry, bc_type=coupling_type, **kwargs)
-        self.coupling_dof_type = coupling_dof_type
+        super().__init__(geometry, bc_type=coupling_type, data=coupling_dof_type)
         self.check_overlapping_nodes = check_overlapping_nodes
 
         # Perform sanity checks for this boundary condition
@@ -104,8 +104,8 @@ class Coupling(_BoundaryConditionBase):
         """Return a list with a single item representing this coupling
         condition."""
 
-        if isinstance(self.coupling_dof_type, dict):
-            data = self.coupling_dof_type
+        if isinstance(self.data, dict):
+            data = self.data
         else:
             # In this case we have to check which beams are connected to the node.
             # TODO: Coupling also makes sense for different beam types, this can
@@ -139,7 +139,7 @@ class Coupling(_BoundaryConditionBase):
                             "Coupling beams of different types is not yet possible!"
                         )
 
-            data = beam_four_c_type.get_coupling_dict(self.coupling_dof_type)
+            data = beam_four_c_type.get_coupling_dict(self.data)
 
         return [{"E": self.geometry_set.i_global, **data}]
 
@@ -153,9 +153,7 @@ def coupling_factory(geometry, coupling_type, coupling_dof_type, **kwargs):
     of the coupling.
     """
 
-    if coupling_type is _mpy.bc.point_coupling_penalty:
-        # Penalty point couplings in 4C can only contain two nodes. In this case
-        # we expect the given geometry to be a list of nodes.
+    if coupling_type.is_point_coupling_pairwise():
         main_node = geometry[0]
         return [
             Coupling([main_node, node], coupling_type, coupling_dof_type, **kwargs)

--- a/src/meshpy/core/mesh_utils.py
+++ b/src/meshpy/core/mesh_utils.py
@@ -60,7 +60,7 @@ def get_coupled_nodes_to_master_map(
     # Get a dictionary that maps the "replaced" nodes to the "master" ones
     replaced_node_to_master_map = {}
     for coupling in mesh.boundary_conditions[_mpy.bc.point_coupling, _mpy.geo.point]:
-        if coupling.coupling_dof_type is not _mpy.coupling_dof.fix:
+        if coupling.data is not _mpy.coupling_dof.fix:
             raise ValueError(
                 "This function is only implemented for rigid joints at the DOFs"
             )

--- a/src/meshpy/space_time/beam_to_space_time.py
+++ b/src/meshpy/space_time/beam_to_space_time.py
@@ -265,7 +265,7 @@ def beam_to_space_time(
                         for node_id in coupling_node_ids
                     ],
                     coupling.bc_type,
-                    coupling.coupling_dof_type,
+                    coupling.data,
                 )
             )
 


### PR DESCRIPTION
This PR moves all the 4C related coupling functionality out of `core` and into `input_file`. The functionality of `_dump_coupling` is also refactored. The function `_dump_coupling` will likely be moved to a better place in the future - when the mesh export stuff is refactored.