### PR TITLE
Allow for submaterials

### DIFF
--- a/src/beamme/core/material.py
+++ b/src/beamme/core/material.py
@@ -43,6 +43,14 @@ class Material(_BaseMeshItem):
         # Return this object again, as no copy should be created.
         return self
 
+    def get_all_contained_materials(self) -> list:
+        """Get all sub materials contained in this material, also nested ones.
+
+        Returns:
+            List of all contained materials, for the base class this is empty.
+        """
+        return []
+
 
 class MaterialBeamBase(Material):
     """Base class for all beam materials."""

--- a/src/beamme/core/mesh.py
+++ b/src/beamme/core/mesh.py
@@ -177,8 +177,21 @@ class Mesh:
 
         Check that the material is only added once.
         """
-        if material not in self.materials:
-            self.materials.append(material)
+        self_materials_set = set(self.materials)
+        all_materials_to_add = [material] + material.get_all_contained_materials()
+        all_materials_to_add_set = set(all_materials_to_add)
+
+        is_subset = all_materials_to_add_set.issubset(self_materials_set)
+        is_disjoint = all_materials_to_add_set.isdisjoint(self_materials_set)
+        if is_subset == is_disjoint:
+            raise ValueError(
+                "The material to be added has some materials that are already "
+                "in the mesh and some that are not. This is not allowed."
+            )
+
+        if is_disjoint:
+            for contained_material in all_materials_to_add:
+                self.materials.append(contained_material)
 
     def add_node(self, node):
         """Add a node to this mesh."""

--- a/src/beamme/four_c/material.py
+++ b/src/beamme/four_c/material.py
@@ -277,6 +277,22 @@ class MaterialSolid(_MaterialSolidBase):
 
         return {"MAT": self.i_global + 1, self.material_string: self.data}
 
+    def get_all_contained_materials(self) -> list["MaterialSolid"]:
+        """Get all sub materials contained in this material, also nested ones.
+
+        Returns:
+            All MaterialSolid objects contained in this material, including those
+            found recursively in nested `MATIDS` fields, in depth-first traversal
+            order.
+        """
+        contained_materials = []
+        if "MATIDS" in self.data:
+            for item in self.data["MATIDS"]:
+                if isinstance(item, MaterialSolid):
+                    contained_materials.append(item)
+                    contained_materials.extend(item.get_all_contained_materials())
+        return contained_materials
+
 
 class MaterialStVenantKirchhoff(MaterialSolid):
     """Holds material definition for StVenant Kirchhoff solids."""

--- a/tests/beamme/four_c/test_beamme_four_c_material.py
+++ b/tests/beamme/four_c/test_beamme_four_c_material.py
@@ -25,6 +25,7 @@ from beamme.four_c.material import (
     MaterialKirchhoff,
     MaterialReissner,
     MaterialReissnerElastoplastic,
+    MaterialSolid,
     MaterialStVenantKirchhoff,
 )
 
@@ -241,3 +242,46 @@ def test_beamme_four_c_material_stvenantkirchhoff_solid(assert_results_close):
             },
         },
     )
+
+
+def test_beamme_four_c_material_sub_materials():
+    """Test that sub-materials are correctly returned from the material."""
+
+    material_1_1 = MaterialSolid(material_string="mat_1_1")
+    material_1_2 = MaterialSolid(material_string="mat_1_2")
+    material_1 = MaterialSolid(
+        material_string="mat_1", data={"MATIDS": [material_1_1, material_1_2]}
+    )
+
+    material_2 = MaterialSolid(material_string="mat_2")
+
+    material_3_1 = MaterialSolid(material_string="mat_3_1")
+    material_3_2_1 = MaterialSolid(material_string="mat_3_2_1")
+    material_3_2 = MaterialSolid(
+        material_string="mat_3_2", data={"MATIDS": [material_3_2_1]}
+    )
+    material_3_3 = MaterialSolid(material_string="mat_3_3")
+    material_3 = MaterialSolid(
+        material_string="mat_3",
+        data={"MATIDS": [material_3_1, material_3_2, material_3_3]},
+    )
+
+    material = MaterialSolid(
+        material_string="mat", data={"MATIDS": [material_1, material_2, material_3]}
+    )
+    sub_materials = material.get_all_contained_materials()
+
+    sub_materials_reference = [
+        material_1,
+        material_1_1,
+        material_1_2,
+        material_2,
+        material_3,
+        material_3_1,
+        material_3_2,
+        material_3_2_1,
+        material_3_3,
+    ]
+    assert len(sub_materials_reference) == len(sub_materials)
+    for mat_reference, mat_test in zip(sub_materials_reference, sub_materials):
+        assert mat_reference is mat_test

--- a/tests/beamme/mesh_creation_functions/test_beamme_mesh_creation_functions_nurbs_generic.py
+++ b/tests/beamme/mesh_creation_functions/test_beamme_mesh_creation_functions_nurbs_generic.py
@@ -209,14 +209,16 @@ from beamme.mesh_creation_functions.nurbs_geometries import (
     ],
 )
 def test_beamme_mesh_creation_functions_nurbs_generic_sets(
-    nurbs_patch, reference_values
+    get_default_test_solid_material, nurbs_patch, reference_values
 ):
     """Test that the add NURBS to mesh functionality returns the correct
     geometry sets."""
 
     # Add the nurbs to a mesh
     mesh = Mesh()
-    add_geomdl_nurbs_to_mesh(mesh, nurbs_patch)
+    add_geomdl_nurbs_to_mesh(
+        mesh, nurbs_patch, material=get_default_test_solid_material()
+    )
     nurbs_patch = mesh.elements[0]
 
     # Create the geometry sets for this patch

--- a/tests/integration/test_integration_four_c_material.py
+++ b/tests/integration/test_integration_four_c_material.py
@@ -1,0 +1,93 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018-2025 BeamMe Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""Integration tests for materials in 4C."""
+
+import pytest
+
+from beamme.core.mesh import Mesh
+from beamme.four_c.material import MaterialSolid
+
+
+def test_integration_four_c_sub_materials(
+    get_corresponding_reference_file_path,
+    assert_results_close,
+):
+    """Check if sub-materials are handled correctly."""
+
+    # Add a nested material to the mesh and check the result.
+    mesh = Mesh()
+    material = MaterialSolid(
+        material_string="MAT_ElastHyper",
+        data={
+            "NUMMAT": 2,
+            "MATIDS": [
+                MaterialSolid(
+                    material_string="ELAST_CoupSVK", data={"YOUNG": 1.0, "NUE": 0.0}
+                ),
+                MaterialSolid(
+                    material_string="MAT_ElastHyper",
+                    data={
+                        "NUMMAT": 1,
+                        "MATIDS": [
+                            MaterialSolid(
+                                material_string="ELAST_CoupSVK",
+                                data={"YOUNG": 2.0, "NUE": 0.0},
+                            )
+                        ],
+                        "DENS": 1.0,
+                    },
+                ),
+            ],
+            "DENS": 1.0,
+        },
+    )
+    mesh.add(material)
+    assert_results_close(get_corresponding_reference_file_path(), mesh)
+
+    # Add the material again and check that the result is the same.
+    mesh.add(material)
+    assert_results_close(get_corresponding_reference_file_path(), mesh)
+
+
+def test_integration_four_c_sub_materials_error():
+    """Check the error for incorrectly added sub-materials."""
+
+    mesh = Mesh()
+    material_sub = MaterialSolid(
+        material_string="ELAST_CoupSVK", data={"YOUNG": 1.0, "NUE": 0.0}
+    )
+    mesh.add(material_sub)
+    material = MaterialSolid(
+        material_string="MAT_ElastHyper",
+        data={
+            "NUMMAT": 1,
+            "MATIDS": [material_sub],
+            "DENS": 1.0,
+        },
+    )
+    with pytest.raises(
+        ValueError,
+        match="The material to be added has some "
+        "materials that are already in the mesh and some that are not. "
+        "This is not allowed.",
+    ):
+        mesh.add(material)

--- a/tests/reference-files/test_integration_four_c_sub_materials.4C.yaml
+++ b/tests/reference-files/test_integration_four_c_sub_materials.4C.yaml
@@ -1,0 +1,19 @@
+MATERIALS:
+  - MAT: 1
+    MAT_ElastHyper:
+      NUMMAT: 2
+      MATIDS: [2, 3]
+      DENS: 1.0
+  - MAT: 2
+    ELAST_CoupSVK:
+      YOUNG: 1.0
+      NUE: 0.0
+  - MAT: 3
+    MAT_ElastHyper:
+      NUMMAT: 1
+      MATIDS: [4]
+      DENS: 1.0
+  - MAT: 4
+    ELAST_CoupSVK:
+      YOUNG: 2.0
+      NUE: 0.0


### PR DESCRIPTION
This PR allows for a convenient definition of nested materials in 4C (#514).

We used to be able to define nested materials as
```python
material_svk = MaterialSolid(
    material_string="ELAST_CoupSVK", data={"YOUNG": 1.0, "NUE": 0.0}
)
material_hyper = MaterialSolid(
    material_string="MAT_ElastHyper",
    data={
        "NUMMAT": 1,
        "MATIDS": [material_svk],
        "DENS": 1.0,
    },
)
mesh.add(material_hyper, material_svk)
```
Now this also works directly in one line of code:
```python
material = MaterialSolid(
    material_string="MAT_ElastHyper",
    data={
        "NUMMAT": 1,
        "MATIDS": [
            MaterialSolid(
                material_string="ELAST_CoupSVK", data={"YOUNG": 1.0, "NUE": 0.0}
            )
        ],
        "DENS": 1.0,
    },
)
mesh.add(material)

```

Closes #514 