### PR TITLE
Fix Github workflows

### DIFF
--- a/.github/workflows/build_binder.yml
+++ b/.github/workflows/build_binder.yml
@@ -14,7 +14,8 @@ jobs:
   trigger-binder-build:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger binder build
-        run: |
-          echo "Triggering Binder build for the main branch..."
-          curl "https://mybinder.org/build/gh/imcs-compsim/meshpy/main"
+      - uses: s-weigand/trigger-mybinder-build@v1
+        with:
+          target-repo: imcs-compsim/meshpy
+          service-name: gh
+          debug: true

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -15,6 +15,8 @@ concurrency:
 
 jobs:
   build_website:
+    # Only run if a push to main occurred, do not run after nightly cron job
+    if: ${{ github.event.workflow_run.event == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This fixes two errors from yesterday

- The documentation was successfully not build after the cron job but the website deployed, this is due to the fact that the documentation workflow is still a success. So we need the condition in the website job as well.

- The automatic binder build failed (maybe due to the wrong link) but lets try to do it with the ready-to-use workflow (if it still works)