### PR TITLE
Improve import of elements from yaml file

### DIFF
--- a/src/meshpy/core/element.py
+++ b/src/meshpy/core/element.py
@@ -21,11 +21,7 @@
 # THE SOFTWARE.
 """This module implements the class that represents one element in the Mesh."""
 
-from typing import List as _List
-
 from meshpy.core.base_mesh_item import BaseMeshItem as _BaseMeshItem
-from meshpy.core.node import Node as _Node
-from meshpy.utils.environment import fourcipp_is_available as _fourcipp_is_available
 
 
 class Element(_BaseMeshItem):
@@ -45,97 +41,6 @@ class Element(_BaseMeshItem):
 
         # VTK cell data for this element.
         self.vtk_cell_data = {}
-
-    @classmethod
-    def from_legacy_string(cls, nodes: _List[_Node], input_line: str):
-        """Create an element from a legacy string."""
-
-        if _fourcipp_is_available():
-            raise ValueError(
-                "Port this functionality to create the element from the dict "
-                "representing the element, not the legacy string."
-                "TODO: pass the nodes array here, so we can directly link to the nodes"
-            )
-
-        # Import solid element classes for creation of the element.
-        from meshpy.core.element_volume import VolumeHEX8 as _VolumeHEX8
-        from meshpy.core.element_volume import VolumeHEX20 as _VolumeHEX20
-        from meshpy.core.element_volume import VolumeHEX27 as _VolumeHEX27
-        from meshpy.core.element_volume import VolumeTET4 as _VolumeTET4
-        from meshpy.core.element_volume import VolumeTET10 as _VolumeTET10
-        from meshpy.core.element_volume import VolumeWEDGE6 as _VolumeWEDGE6
-        from meshpy.four_c.element_volume import SolidRigidSphere as _SolidRigidSphere
-
-        # Split up input line and get pre node string.
-        line_split = input_line.split()
-        string_pre_nodes = " ".join(line_split[1:3])
-
-        # Get a list of the element nodes.
-        # This is only here because we need the pre and post strings - can be
-        # removed when moving on from the legacy format.
-        dummy = []
-        for i, item in enumerate(line_split[3:]):
-            if item.isdigit():
-                dummy.append(int(item) - 1)
-            else:
-                break
-        else:
-            raise ValueError(
-                f'The input line:\n"{input_line}"\ncould not be converted to a solid element!'
-            )
-
-        # Get the post node string
-        string_post_nodes = " ".join(line_split[3 + i :])
-
-        # Depending on the number of nodes chose which solid element to return.
-        n_nodes = len(nodes)
-        match n_nodes:
-            case 8:
-                return _VolumeHEX8(
-                    nodes=nodes,
-                    string_pre_nodes=string_pre_nodes,
-                    string_post_nodes=string_post_nodes,
-                )
-            case 4:
-                return _VolumeTET4(
-                    nodes=nodes,
-                    string_pre_nodes=string_pre_nodes,
-                    string_post_nodes=string_post_nodes,
-                )
-            case 10:
-                return _VolumeTET10(
-                    nodes=nodes,
-                    string_pre_nodes=string_pre_nodes,
-                    string_post_nodes=string_post_nodes,
-                )
-            case 20:
-                return _VolumeHEX20(
-                    nodes=nodes,
-                    string_pre_nodes=string_pre_nodes,
-                    string_post_nodes=string_post_nodes,
-                )
-            case 27:
-                return _VolumeHEX27(
-                    nodes=nodes,
-                    string_pre_nodes=string_pre_nodes,
-                    string_post_nodes=string_post_nodes,
-                )
-            case 6:
-                return _VolumeWEDGE6(
-                    nodes=nodes,
-                    string_pre_nodes=string_pre_nodes,
-                    string_post_nodes=string_post_nodes,
-                )
-            case 1:
-                return _SolidRigidSphere(
-                    nodes=nodes,
-                    string_pre_nodes=string_pre_nodes,
-                    string_post_nodes=string_post_nodes,
-                )
-            case _:
-                raise TypeError(
-                    f"Could not find a element type for {string_pre_nodes}, with {n_nodes} nodes"
-                )
 
     def flip(self):
         """Reverse the nodes of this element.

--- a/src/meshpy/four_c/model_importer.py
+++ b/src/meshpy/four_c/model_importer.py
@@ -36,10 +36,16 @@ from meshpy.core.boundary_condition import (
 )
 from meshpy.core.conf import mpy as _mpy
 from meshpy.core.coupling import Coupling as _Coupling
-from meshpy.core.element import Element as _Element
+from meshpy.core.element_volume import VolumeHEX8 as _VolumeHEX8
+from meshpy.core.element_volume import VolumeHEX20 as _VolumeHEX20
+from meshpy.core.element_volume import VolumeHEX27 as _VolumeHEX27
+from meshpy.core.element_volume import VolumeTET4 as _VolumeTET4
+from meshpy.core.element_volume import VolumeTET10 as _VolumeTET10
+from meshpy.core.element_volume import VolumeWEDGE6 as _VolumeWEDGE6
 from meshpy.core.geometry_set import GeometrySetNodes as _GeometrySetNodes
 from meshpy.core.mesh import Mesh as _Mesh
 from meshpy.core.node import Node as _Node
+from meshpy.four_c.element_volume import SolidRigidSphere as _SolidRigidSphere
 from meshpy.four_c.input_file import InputFile as _InputFile
 from meshpy.four_c.input_file import (
     get_geometry_set_indices_from_section as _get_geometry_set_indices_from_section,
@@ -80,6 +86,62 @@ def import_four_c_model(
         return _extract_mesh_sections(input_file)
     else:
         return input_file, _Mesh()
+
+
+def _element_from_dict(nodes: _List[_Node], input_line: str):
+    """TODO: Update this doc string once we don't use the legacy string any more.
+    Create an element from a legacy string."""
+
+    if _fourcipp_is_available():
+        raise ValueError(
+            "Port this functionality to create the element from the dict "
+            "representing the element, not the legacy string."
+            "TODO: pass the nodes array here, so we can directly link to the nodes"
+            "TODO: The whole string_pre_nodes and string_post_nodes is obsolete once"
+            " we move on from legacy string"
+        )
+
+    # Split up input line and get pre node string.
+    line_split = input_line.split()
+    string_pre_nodes = " ".join(line_split[1:3])
+
+    # Get a list of the element nodes.
+    # This is only here because we need the pre and post strings - can be
+    # removed when moving on from the legacy format.
+    dummy = []
+    for i, item in enumerate(line_split[3:]):
+        if item.isdigit():
+            dummy.append(int(item) - 1)
+        else:
+            break
+    else:
+        raise ValueError(
+            f'The input line:\n"{input_line}"\ncould not be converted to a solid element!'
+        )
+
+    # Get the post node string
+    string_post_nodes = " ".join(line_split[3 + i :])
+
+    # Depending on the number of nodes chose which solid element to return.
+    n_nodes = len(nodes)
+    element_type = {
+        8: _VolumeHEX8,
+        20: _VolumeHEX20,
+        27: _VolumeHEX27,
+        4: _VolumeTET4,
+        10: _VolumeTET10,
+        6: _VolumeWEDGE6,
+        1: _SolidRigidSphere,
+    }
+    if n_nodes not in element_type:
+        raise TypeError(
+            f"Could not find a element type for {string_pre_nodes}, with {n_nodes} nodes"
+        )
+    return element_type[n_nodes](
+        nodes=nodes,
+        string_pre_nodes=string_pre_nodes,
+        string_post_nodes=string_post_nodes,
+    )
 
 
 def _boundary_condition_from_dict(
@@ -174,7 +236,7 @@ def _extract_mesh_sections(input_file: _InputFile) -> _Tuple[_InputFile, _Mesh]:
                 f'The input line:\n"{item}"\ncould not be converted to a element!'
             )
 
-        mesh.elements.append(_Element.from_legacy_string(element_nodes, item))
+        mesh.elements.append(_element_from_dict(element_nodes, item))
 
     # Add geometry sets
     geometry_sets_in_sections: dict[str, dict[int, _GeometrySetNodes]] = {


### PR DESCRIPTION
This PR moves the import of (mainly) solid elements from a yaml file from `core.element` to `model_importer` which make a slot more sense from a modularisation point of view. The function is now named `_element_condition_from_dict` (at the moment it still converts a legacy string, but that will hopefully change soon). 

This also allows us to get rid of a lot of "in function" includes.

@davidrudlstorfer I hope this does not interfere with your existing work too much. If so, let's talk and we will find a solution.