### PR TITLE
Install cubit in GitHub hosted container

### DIFF
--- a/.github/actions/setup_cubit/action.yml
+++ b/.github/actions/setup_cubit/action.yml
@@ -1,0 +1,19 @@
+name: setup_cubit
+description: Setup a Cubit installation for testing
+runs:
+  using: composite
+  steps:
+    - name: Setup Cubit
+      shell: bash
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        wget https://f002.backblazeb2.com/file/cubit-downloads/Coreform-Cubit/Releases/Linux/Coreform-Cubit-2025.3%2B58709-Lin64.tar.gz
+        ll -la
+        # ${{ inputs.source-command }}
+        # pip install ${{ inputs.install-command }}
+        # python --version
+        # pip list
+        # TEMP_DIR="${RUNNER_TEMP}/meshpy_pytest"
+        # mkdir -p "$TEMP_DIR"
+        # echo "PYTEST_TMPDIR=$TEMP_DIR" >> $GITHUB_ENV
+        # pytest  --basetemp="$TEMP_DIR" ${{ inputs.additional-pytest-flags}} --color=yes

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -88,6 +88,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Setup cubit
+        uses: ./.github/actions/setup_cubit
       - name: Setup virtual python environment
         uses: ./.github/actions/setup_virtual_python_environment
       - name: Build ArborX geometric search


### PR DESCRIPTION
Install cubit in the GitHub hosted container, this would allow us to not need self-hosted runners.

Approach is the following, we download cubit and activate it using a academic-testing license (cubit support suggested this approach).

Only downside, the installation has to download 1GB which could drastically slow down the pipeline - let's see.