### PR TITLE
refactor: simplify model importer

### DIFF
--- a/src/beamme/four_c/input_file_mappings.py
+++ b/src/beamme/four_c/input_file_mappings.py
@@ -126,6 +126,12 @@ INPUT_FILE_MAPPINGS["geometry_sets_geometry_to_condition_name"] = {
     _bme.geo.surface: "DSURF-NODE TOPOLOGY",
     _bme.geo.volume: "DVOL-NODE TOPOLOGY",
 }
+INPUT_FILE_MAPPINGS["geometry_sets_condition_to_geometry_name"] = {
+    value: key
+    for key, value in INPUT_FILE_MAPPINGS[
+        "geometry_sets_geometry_to_condition_name"
+    ].items()
+}
 INPUT_FILE_MAPPINGS["geometry_sets_geometry_to_entry_name"] = {
     _bme.geo.point: "DNODE",
     _bme.geo.line: "DLINE",


### PR DESCRIPTION
Part of #356

This would be one of the last points of #356.

The basics were done by chatgpt and then the code was overhauled by me. All local tests pass.
Main objective was to simplify the code in general. I also wanted to get rid of the `get_geometry_set_indices_from_section` function. This can then be deleted once the mesh conversion is simplified (next step of #356).

Curious on what you think @isteinbrecher :)