### PR TITLE
Move 4C related stuff out of function

### DIFF
--- a/src/meshpy/core/function.py
+++ b/src/meshpy/core/function.py
@@ -19,8 +19,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-"""This module implements a basic class to manage functions in the 4C input
-file."""
+"""This module implements a basic class to manage functions in a MeshPy
+mesh."""
 
 from meshpy.core.base_mesh_item import BaseMeshItem as _BaseMeshItem
 
@@ -28,9 +28,8 @@ from meshpy.core.base_mesh_item import BaseMeshItem as _BaseMeshItem
 class Function(_BaseMeshItem):
     """Holds information for a function."""
 
-    def __init__(self, function_list):
-        super().__init__()
-        self.function_list = function_list
+    def __init__(self, function_data):
+        super().__init__(data=function_data)
 
     def __deepcopy__(self, memo):
         """When deepcopy is called on a mesh, we do not want the same functions
@@ -42,7 +41,3 @@ class Function(_BaseMeshItem):
 
         # Return this object again, as no copy should be created.
         return self
-
-    def dump_to_list(self):
-        """Return a list with the items representing this function."""
-        return self.function_list

--- a/src/meshpy/core/mesh.py
+++ b/src/meshpy/core/mesh.py
@@ -42,6 +42,7 @@ from meshpy.core.conf import mpy as _mpy
 from meshpy.core.coupling import coupling_factory as _coupling_factory
 from meshpy.core.element import Element as _Element
 from meshpy.core.element_beam import Beam as _Beam
+from meshpy.core.function import Function as _Function
 from meshpy.core.geometry_set import GeometryName as _GeometryName
 from meshpy.core.geometry_set import GeometrySetBase as _GeometrySetBase
 from meshpy.core.geometry_set import GeometrySetContainer as _GeometrySetContainer
@@ -52,7 +53,6 @@ from meshpy.core.rotation import Rotation as _Rotation
 from meshpy.core.rotation import add_rotations as _add_rotations
 from meshpy.core.rotation import rotate_coordinates as _rotate_coordinates
 from meshpy.core.vtk_writer import VTKWriter as _VTKWriter
-from meshpy.four_c.function import Function as _Function
 from meshpy.geometric_search.find_close_points import (
     find_close_points as _find_close_points,
 )

--- a/src/meshpy/four_c/dbc_monitor.py
+++ b/src/meshpy/four_c/dbc_monitor.py
@@ -28,9 +28,9 @@ import numpy as _np
 
 from meshpy.core.boundary_condition import BoundaryCondition as _BoundaryCondition
 from meshpy.core.conf import mpy as _mpy
+from meshpy.core.function import Function as _Function
 from meshpy.core.geometry_set import GeometrySet as _GeometrySet
 from meshpy.core.mesh import Mesh as _Mesh
-from meshpy.four_c.function import Function as _Function
 from meshpy.four_c.function_utility import (
     create_linear_interpolation_function as _create_linear_interpolation_function,
 )

--- a/src/meshpy/four_c/function_utility.py
+++ b/src/meshpy/four_c/function_utility.py
@@ -26,7 +26,7 @@ from typing import List as _List
 
 import numpy as _np
 
-from meshpy.four_c.function import Function as _Function
+from meshpy.core.function import Function as _Function
 
 
 def create_linear_interpolation_dict(

--- a/src/meshpy/four_c/input_file.py
+++ b/src/meshpy/four_c/input_file.py
@@ -423,7 +423,7 @@ class InputFile:
 
         # Add the functions.
         for function in mesh.functions:
-            self.sections[f"FUNCT{function.i_global}"] = function.dump_to_list()
+            self.sections[f"FUNCT{function.i_global}"] = function.data
 
         # If there are couplings in the mesh, set the link between the nodes
         # and elements, so the couplings can decide which DOFs they couple,

--- a/src/meshpy/four_c/locsys_condition.py
+++ b/src/meshpy/four_c/locsys_condition.py
@@ -27,9 +27,9 @@ from typing import Union as _Union
 
 from meshpy.core.boundary_condition import BoundaryCondition as _BoundaryCondition
 from meshpy.core.conf import mpy as _mpy
+from meshpy.core.function import Function as _Function
 from meshpy.core.geometry_set import GeometrySet as _GeometrySet
 from meshpy.core.rotation import Rotation as _Rotation
-from meshpy.four_c.function import Function as _Function
 from meshpy.four_c.function_utility import (
     ensure_length_of_function_array as _ensure_length_of_function_array,
 )

--- a/src/meshpy/four_c/yaml_dumper.py
+++ b/src/meshpy/four_c/yaml_dumper.py
@@ -24,7 +24,7 @@
 import numpy as _np
 import yaml as _yaml
 
-from meshpy.four_c.function import Function as _Function
+from meshpy.core.function import Function as _Function
 
 
 class MeshPyDumper(_yaml.SafeDumper):

--- a/tests/test_four_c.py
+++ b/tests/test_four_c.py
@@ -27,6 +27,7 @@ import pytest
 
 from meshpy.core.boundary_condition import BoundaryCondition
 from meshpy.core.conf import mpy
+from meshpy.core.function import Function
 from meshpy.core.geometry_set import GeometrySet
 from meshpy.core.mesh import Mesh
 from meshpy.core.rotation import Rotation
@@ -34,7 +35,6 @@ from meshpy.four_c.beam_interaction_conditions import add_beam_interaction_condi
 from meshpy.four_c.beam_potential import BeamPotential
 from meshpy.four_c.dbc_monitor import linear_time_transformation
 from meshpy.four_c.element_beam import Beam3rHerm2Line3
-from meshpy.four_c.function import Function
 from meshpy.four_c.input_file import InputFile
 from meshpy.four_c.locsys_condition import LocSysCondition
 from meshpy.four_c.material import MaterialReissner

--- a/tests/test_four_c_simulation.py
+++ b/tests/test_four_c_simulation.py
@@ -28,6 +28,7 @@ import pytest
 
 from meshpy.core.boundary_condition import BoundaryCondition
 from meshpy.core.conf import mpy
+from meshpy.core.function import Function
 from meshpy.core.geometry_set import GeometrySet
 from meshpy.core.mesh import Mesh
 from meshpy.core.rotation import Rotation
@@ -37,7 +38,6 @@ from meshpy.four_c.dbc_monitor import (
     dbc_monitor_to_mesh_all_values,
 )
 from meshpy.four_c.element_beam import Beam3rHerm2Line3
-from meshpy.four_c.function import Function
 from meshpy.four_c.function_utility import create_linear_interpolation_function
 from meshpy.four_c.header_functions import (
     add_result_description,

--- a/tests/test_function_utilities.py
+++ b/tests/test_function_utilities.py
@@ -47,7 +47,7 @@ def test_linear_interpolation_function(assert_results_equal):
                 "VALUES": [1.0, 1.0, -1.0, 3.5, -10.3, -10.3],
             },
         ],
-        fun.dump_to_list(),
+        fun.data,
     )
 
     fun = create_linear_interpolation_function(t, values, function_type="My type")
@@ -63,7 +63,7 @@ def test_linear_interpolation_function(assert_results_equal):
                 "VALUES": [1.0, 1.0, -1.0, 3.5, -10.3, -10.3],
             },
         ],
-        fun.dump_to_list(),
+        fun.data,
     )
 
     function_definition = create_linear_interpolation_dict(

--- a/tests/test_meshpy.py
+++ b/tests/test_meshpy.py
@@ -34,6 +34,7 @@ from meshpy.core.boundary_condition import BoundaryCondition
 from meshpy.core.conf import mpy
 from meshpy.core.coupling import Coupling
 from meshpy.core.element_beam import Beam
+from meshpy.core.function import Function
 from meshpy.core.geometry_set import GeometryName, GeometrySet, GeometrySetNodes
 from meshpy.core.material import MaterialBeam
 from meshpy.core.mesh import Mesh
@@ -46,7 +47,6 @@ from meshpy.four_c.element_beam import (
     Beam3rHerm2Line3,
     Beam3rLine2Line2,
 )
-from meshpy.four_c.function import Function
 from meshpy.four_c.header_functions import (
     add_result_description,
     set_beam_to_solid_meshtying,


### PR DESCRIPTION
Until now the base `Function` class was in `four_c`. However, there is no functionality related to 4C in there. This PR moves the function to `core`. With this there are no more `four_c` imports in core. (Still not all 4C functionality is moved out of `core`, e.g., `dump` functions, ...).