### PR TITLE
feat: introduce beamme version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ api-documentation/*
 # website folder which contains automatically copied files
 website/docs/source/md/*
 
+# BeamMe version file
+src/beamme/version.py
+
 
 ### Automatically created ignores ###
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython", "numpy"]
+requires = ["setuptools", "setuptools_scm[toml]", "wheel", "cython", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -28,6 +28,11 @@ dependencies = [
 
 dynamic = ["version"]
 
+[tool.setuptools_scm]
+version_file = "src/beamme/version.py"
+version_scheme = "post-release"
+local_scheme = "no-local-version"
+
 [project.optional-dependencies]
 cubitpy = ["cubitpy"]
 fourc = ["fourcipp"]
@@ -50,6 +55,11 @@ Repository = "https://github.com/beamme-py/beamme/"
 Issues = "https://github.com/beamme-py/beamme/issues/"
 
 # Tools
+
+[tool.coverage.run]
+omit = [
+  "src/beamme/version.py",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
third part of #418 

we now automatically retrieve and install the version from the tag. If the last version is connected to an older commit it is automatically v0.0.1.post

This is the same approach as in FourCIPP