### PR TITLE
Temporarily use last 4C release for testing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -79,7 +79,7 @@ jobs:
     name: ubuntu-latest with 4C and ArborX
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c:main
+      image: ghcr.io/4c-multiphysics/4c:2025.2.0
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Check if we can temporarily fix the pipelines by using the latest 4C release image.