### PR TITLE
Improve performance of rotation copy

### DIFF
--- a/src/meshpy/core/rotation.py
+++ b/src/meshpy/core/rotation.py
@@ -332,8 +332,8 @@ class Rotation:
             return object.__eq__(self, other)
 
     def copy(self):
-        """Return a deep copy of this object."""
-        return _copy.deepcopy(self)
+        """Return a copy of this object."""
+        return Rotation.from_quaternion(self.q, normalized=True)
 
     def __str__(self):
         """String representation of object."""


### PR DESCRIPTION
Improves the performance of the rotation functionality.

Notes:

- I also tested
```
return copy.copy(self)
```
which already was faster. But the current approach is much faster

- If the copy is not independent of the original rotation, the tests fail. With this approach all tests succeed.