### PR TITLE
Update vistools link

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ dev = [
   "pre-commit",
   "pytest",
   "pytest-cov",
-  "pyvista_utils@git+https://github.com/isteinbrecher/pyvista_utils.git@main",
-  "testbook"
+  "testbook",
+  "vistools"
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ import vtk
 import yaml
 from _pytest.config import Config
 from _pytest.config.argparsing import Parser
-from vtk_utils.compare_grids import compare_grids
+from vistools.vtk.compare_grids import compare_grids
 
 from meshpy.core.conf import mpy
 from meshpy.core.mesh import Mesh


### PR DESCRIPTION
The package `pyvista_utils` has been renamed to `vistools` (thus the failing pipeline tonight) and uploaded to PyPi. This PR updates the names and links.