### PR TITLE
fix: website deployment

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -15,8 +15,8 @@ concurrency:
 
 jobs:
   build_website:
-    # Only run if a push to main occurred, do not run after nightly cron job
-    if: ${{ github.event.workflow_run.event == 'push' }}
+    # Only run if documentation was built successfully (if it is skipped, it is not successful)
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This was far more complex than initially anticipated :D

The problem is that our testing workflow is either triggered by a push or a cron. This condition can be checked *one* downstream workflow, i.e., in the documentation workflow. But this condition can *not* be checked during the website build because we have one intermediate workflow.

I then tried to hand over variables between the workflows, I tried to hand over artifacts but all of that is pretty complex.

Turns out this could be far simpler if we just check if the docu step was "successfull". Note that we have to skip all jobs in the docu workflow - but we are skipping all of them.

I checked that it works on my branch "in production". The skip works, and also the "not" skip works.