### PR TITLE
Improve handling of `data` in BaseMeshItem

### DIFF
--- a/src/meshpy/core/element.py
+++ b/src/meshpy/core/element.py
@@ -28,7 +28,7 @@ class Element(_BaseMeshItem):
     """A base class for an FEM element in the mesh."""
 
     def __init__(self, nodes=None, material=None, **kwargs):
-        super().__init__(data=None, **kwargs)
+        super().__init__(**kwargs)
 
         # List of nodes that are connected to the element.
         if nodes is None:

--- a/src/meshpy/core/material.py
+++ b/src/meshpy/core/material.py
@@ -29,8 +29,8 @@ from meshpy.core.base_mesh_item import BaseMeshItem as _BaseMeshItem
 class Material(_BaseMeshItem):
     """Base class for all materials."""
 
-    def __init__(self, data=None, **kwargs):
-        super().__init__(data=data, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     def __deepcopy__(self, memo):
         """When deepcopy is called on a mesh, we do not want the materials to

--- a/src/meshpy/core/node.py
+++ b/src/meshpy/core/node.py
@@ -32,7 +32,7 @@ class Node(_BaseMeshItem):
     """This object represents one node in the mesh."""
 
     def __init__(self, coordinates, *, is_middle_node=False, **kwargs):
-        super().__init__(data=None, **kwargs)
+        super().__init__(**kwargs)
 
         # Coordinates of this node.
         self.coordinates = _np.array(coordinates)


### PR DESCRIPTION
We have the member variable `self.data` in `BaseMeshItem`, which is very well suited to hold solver specific data. This PR fixes some weird initialisations of this variable in `Node`, `Material` and `Element`.

@davidrudlstorfer at the moment the default value of `BaseMeshItem.data` is `None`. I think that is the most natural choice, but if it helps us for 4C, we can also change this to an empty dict.