### PR TITLE
Enhance Path-Treatment in Inputfile

### DIFF
--- a/src/beamme/utils/environment.py
+++ b/src/beamme/utils/environment.py
@@ -24,6 +24,7 @@
 import os as _os
 import shutil as _shutil
 import subprocess as _subprocess  # nosec B404
+import sys as _sys
 from importlib.util import find_spec as _find_spec
 from pathlib import Path as _Path
 from typing import Optional as _Optional
@@ -107,3 +108,18 @@ def get_git_data(repo_path: _Path) -> _Tuple[_Optional[str], _Optional[str]]:
     git_date = out_date.stdout.decode("ascii").strip()
 
     return git_sha, git_date
+
+
+def get_application_path() -> _Path | None:
+    """Returns the application path which created this input file and ensures
+    that the file exists.
+
+    Returns:
+        A path to the file, which created this input file or None.
+    """
+
+    # return valid application path if it exists.
+    if _Path(_sys.argv[0]).resolve().exists():
+        return _Path(_sys.argv[0]).resolve()
+
+    return None


### PR DESCRIPTION
The Path within the Inputfile is currently not updated.
Hence by switching the `Path` within your application script and activating  `add_footer_application_script=True` an error occurs. Here are the steps to reproduce the error:

```python
import os
from pathlib import Path

from beamme.four_c.header_functions import set_header_static
from beamme.four_c.input_file import InputFile


if __name__ == '__main__':

    input_file = InputFile()
    set_header_static(
        input_file, total_time=1.0, n_steps=1, tol_increment=1e-4, tol_residuum=1e-5
    )
    input_file.dump(os.getcwd()+'/myfile.4c.yaml')
    os.mkdir("test")
    file2=Path(os.getcwd()).joinpath("test/myfile.4c.yaml")
    os.chdir(file2.parent)
    input_file2 = InputFile()
    set_header_static(
        input_file2, total_time=1.0, n_steps=1, tol_increment=1e-4, tol_residuum=1e-5
    )
    input_file2.dump(file2)
```
Within this MR the class `InputFile` is enhanced by introducing a function called `_resolve_application_path` to detect the path based on the main function of a script. 

Do we need to add a test case for that? 