### PR TITLE
Unify `i_global` to be 0-based

### DIFF
--- a/src/beamme/core/element_volume.py
+++ b/src/beamme/core/element_volume.py
@@ -44,7 +44,7 @@ class VolumeElement(_Element):
         """Return a dict with the items representing this object."""
 
         return {
-            "id": self.i_global,
+            "id": self.i_global + 1,
             "cell": {
                 "type": element_type_to_four_c_string[type(self)],
                 "connectivity": self.nodes,

--- a/src/beamme/core/geometry_set.py
+++ b/src/beamme/core/geometry_set.py
@@ -156,9 +156,9 @@ class GeometrySetBase(_BaseMeshItem):
         return [
             {
                 "type": "NODE",
-                "node_id": node.i_global,
+                "node_id": node.i_global + 1,
                 "d_type": self.geometry_set_names[self.geometry_type],
-                "d_id": self.i_global,
+                "d_id": self.i_global + 1,
             }
             for node in nodes
         ]

--- a/src/beamme/core/mesh.py
+++ b/src/beamme/core/mesh.py
@@ -329,7 +329,7 @@ class Mesh:
                     raise KeyError("Could not find {key} in geometry_set_start_indices")
             for i, geometry_set in enumerate(mesh_sets[key]):
                 # Add global indices to the geometry set.
-                geometry_set.i_global = i + 1 + i_global_offset
+                geometry_set.i_global = i + i_global_offset
                 if is_link_nodes:
                     geometry_set.link_to_nodes(link_to_nodes=link_to_nodes)
 

--- a/src/beamme/core/node.py
+++ b/src/beamme/core/node.py
@@ -97,7 +97,7 @@ class Node(_BaseMeshItem):
         """Return a list with the legacy string representing this node."""
 
         return {
-            "id": self.i_global,
+            "id": self.i_global + 1,
             "COORD": self.coordinates,
             "data": {"type": "NODE"},
         }
@@ -150,7 +150,7 @@ class ControlPoint(Node):
         point."""
 
         return {
-            "id": self.i_global,
+            "id": self.i_global + 1,
             "COORD": self.coordinates,
             "data": {"type": "CP", "weight": self.weight},
         }

--- a/src/beamme/core/nurbs_patch.py
+++ b/src/beamme/core/nurbs_patch.py
@@ -226,7 +226,7 @@ class NURBSSurface(NURBSPatch):
 
                 patch_elements.append(
                     {
-                        "id": self.i_global + j,
+                        "id": self.i_global + j + 1,
                         "cell": {
                             "type": f"NURBS{num_cp_in_element}",
                             "connectivity": connectivity,
@@ -319,7 +319,7 @@ class NURBSVolume(NURBSPatch):
 
                     patch_elements.append(
                         {
-                            "id": self.i_global + increment_ele,
+                            "id": self.i_global + increment_ele + 1,
                             "cell": {
                                 "type": f"NURBS{num_cp_in_element}",
                                 "connectivity": connectivity,

--- a/src/beamme/core/vtk_writer.py
+++ b/src/beamme/core/vtk_writer.py
@@ -76,7 +76,7 @@ def add_point_data_node_sets(point_data, nodes, *, extra_points=0):
             raise TypeError("The geometry type is wrong!")
 
         # Add the data vector.
-        set_name = f"{geometry_name}_set_{_bme.vtk_node_set_format.format(geometry_set.i_global)}"
+        set_name = f"{geometry_name}_set_{_bme.vtk_node_set_format.format(geometry_set.i_global + 1)}"
         point_data[set_name] = (data_vector, _bme.vtk_type.int)
 
 

--- a/src/beamme/four_c/element_beam.py
+++ b/src/beamme/four_c/element_beam.py
@@ -54,7 +54,7 @@ class Beam3rHerm2Line3(_Beam):
         self._check_material()
 
         return {
-            "id": self.i_global,
+            "id": self.i_global + 1,
             "cell": {
                 "type": "LINE3",
                 "connectivity": [self.nodes[i] for i in [0, 2, 1]],
@@ -90,7 +90,7 @@ class Beam3rLine2Line2(_Beam):
         self._check_material()
 
         return {
-            "id": self.i_global,
+            "id": self.i_global + 1,
             "cell": {
                 "type": "LINE2",
                 "connectivity": self.nodes,
@@ -139,7 +139,7 @@ class Beam3kClass(_Beam):
         self._check_material()
 
         return {
-            "id": self.i_global,
+            "id": self.i_global + 1,
             "cell": {
                 "type": "LINE3",
                 "connectivity": [self.nodes[i] for i in [0, 2, 1]],
@@ -205,7 +205,7 @@ class Beam3eb(_Beam):
             )
 
         return {
-            "id": self.i_global,
+            "id": self.i_global + 1,
             "cell": {
                 "type": "LINE2",
                 "connectivity": self.nodes,

--- a/src/beamme/four_c/element_volume.py
+++ b/src/beamme/four_c/element_volume.py
@@ -41,7 +41,7 @@ class SolidRigidSphere(_VolumeElement):
         """Return a dict with the items representing this object."""
 
         return {
-            "id": self.i_global,
+            "id": self.i_global + 1,
             "cell": {
                 "type": "POINT1",
                 "connectivity": self.nodes,

--- a/src/beamme/four_c/input_file.py
+++ b/src/beamme/four_c/input_file.py
@@ -106,7 +106,7 @@ def _dump_coupling(coupling):
 
         data = element_type.get_coupling_dict(coupling.data)
 
-    return {"E": coupling.geometry_set.i_global, **data}
+    return {"E": coupling.geometry_set.i_global + 1, **data}
 
 
 class InputFile(_FourCInput):
@@ -124,7 +124,7 @@ class InputFile(_FourCInput):
         # to native Python types via the FourCIPP type converter.
         self.type_converter.register_numpy_types()
         self.type_converter.register_type(
-            (_Function, _Material, _Node), lambda converter, obj: obj.i_global
+            (_Function, _Material, _Node), lambda converter, obj: obj.i_global + 1
         )
 
     def add(self, object_to_add, **kwargs):
@@ -298,8 +298,7 @@ class InputFile(_FourCInput):
 
             # Set the values for i_global.
             for i, item in enumerate(data_list):
-                # TODO make i_global index-0 based
-                item.i_global = i + 1 + start_index
+                item.i_global = i + start_index
 
         def _set_i_global_elements(element_list, *, start_index=0):
             """Set i_global in every item of element_list."""
@@ -314,8 +313,7 @@ class InputFile(_FourCInput):
             for item in element_list:
                 # As a NURBS patch can be defined with more elements, an offset is applied to the
                 # rest of the items
-                # TODO make i_global index-0 based
-                item.i_global = i + 1
+                item.i_global = i
                 if isinstance(item, _NURBSPatch):
                     item.n_nurbs_patch = i_nurbs_patch + 1
                     offset = item.get_number_elements()
@@ -346,7 +344,7 @@ class InputFile(_FourCInput):
                 elif isinstance(item, _BoundaryCondition):
                     list.append(
                         {
-                            "E": item.geometry_set.i_global,
+                            "E": item.geometry_set.i_global + 1,
                             **item.data,
                         }
                     )
@@ -391,7 +389,7 @@ class InputFile(_FourCInput):
 
         # Add the functions.
         for function in mesh.functions:
-            self.add({f"FUNCT{function.i_global}": function.data})
+            self.add({f"FUNCT{function.i_global + 1}": function.data})
 
         # If there are couplings in the mesh, set the link between the nodes
         # and elements, so the couplings can decide which DOFs they couple,

--- a/src/beamme/four_c/material.py
+++ b/src/beamme/four_c/material.py
@@ -72,7 +72,7 @@ class MaterialReissner(_MaterialBeamBase):
         }
         if self.interaction_radius is not None:
             data["INTERACTIONRADIUS"] = self.interaction_radius
-        return {"MAT": self.i_global, self.material_string: data}
+        return {"MAT": self.i_global + 1, self.material_string: data}
 
 
 class MaterialReissnerElastoplastic(MaterialReissner):
@@ -153,7 +153,7 @@ class MaterialKirchhoff(_MaterialBeamBase):
         }
         if self.interaction_radius is not None:
             data["INTERACTIONRADIUS"] = self.interaction_radius
-        return {"MAT": self.i_global, self.material_string: data}
+        return {"MAT": self.i_global + 1, self.material_string: data}
 
 
 class MaterialEulerBernoulli(_MaterialBeamBase):
@@ -184,7 +184,7 @@ class MaterialEulerBernoulli(_MaterialBeamBase):
             "CROSSAREA": area,
             "MOMIN": mom2,
         }
-        return {"MAT": self.i_global, self.material_string: data}
+        return {"MAT": self.i_global + 1, self.material_string: data}
 
 
 class MaterialSolid(_MaterialSolidBase):
@@ -198,7 +198,7 @@ class MaterialSolid(_MaterialSolidBase):
     def dump_to_list(self):
         """Return a list with the (single) item representing this material."""
 
-        return {"MAT": self.i_global, self.material_string: self.data}
+        return {"MAT": self.i_global + 1, self.material_string: self.data}
 
 
 class MaterialStVenantKirchhoff(MaterialSolid):

--- a/tests/test_beamme.py
+++ b/tests/test_beamme.py
@@ -536,14 +536,14 @@ def test_reissner_elasto_plastic(assert_results_close):
     }
 
     mat = MaterialReissnerElastoplastic(**kwargs)
-    mat.i_global = 69
+    mat.i_global = 68
 
     assert_results_close(mat.dump_to_list(), ref_dict)
 
     ref_dict["MAT_BeamReissnerElastPlastic"]["TORSIONPLAST"] = True
     kwargs["torsion_plasticity"] = True
     mat = MaterialReissnerElastoplastic(**kwargs)
-    mat.i_global = 69
+    mat.i_global = 68
     assert_results_close(mat.dump_to_list(), ref_dict)
 
 
@@ -612,11 +612,12 @@ def test_kirchhoff_material(assert_results_close):
         material.polar = 5.0
 
     material = MaterialKirchhoff(youngs_modulus=1000, is_fad=True)
+    material.i_global = 26
     set_stiff(material)
     assert_results_close(
         material.dump_to_list(),
         {
-            "MAT": None,
+            "MAT": 27,
             "MAT_BeamKirchhoffElastHyper": {
                 "YOUNG": 1000,
                 "SHEARMOD": 500.0,
@@ -631,11 +632,12 @@ def test_kirchhoff_material(assert_results_close):
     )
 
     material = MaterialKirchhoff(youngs_modulus=1000, is_fad=False)
+    material.i_global = 26
     set_stiff(material)
     assert_results_close(
         material.dump_to_list(),
         {
-            "MAT": None,
+            "MAT": 27,
             "MAT_BeamKirchhoffElastHyper": {
                 "YOUNG": 1000,
                 "SHEARMOD": 500.0,
@@ -650,11 +652,12 @@ def test_kirchhoff_material(assert_results_close):
     )
 
     material = MaterialKirchhoff(youngs_modulus=1000, interaction_radius=1.1)
+    material.i_global = 26
     set_stiff(material)
     assert_results_close(
         material.dump_to_list(),
         {
-            "MAT": None,
+            "MAT": 27,
             "MAT_BeamKirchhoffElastHyper": {
                 "YOUNG": 1000,
                 "SHEARMOD": 500.0,


### PR DESCRIPTION
Currently we use i_global in different ways, sometimes with a 0 based index and sometimes with an 1 based index. This PR unifies this to be 0 based in the whole code base. This should also ease the usage of common functions for the different application modules (4C, Abaqus, space-time).