### PR TITLE
Remove add_sets option

### DIFF
--- a/src/beamme/mesh_creation_functions/applications/beam_honeycomb.py
+++ b/src/beamme/mesh_creation_functions/applications/beam_honeycomb.py
@@ -45,7 +45,6 @@ def create_beam_mesh_honeycomb_flat(
     closed_width=True,
     closed_height=True,
     create_couplings=True,
-    add_sets=False,
 ):
     """Add a flat honeycomb structure. The structure will be created in the x-y
     plane.
@@ -72,10 +71,6 @@ def create_beam_mesh_honeycomb_flat(
         If the last vertical lines in y-direction will be created.
     create_couplings: bool
         If the nodes will be connected in this function.
-    add_sets: bool
-        If this is true the sets are added to the mesh and then displayed
-        in eventual VTK output, even if they are not used for a boundary
-        condition or coupling.
 
     Return
     ----
@@ -158,8 +153,7 @@ def create_beam_mesh_honeycomb_flat(
     return_set["all"] = _GeometrySet(mesh_honeycomb.elements)
 
     mesh.add(mesh_honeycomb)
-    if add_sets:
-        mesh.add(return_set)
+
     return return_set
 
 
@@ -174,7 +168,6 @@ def create_beam_mesh_honeycomb(
     n_el=1,
     closed_top=True,
     vertical=True,
-    add_sets=False,
 ):
     """Wrap a honeycomb structure around a cylinder. The cylinder axis will be
     the z-axis.
@@ -200,10 +193,6 @@ def create_beam_mesh_honeycomb(
         If the last honeycombs in axial-direction will be closed.
     vertical: bool
         If there are vertical lines in the honeycomb or horizontal.
-    add_sets: bool
-        If this is true the sets are added to the mesh and then displayed
-        in eventual VTK output, even if they are not used for a boundary
-        condition or coupling.
 
     Return
     ----
@@ -271,8 +260,6 @@ def create_beam_mesh_honeycomb(
     else:
         return_set["top"] = honeycomb_sets["east"]
         return_set["bottom"] = honeycomb_sets["west"]
-    if add_sets:
-        mesh_temp.add(return_set)
 
     # Add to this mesh
     mesh.add_mesh(mesh_temp)

--- a/src/beamme/mesh_creation_functions/applications/beam_stent.py
+++ b/src/beamme/mesh_creation_functions/applications/beam_stent.py
@@ -285,7 +285,6 @@ def create_beam_mesh_stent(
     diameter,
     n_axis,
     n_circumference,
-    add_sets=False,
     **kwargs,
 ):
     """Create a stent structure around cylinder, The cylinder axis will be the
@@ -308,10 +307,6 @@ def create_beam_mesh_stent(
     n_circumference: int
         Number of cells around the diameter.
     ( these variables are described in a file )
-    add_sets: bool
-    If this is true the sets are added to the mesh and then displayed
-    n eventual VTK output, even if they are not used for a boundary
-    condition or coupling.
 
     Return
     ----
@@ -356,6 +351,4 @@ def create_beam_mesh_stent(
 
     mesh.add_mesh(mesh_stent)
 
-    if add_sets:
-        mesh.add(return_set)
     return return_set

--- a/src/beamme/mesh_creation_functions/beam_line.py
+++ b/src/beamme/mesh_creation_functions/beam_line.py
@@ -58,10 +58,6 @@ def create_beam_mesh_line(mesh, beam_class, material, start_point, end_point, **
         is connected to other lines (angles have to be the same, otherwise
         connections should be used). If a geometry set is given, it can
         contain one, and one node only.
-    add_sets: bool
-        If this is true the sets are added to the mesh and then displayed
-        in eventual VTK output, even if they are not used for a boundary
-        condition or coupling.
 
     Return
     ----

--- a/tests/test_beamme.py
+++ b/tests/test_beamme.py
@@ -1645,9 +1645,10 @@ def test_vtk_writer_beam(
 
     # Add content to the mesh.
     mat = MaterialBeamBase(radius=0.05)
-    create_beam_mesh_honeycomb(
-        mesh, Beam3rHerm2Line3, mat, 2.0, 2, 3, n_el=2, add_sets=True
+    honeycomb_set = create_beam_mesh_honeycomb(
+        mesh, Beam3rHerm2Line3, mat, 2.0, 2, 3, n_el=2
     )
+    mesh.add(honeycomb_set)
 
     # Write VTK output, with coupling sets."""
     ref_file = get_corresponding_reference_file_path(extension="vtu")

--- a/tests/test_four_c_simulation.py
+++ b/tests/test_four_c_simulation.py
@@ -209,8 +209,8 @@ def test_four_c_simulation_honeycomb_sphere(
         4,
         n_el=1,
         closed_top=False,
-        add_sets=True,
     )
+    mesh_honeycomb.add(honeycomb_set)
     mesh_honeycomb.rotate(Rotation([0, 0, 1], 0.5 * np.pi))
 
     # Functions for the boundary conditions


### PR DESCRIPTION
The `add_sets` option was removed a wile ago from the basic mesh creation functions. This PR now removes all occurrences, since this construct is obsolete.