### PR TITLE
feat: add two half pass approach to beam potential

### DIFF
--- a/src/beamme/four_c/beam_potential.py
+++ b/src/beamme/four_c/beam_potential.py
@@ -104,6 +104,7 @@ class BeamPotential:
         potential_reduction_length: float | int | None = None,
         automatic_differentiation: bool,
         choice_master_slave: str | None,
+        two_half_pass: bool,
         runtime_output_interval_steps: int | None = None,
         runtime_output_every_iteration: bool,
         runtime_output_force: bool,
@@ -137,6 +138,8 @@ class BeamPotential:
                 force.
             automatic_differentiation:
                 Use automatic differentiation via FAD.
+            two_half_pass:
+                Whether to use the two half pass approach.
             choice_master_slave:
                 Rule how to assign the role of master and slave to beam elements (if
                 applicable).
@@ -171,6 +174,7 @@ class BeamPotential:
                 "n_integration_segments": integration_segments,
                 "n_gauss_points": gauss_points,
                 "potential_reduction_length": potential_reduction_length,
+                "two_half_pass": two_half_pass,
             }
         }
 

--- a/tests/integration/test_integration_four_c_beam_potential.py
+++ b/tests/integration/test_integration_four_c_beam_potential.py
@@ -71,6 +71,7 @@ def test_integration_four_c_beam_potential_helix(
             potential_reduction_length=15.0,
             automatic_differentiation=False,
             choice_master_slave="smaller_eleGID_is_slave",
+            two_half_pass=True,
             runtime_output_interval_steps=1,
             runtime_output_force=True,
             runtime_output_moment=True,

--- a/tests/reference-files/test_integration_four_c_beam_potential_helix.4C.yaml
+++ b/tests/reference-files/test_integration_four_c_beam_potential_helix.4C.yaml
@@ -9,6 +9,7 @@ beam_potential:
   n_gauss_points: 50
   n_integration_segments: 2
   potential_reduction_length: 15.0
+  two_half_pass: true
   regularization:
     type: "linear"
     separation: 0.1


### PR DESCRIPTION
FYI: test pipeline does not fail because we do not write out the file during testing (the validation happens during the write), but the pre-commit hook where we verify the input file fails

Follows https://github.com/4C-multiphysics/4C/pull/1957