### PR TITLE
refactor: improve beam potential

### DIFF
--- a/src/beamme/four_c/beam_potential.py
+++ b/src/beamme/four_c/beam_potential.py
@@ -22,7 +22,11 @@
 """This file includes functions to ease the creation of input files using beam
 interaction potentials."""
 
+import numpy as _np
+
 from beamme.core.boundary_condition import BoundaryCondition as _BoundaryCondition
+from beamme.core.function import Function as _Function
+from beamme.core.geometry_set import GeometrySet as _GeometrySet
 
 
 class BeamPotential:
@@ -31,42 +35,32 @@ class BeamPotential:
 
     def __init__(
         self,
-        input_file,
-        mesh,
         *,
-        pot_law_prefactor=None,
-        pot_law_exponent=None,
-        pot_law_line_charge_density=None,
-        pot_law_line_charge_density_funcs=None,
+        pot_law_prefactor: float | int | list | _np.ndarray,
+        pot_law_exponent: float | int | list | _np.ndarray,
+        pot_law_line_charge_density: float | int | list | _np.ndarray,
+        pot_law_line_charge_density_funcs: _Function | list | _np.ndarray | None,
     ):
         """Initialize object to enable beam potential interactions.
 
-        Args
-        ----
-        input_file:
-            Input file of current problem setup.
-        mesh:
-            Mesh object of current problem setup.
-        pot_law_prefactors: float, int, _np.array, list
-            Prefactors of a potential law in form of a power law. Same number
-            of prefactors and exponents/line charge densities/functions must be
-            provided!
-        pot_law_exponent: float, int, _np.array, list
-            Exponents of a potential law in form of a power law. Same number
-            of exponents and prefactors/line charge densities/functions must be
-            provided!
-        pot_law_line_charge_density: float, int, _np.array, list
-            Line charge densities of a potential law in form of a power law.
-            Same number of line charge densities and prefactors/exponents/functions
-            must be provided!
-        pot_law_line_charge_density_funcs:
-            Functions for line charge densities of a potential law in form of a
-            power law. Same number of functions and prefactors/exponents/line
-            charge densities must be provided!
+        Args:
+            pot_law_prefactors:
+                Prefactors of a potential law in form of a power law. Same number
+                of prefactors and exponents/line charge densities/functions must be
+                provided!
+            pot_law_exponent:
+                Exponents of a potential law in form of a power law. Same number
+                of exponents and prefactors/line charge densities/functions must be
+                provided!
+            pot_law_line_charge_density:
+                Line charge densities of a potential law in form of a power law.
+                Same number of line charge densities and prefactors/exponents/functions
+                must be provided!
+            pot_law_line_charge_density_funcs:
+                Functions for line charge densities of a potential law in form of a
+                power law. Same number of functions and prefactors/exponents/line
+                charge densities must be provided!
         """
-
-        self.input_file = input_file
-        self.mesh = mesh
 
         # if only one potential law prefactor/exponent is present, convert it
         # into a list for simplified usage
@@ -76,6 +70,11 @@ class BeamPotential:
             pot_law_exponent = [pot_law_exponent]
         if isinstance(pot_law_line_charge_density, (float, int)):
             pot_law_line_charge_density = [pot_law_line_charge_density]
+        if (
+            isinstance(pot_law_line_charge_density_funcs, _Function)
+            or pot_law_line_charge_density_funcs is None
+        ):
+            pot_law_line_charge_density_funcs = [pot_law_line_charge_density_funcs]
 
         # check if same number of prefactors and exponents are provided
         if (
@@ -84,7 +83,7 @@ class BeamPotential:
             == len(pot_law_line_charge_density)
         ):
             raise ValueError(
-                "Number of potential law prefactors do not match potential law exponents!"
+                "Number of potential law prefactors do not match potential law exponents or potential line charge density!"
             )
 
         self.pot_law_prefactor = pot_law_prefactor
@@ -92,158 +91,136 @@ class BeamPotential:
         self.pot_law_line_charge_density = pot_law_line_charge_density
         self.pot_law_line_charge_density_funcs = pot_law_line_charge_density_funcs
 
-    def add_header(
+    def create_header(
         self,
         *,
-        potential_type="volume",
-        cutoff_radius=None,
-        evaluation_strategy=None,
-        regularization_type=None,
-        regularization_separation=None,
-        integration_segments=1,
-        gauss_points=10,
-        potential_reduction_length=-1,
-        automatic_differentiation=False,
-        choice_master_slave=None,
-    ):
+        potential_type: str,
+        evaluation_strategy: str,
+        cutoff_radius: float,
+        regularization_type: str | None = None,
+        regularization_separation: float,
+        integration_segments: int,
+        gauss_points: int,
+        potential_reduction_length: float | int | None = None,
+        automatic_differentiation: bool,
+        choice_master_slave: str | None,
+        runtime_output_interval_steps: int | None = None,
+        runtime_output_every_iteration: bool,
+        runtime_output_force: bool,
+        runtime_output_moment: bool,
+        runtime_output_uids: bool,
+        runtime_output_per_ele_pair: bool,
+    ) -> dict:
         """Set the basic header options for beam potential interactions.
 
-        Args
-        ----
-        potential_type: string
-            Type of applied potential (volume, surface).
-        cutoff_radius: float
-            Neglect all contributions at separation larger than this cutoff
-            radius.
-        evaluation_strategy: string
-            Strategy to evaluate interaction potential.
-        regularization_type: string
-            Type of regularization to use for force law at separations below
-            specified separation (constant_extrapolation, linear_extrapolation).
-        regularization_separation: float
-            Use specified regularization type for separations smaller than
-            this value.
-        integration_segments: int
-            Number of integration segments to be used per beam element.
-        gauss_points: int
-            Number of Gauss points to be used per integration segment.
-        potential_reduction_length: float
-            Potential is smoothly decreased within this length when using the
-            single length specific (SBIP) approach to enable an axial pull off
-            force.
-        automatic_differentiation: bool
-            Use automatic differentiation via FAD.
-        choice_master_slave: string
-            Rule how to assign the role of master and slave to beam elements (if
-            applicable) (lower_eleGID_is_slave, higher_eleGID_is_slave).
+        Args:
+            potential_type:
+                Type of applied potential.
+            evaluation_strategy:
+                Strategy to evaluate interaction potential.
+            cutoff_radius:
+                Neglect all contributions at separation larger than this cutoff
+                radius.
+            regularization_type:
+                Type of regularization to use for force law at separations below
+                specified separation.
+            regularization_separation:
+                Use specified regularization type for separations smaller than
+                this value.
+            integration_segments:
+                Number of integration segments to be used per beam element.
+            gauss_points:
+                Number of Gauss points to be used per integration segment.
+            potential_reduction_length:
+                Potential is smoothly decreased within this length when using the
+                single length specific (SBIP) approach to enable an axial pull off
+                force.
+            automatic_differentiation:
+                Use automatic differentiation via FAD.
+            choice_master_slave:
+                Rule how to assign the role of master and slave to beam elements (if
+                applicable).
+
+            runtime_output:
+                If the output for beam potential should be written.
+            runtime_output_interval_steps:
+                Interval at which output is written.
+            runtime_output_every_iteration:
+                If output at every Newton iteration should be written.
+            runtime_output_force:
+                If the forces should be written.
+            runtime_output_moment:
+                If the moments should be written.
+            runtime_output_uids:
+                If the unique ids should be written.
+            runtime_output_per_ele_pair:
+                If the forces/moments should be written per element pair.
+
+        Returns:
+            Header for beam potential interactions.
         """
 
-        settings = {
-            "type": potential_type,
-            "strategy": evaluation_strategy,
-            "potential_law_prefactors": self.pot_law_prefactor,
-            "potential_law_exponents": self.pot_law_exponent,
-            "automatic_differentiation": automatic_differentiation,
-            "cutoff_radius": cutoff_radius,
-            "n_integration_segments": integration_segments,
-            "n_gauss_points": gauss_points,
-            "potential_reduction_length": potential_reduction_length,
+        header = {
+            "beam_potential": {
+                "type": potential_type,
+                "strategy": evaluation_strategy,
+                "potential_law_prefactors": self.pot_law_prefactor,
+                "potential_law_exponents": self.pot_law_exponent,
+                "automatic_differentiation": automatic_differentiation,
+                "cutoff_radius": cutoff_radius,
+                "n_integration_segments": integration_segments,
+                "n_gauss_points": gauss_points,
+                "potential_reduction_length": potential_reduction_length,
+            }
         }
 
         if regularization_type is not None:
-            settings = settings | {
-                "regularization": {
-                    "type": regularization_type,
-                    "separation": regularization_separation,
-                }
+            header["beam_potential"]["regularization"] = {
+                "type": regularization_type,
+                "separation": regularization_separation,
             }
 
         if choice_master_slave is not None:
-            settings = settings | {"choice_master_slave": choice_master_slave}
+            header["beam_potential"]["choice_master_slave"] = choice_master_slave
 
-        # check if the section already exists, so one can either create the settings or runtime output settings first
-        if "beam_potential" in self.input_file.sections:
-            existing_entries = self.input_file.pop("beam_potential")
-            existing_entries.update(settings)
-            self.input_file["beam_potential"] = existing_entries
-        else:
-            self.input_file.add({"beam_potential": settings})
-
-    def add_runtime_output(
-        self,
-        *,
-        output_beam_potential=True,
-        interval_steps=1,
-        every_iteration=False,
-        forces=True,
-        moments=True,
-        uids=True,
-        per_ele_pair=True,
-    ):
-        """Set the basic runtime output options for beam potential
-        interactions.
-
-        Args
-        ----
-        output_beam_potential: bool
-            If the output for beam potential should be written.
-        interval_steps: int
-            Interval at which output is written.
-        every_iteration: bool
-            If output at every Newton iteration should be written.
-        forces: bool
-            If the forces should be written.
-        moments: bool
-            If the moments should be written.
-        uids: bool
-            If the unique ids should be written.
-        per_ele_pair: bool
-            If the forces/moments should be written per element pair.
-        """
-
-        runtime_output_settings = {
-            "runtime_output": {
-                "interval_steps": interval_steps,
-                "force": forces,
-                "moment": moments,
-                "every_iteration": every_iteration,
-                "write_force_moment_per_elementpair": per_ele_pair,
-                "write_uids": uids,
+        if runtime_output_interval_steps is not None:
+            header["beam_potential"]["runtime_output"] = {
+                "interval_steps": runtime_output_interval_steps,
+                "force": runtime_output_force,
+                "moment": runtime_output_moment,
+                "every_iteration": runtime_output_every_iteration,
+                "write_force_moment_per_elementpair": runtime_output_per_ele_pair,
+                "write_uids": runtime_output_uids,
             }
-        }
 
-        if not output_beam_potential:
-            runtime_output_settings["runtime_output"]["interval_steps"] = None
+        return header
 
-        # check if the section already exists, so one can either create the settings or runtime output settings first
-        if "beam_potential" in self.input_file.sections:
-            existing_entries = self.input_file.pop("beam_potential")
-            existing_entries.update(runtime_output_settings)
-            self.input_file["beam_potential"] = existing_entries
-        else:
-            self.input_file.add({"beam_potential": runtime_output_settings})
+    def create_potential_charge_conditions(
+        self, *, geometry_set: _GeometrySet
+    ) -> list[_BoundaryCondition]:
+        """Create potential charge conditions.
 
-    def add_potential_charge_condition(self, *, geometry_set=None):
-        """Add potential charge condition to geometry.
+        Args:
+            geometry_set:
+                Add potential charge condition to this set.
 
-        Args
-        ----
-        geometry_set:
-            Add potential charge condition to this set.
+        Returns:
+            List of boundary conditions for potential charge.
         """
+
+        bcs = []
 
         for i, (line_charge, func) in enumerate(
             zip(
                 self.pot_law_line_charge_density, self.pot_law_line_charge_density_funcs
             )
         ):
-            if func:
-                self.mesh.add(func)
-
             bc = _BoundaryCondition(
                 geometry_set,
                 {"POTLAW": i + 1, "VAL": line_charge, "FUNCT": func},
                 bc_type="DESIGN LINE BEAM POTENTIAL CHARGE CONDITIONS",
             )
 
-            self.mesh.add(bc)
+            bcs.append(bc)
+
+        return bcs


### PR DESCRIPTION
After many months I am finally updating my personal stuff to the new BeamMe/Yaml layout (until now I was lazy enough and did a lot of manual work :smile:)

In the process it turned out that the beam potential approach was pretty convoluted because you needed to pass an input file and mesh into the function.

Now I simply return the header dict and BC's. This eases the workflow in an external package by a lot and should make this a lot more flexible in use.