### PR TITLE
Ensure close nodes match in mesh

### DIFF
--- a/src/beamme/utils/nodes.py
+++ b/src/beamme/utils/nodes.py
@@ -68,6 +68,22 @@ def find_close_nodes(nodes, **kwargs):
     return [[nodes[i] for i in partners] for partners in partner_indices]
 
 
+def adjust_close_nodes(nodes: list[_Node], *, tol=_bme.eps_pos) -> None:
+    """Adjust the coordinates of nodes that are within the given tolerance by
+    setting all involved coordinates of the nodes to their common mean.
+
+    Args:
+        nodes: List of nodes whose coordinates need adjustment.
+        tol: Distance tolerance used to detect partner nodes.
+    """
+
+    partner_nodes = find_close_nodes(nodes, tol=tol)
+    for close_nodes in partner_nodes:
+        average_coords = _np.mean([node.coordinates for node in close_nodes], axis=0)
+        for node in close_nodes:
+            node.coordinates = average_coords.copy()
+
+
 def check_node_by_coordinate(node, axis, value, eps=_bme.eps_pos):
     """Check if the node is at a certain coordinate value.
 

--- a/tests/beamme/utils/test_nodes.py
+++ b/tests/beamme/utils/test_nodes.py
@@ -1,0 +1,52 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2025 BeamMe Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""This script is used to test all utils functions for nodes."""
+
+import numpy as np
+
+from beamme.core.node import Node
+from beamme.utils.nodes import adjust_close_nodes
+
+
+def test_adjusting_of_nodes(
+    get_default_test_beam_material,
+    assert_results_close,
+    get_corresponding_reference_file_path,
+):
+    """Test the mesh function adjust_close_nodes."""
+
+    coordinates = np.array(
+        [[0, 0, 0], [1, 0, 0], [2, 0, 0], [1.3, 0, 0], [1.0, 0.3, 0], [2, 0, 0.2]]
+    )
+    coordinates_averaged = np.array(
+        [
+            [0, 0, 0],
+            [1.1, 0.1, 0],
+            [2, 0, 0.1],
+            [1.1, 0.1, 0],
+            [1.1, 0.1, 0],
+            [2, 0, 0.1],
+        ]
+    )
+    nodes = [Node(coordinates=coord) for coord in coordinates]
+    adjust_close_nodes(nodes, tol=0.35)
+    assert_results_close(coordinates_averaged, [node.coordinates for node in nodes])


### PR DESCRIPTION
Sometimes you have the issue, that two points do not coincide due too numerical rounding errors. However if you want to couple them this can cause multiple issues(Partner not found, coordinates to not overlap, check boundary condition fails and finally 4c error).

This MR adds a function called `adjust_close_nodes` which assigns the values of a given coordinate to ensure, that they are same. This can in the later be used in combination with `couple_nodes` to add a desired coupling condition. 