### PR TITLE
Remove BeamToSolidInteractionType

### DIFF
--- a/src/meshpy/core/conf.py
+++ b/src/meshpy/core/conf.py
@@ -80,13 +80,6 @@ class CouplingDofType(_Enum):
     joint = _auto()
 
 
-class BeamToSolidInteractionType(_Enum):
-    """Enum for beam-to-solid interaction types."""
-
-    volume_meshtying = _auto()
-    surface_meshtying = _auto()
-
-
 class DoubleNodes(_Enum):
     """Enum for handing double nodes in Neumann conditions."""
 
@@ -138,9 +131,6 @@ class MeshPy(object):
 
         # Beam types.
         self.beam = BeamType
-
-        # Beam-to-solid interaction types.
-        self.beam_to_solid = BeamToSolidInteractionType
 
         # Coupling types.
         self.coupling_dof = CouplingDofType

--- a/src/meshpy/four_c/header_functions.py
+++ b/src/meshpy/four_c/header_functions.py
@@ -185,7 +185,7 @@ def set_beam_to_solid_meshtying(
     ----
     input_file:
         Input file that the options will be added to.
-    interaction_type: BeamToSolidInteractionType
+    interaction_type: BoundaryCondition
         Type of beam-to-solid interaction.
     contact_discretization: str
         Type of contact (mortar, Gauss point, ...)
@@ -231,9 +231,9 @@ def set_beam_to_solid_meshtying(
 
     # Add the beam to solid volume mesh tying options.
     bts_parameters = {}
-    if interaction_type == _mpy.beam_to_solid.volume_meshtying:
+    if interaction_type == _mpy.bc.beam_to_solid_volume_meshtying:
         bts_section_name = "BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING"
-    elif interaction_type == _mpy.beam_to_solid.surface_meshtying:
+    elif interaction_type == _mpy.bc.beam_to_solid_surface_meshtying:
         bts_section_name = "BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING"
         if coupling_type is not None:
             bts_parameters["COUPLING_TYPE"] = coupling_type
@@ -267,7 +267,7 @@ def set_beam_to_solid_meshtying(
     bts_parameters["GEOMETRY_PAIR_SEGMENTATION_SEARCH_POINTS"] = (
         segmentation_search_points
     )
-    if interaction_type == _mpy.beam_to_solid.volume_meshtying:
+    if interaction_type == _mpy.bc.beam_to_solid_volume_meshtying:
         bts_parameters["COUPLE_RESTART_STATE"] = couple_restart
 
     input_file.add({bts_section_name: bts_parameters})

--- a/tests/test_header_functions.py
+++ b/tests/test_header_functions.py
@@ -54,13 +54,13 @@ def test_header_functions_static(
 
     set_beam_to_solid_meshtying(
         input_file,
-        mpy.beam_to_solid.volume_meshtying,
+        mpy.bc.beam_to_solid_volume_meshtying,
         contact_discretization="mortar",
     )
 
     set_beam_to_solid_meshtying(
         input_file,
-        mpy.beam_to_solid.surface_meshtying,
+        mpy.bc.beam_to_solid_surface_meshtying,
         contact_discretization="gp",
         coupling_type="consistent_fad",
         segmentation=False,
@@ -124,7 +124,7 @@ def test_header_functions_static_prestress(
     )
     set_beam_to_solid_meshtying(
         input_file,
-        mpy.beam_to_solid.volume_meshtying,
+        mpy.bc.beam_to_solid_volume_meshtying,
         contact_discretization="mortar",
         binning_parameters={
             "binning_bounding_box": [1, 2, 3, 4, 5, 6],
@@ -135,7 +135,7 @@ def test_header_functions_static_prestress(
 
     set_beam_to_solid_meshtying(
         input_file,
-        mpy.beam_to_solid.surface_meshtying,
+        mpy.bc.beam_to_solid_surface_meshtying,
         contact_discretization="gp",
         segmentation=False,
         couple_restart=False,

--- a/tests/test_meshpy.py
+++ b/tests/test_meshpy.py
@@ -1295,7 +1295,7 @@ def test_meshpy_nurbs_import(
     )
     set_beam_to_solid_meshtying(
         input_file,
-        mpy.beam_to_solid.volume_meshtying,
+        mpy.bc.beam_to_solid_volume_meshtying,
         contact_discretization="mortar",
         mortar_shape="line4",
         penalty_parameter=1000,


### PR DESCRIPTION
Remove `BeamToSolidInteractionType`, this enum was overlapping with the `BoundaryCondition` enums, so let's remove this to have one unique set of enums for beam-to-solid types. If we want, we can at some point move them out of `BoundaryCondition` in an individual enum container (I think that was the original idea why this happened in the first place).